### PR TITLE
docs: add gtag collect

### DIFF
--- a/docs_roll/docusaurus.config.js
+++ b/docs_roll/docusaurus.config.js
@@ -66,6 +66,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-D6R4GXHVFP',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],

--- a/docs_roll/package.json
+++ b/docs_roll/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ant-design/icons": "^6.0.0",
     "@docusaurus/core": "^3.0.0",
+    "@docusaurus/plugin-google-gtag": "^3.9.2",
     "@docusaurus/preset-classic": "^3.0.0",
     "@easyops-cn/docusaurus-search-local": "^0.52.1",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
Collect access data for documentation pages and send it to Google Analytics.