### PR TITLE
(fix): Fix the position_ids issue for qwen_vl when uses megatron

### DIFF
--- a/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -324,7 +324,19 @@ class Qwen2_5_VLModel(McaGPTModel, ModuleUtilsMixin):
         **kwargs,
     ) -> "torch.Tensor":
         force_vit_image = kwargs.pop("force_vit_image", False)
-        force_vit_video = kwargs.pop("force_vit_video", False)
+        force_vit_video = kwargs.pop("force_vit_video", False)       
+        
+        if position_ids is not None:
+            expected_shape = (3, input_ids.shape[0], input_ids.shape[1])  # (3, batch, seq_len)
+            if position_ids.shape != expected_shape:
+                if position_ids.shape == (input_ids.shape[0], input_ids.shape[1]):
+                    position_ids, _ = self.get_rope_index(
+                        input_ids, image_grid_thw, video_grid_thw, second_per_grid_ts, attention_mask
+                    )
+                else:
+                    raise ValueError(f"Unexpected position_ids shape: {position_ids.shape}, "
+                                     f"expected: {expected_shape} or {(input_ids.shape[0], input_ids.shape[1])}")
+
         if position_ids is None and input_ids is not None:
             position_ids, _ = self.get_rope_index(
                 input_ids, image_grid_thw, video_grid_thw, second_per_grid_ts, attention_mask

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_vl/modeling_qwen2_vl.py
@@ -303,6 +303,16 @@ class Qwen2VLModel(McaGPTModel, ModuleUtilsMixin):
     ) -> "torch.Tensor":
         force_vit_image = kwargs.pop("force_vit_image", False)
         force_vit_video = kwargs.pop("force_vit_video", False)
+
+        if position_ids is not None:
+            expected_shape = (3, input_ids.shape[0], input_ids.shape[1])  # (3, batch, seq_len)
+            if position_ids.shape != expected_shape:
+                if position_ids.shape == (input_ids.shape[0], input_ids.shape[1]):
+                    position_ids, _ = self.get_rope_index(input_ids, image_grid_thw, video_grid_thw)
+                else:
+                    raise ValueError(f"Unexpected position_ids shape: {position_ids.shape}, "
+                                     f"expected: {expected_shape} or {(input_ids.shape[0], input_ids.shape[1])}")
+
         if position_ids is None and input_ids is not None:
             position_ids, _ = self.get_rope_index(input_ids, image_grid_thw, video_grid_thw)
 


### PR DESCRIPTION
**bug description:**
    When using megatron for qwen_vl SFT, an error occurred due to the mismatch between the shape of position_ids and that of megatron as shown below.

File "/Megatron-LM/megatron/core/models/common/embeddings/rotary_pos_embedding.py", line 301, in forward
1768
【2025-11-10 11:33:52】[rank5]: seq_expanded = seq[:, :, None, :].float()
1769
【2025-11-10 11:33:52】[rank5]: ~~~^^^^^^^^^^^^^^^
1770
【2025-11-10 11:33:52】[rank5]: IndexError: too many indices for tensor of dimension 2

**Megatron-LM code**
    https://github.com/NVIDIA/Megatron-LM/blob/c550cf6c41c31cd3ec72e05c25ea0c979f2b6631/megatron/core/models/common/embeddings/rotary_pos_embedding.py#L295


**Fix**
    When position_ids is not None and not expected shape, use get_rope_index to generate the correct position_ids