### PR TITLE
fix ray status query for multi-tenant case

### DIFF
--- a/roll/distributed/scheduler/driver_utils.py
+++ b/roll/distributed/scheduler/driver_utils.py
@@ -75,7 +75,7 @@ def filter_known_msg(msg):
 
 
 def is_ray_cluster_running():
-    ret = subprocess.run("ray status", shell=True, capture_output=True)
+    ret = subprocess.run(f"ray status --address {get_driver_master_addr()}:{get_driver_master_port()}", shell=True, capture_output=True)
     if ret.returncode != 0:
         return False
     return True


### PR DESCRIPTION
For a multi-tenant case, one physical machine may contain multiple ray instances with different ports. 
```
root@dgx-44:/workspace/ROLL# ray status
2025-06-06 21:31:56,570 WARNING services.py:412 -- Found multiple active Ray instances: {'10.22.4.152:6380', '10.22.4.152:6379'}. Connecting to latest cluster at 10.22.4.152:6380. You can override this by setting the `--address` flag or `RAY_ADDRESS` environment variable.
```
This PR fix it by querying the cluster status specified by MASTER_PORT.