### PR TITLE
fix(vllm_strategy): llm.generate params 'prompt_token_ids' become part of 'prompts'

### DIFF
--- a/roll/distributed/strategy/vllm_strategy.py
+++ b/roll/distributed/strategy/vllm_strategy.py
@@ -12,9 +12,12 @@ import torch
 import torch.distributed as dist
 from torch.nn.utils.rnn import pad_sequence
 from transformers import set_seed
+import vllm
 from vllm import RequestOutput, SamplingParams
 from vllm.lora.request import LoRARequest
 from vllm.utils import random_uuid
+
+from packaging.version import Version
 
 from mcore_adapter.models.converter.convert_utils import RecvBucketManager
 from roll.distributed.executor.worker import Worker
@@ -138,9 +141,18 @@ class VllmStrategy(InferenceStrategy):
         if "multi_modal_data" in batch.non_tensor_batch:
             vllm_input_args["prompts"] = batch.non_tensor_batch["multi_modal_data"]
         else:
-            vllm_input_args["prompt_token_ids"] = gather_unpadded_input_ids(
-                input_ids=input_ids, attention_mask=attention_mask
-            )
+            # fix llm generate params for vllm 0.10.2
+            if Version("0.10.2") >= Version(vllm.__version__):
+                from vllm.inputs.data import TokensPrompt
+                prompt_token_ids_list = gather_unpadded_input_ids(
+                    input_ids=input_ids, attention_mask=attention_mask
+                )
+                prompts = [TokensPrompt(prompt_token_ids=p_ids) for p_ids in prompt_token_ids_list]
+                vllm_input_args["prompts"] = prompts
+            else:
+                vllm_input_args["prompt_token_ids"] = gather_unpadded_input_ids(
+                    input_ids=input_ids, attention_mask=attention_mask
+                )
 
         lora_requests = None
         if self.is_lora:


### PR DESCRIPTION
- bug: TypeError: LLM.generate() got an unexpected keyword argument 'prompt_token_ids', when using LLMJudgeRewardWorker on vllm 0.10.2.

- fix: The _run_local_inference method of LLMJudgeRewardWorker will call llm.generate, and the vllm llm.generate interface has modified the input parameters. The parameter prompt_token_ids has been deprecated, and prompt_token_ids is now part of the prompts parameter.