### PR TITLE
fix: avoid clear cache when adding requests to improve performance

### DIFF
--- a/roll/distributed/scheduler/decorator.py
+++ b/roll/distributed/scheduler/decorator.py
@@ -254,7 +254,7 @@ def _check_execute_mode(execute_mode):
     assert isinstance(execute_mode, Execute), f"execute_mode must be a Execute. Got {execute_mode}"
 
 
-def register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL):
+def register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL, clear_cache=True):
     _check_dispatch_mode(dispatch_mode)
     _check_execute_mode(execute_mode)
 
@@ -263,12 +263,13 @@ def register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL):
         def inner(*args, **kwargs):
             try:
                 result = func(*args, **kwargs)
-                try:
-                    torch._C._cuda_clearCublasWorkspaces()
-                    gc.collect()
-                    torch.cuda.empty_cache()
-                except Exception as oe:
-                    pass
+                if clear_cache:
+                    try:
+                        torch._C._cuda_clearCublasWorkspaces()
+                        gc.collect()
+                        torch.cuda.empty_cache()
+                    except Exception as oe:
+                        pass
 
             except Exception as e:
                 logger.error(str(e))

--- a/roll/pipeline/base_worker.py
+++ b/roll/pipeline/base_worker.py
@@ -338,7 +338,7 @@ class ActorWorker(Worker):
         output = DataProto(meta_info={"metrics": metrics})
         return output
 
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, clear_cache=False)
     def add_request(self, command, data: DataProto):
         """
         data req meta_info里需要包含:


### PR DESCRIPTION
add an option to clear cache when registering a function. This is due to clear cache is a time consuming operation, and may potentially hurt add_request performance (~0.3-0.5s overhead per request)