### PR TITLE
[fix] skip _align_special_tokens during training.

### DIFF
--- a/mcore_adapter/src/mcore_adapter/models/model_config.py
+++ b/mcore_adapter/src/mcore_adapter/models/model_config.py
@@ -203,16 +203,6 @@ class McaModelConfig(TransformerConfig, PretrainedConfig):
     )
 
     def __post_init__(self):
-        if self.hf_config_json:
-            hf_config = json.loads(self.hf_config_json)
-            if "text_config" in hf_config:
-                hf_config = hf_config["text_config"] # for multimodal model
-
-            for special_token_name in ["eos_token_id", "bos_token_id"]:
-                setattr(self, special_token_name, hf_config.get(special_token_name))
-
-            setattr(self, "pad_token_id", self.eos_token_id)
-
         if self.virtual_pipeline_model_parallel_size is None and self.overlap_p2p_comm:
             self.overlap_p2p_comm = False
             logger.warning("Non-interleaved pipeline parallelism does not support overlapping p2p communication!")

--- a/mcore_adapter/src/mcore_adapter/trainer/trainer.py
+++ b/mcore_adapter/src/mcore_adapter/trainer/trainer.py
@@ -75,6 +75,10 @@ class McaTrainer(Trainer):
     _language_input_names = ["input_ids", "attention_mask", "labels", "position_ids"]
     ckpt_sharding_type = "fully_sharded_model_space"
 
+    if hasattr(Trainer, "_align_special_tokens"): # skip for transformers==4.57.0
+        def _align_special_tokens(self, *args, **kwargs):
+            return
+
     def __init__(
         self,
         model: "VirtualModels" = None,


### PR DESCRIPTION
In the recent `transformers` versions, e,g. >=  4.56.0 , `_align_special_tokens(self)` is introduced to check the model special token with the tokenizer configuration during training. 
But `McaModelConfig` does not have these attributes. So `mcatrainer` failed in the process. In order to match this,  this PR patches these attributes.
