### PR TITLE
fixed_llm_proxy_mode_rollout_pipeline

### DIFF
--- a/roll/pipeline/agentic/agentic_rollout_pipeline.py
+++ b/roll/pipeline/agentic/agentic_rollout_pipeline.py
@@ -63,8 +63,9 @@ class AgenticRolloutPipeline(BasePipeline):
             batch.meta_info = {"global_step": global_step}
 
             with Timer(name="rollout", logger=None) as rollout_timer:
-                batch.meta_info["is_offload_states"] = True
-                self.actor_infer.start_server(data=batch)
+                if self.use_policy_model:
+                    batch.meta_info["is_offload_states"] = True
+                    self.actor_infer.start_server(data=batch)
                 batch = ray.get(self.rollout_scheduler.get_batch.remote(batch, self.pipeline_config.rollout_batch_size))
                 if batch is None:
                     break


### PR DESCRIPTION
在执行 AgenticRolloutPipeline 的过程中，如果在 yaml 文件中配置使用 llm_proxy 时，如果不进行此修改会报错。

原因:
在 AgenticRolloutPipeline 初始化的过程中，只有 self.pipeline_config.train_env_manager.llm_proxy.proxy_type == “policy” 时才会对 self.actor_infer 进行初始化 (./ROLL/roll/pipeline/agentic/agentic_rollout_pipeline.py, line 53)，使用 llm_proxy 时 proxy_type 为 "openai" 而非 "policy"，导致 self.actor_infer.start_server(data=batch)  (./ROLL/roll/pipeline/agentic/agentic_rollout_pipeline.py, line 66) 无法正常运行导致报错