### PR TITLE
Fix: apply sequence packing loss wrapper in SFT validation

### DIFF
--- a/roll/pipeline/sft/sft_worker.py
+++ b/roll/pipeline/sft/sft_worker.py
@@ -46,7 +46,13 @@ class SFTWorker(Worker):
         data = data.to(current_platform.device_type)
         data.meta_info["micro_batch_size"] = self.worker_config.infer_batch_size
         data = self.strategy.get_data_input(data)
-        metrics = self.strategy.forward_step(batch=data, forward_func=self.loss_func)
+        
+        loss_func = self.loss_func
+        if self.worker_config.use_sequence_packing:
+            from roll.utils.sequence_packing import SequencePackingSFTLossWrapper
+            loss_func = SequencePackingSFTLossWrapper(self.strategy, loss_func)
+
+        metrics = self.strategy.forward_step(batch=data, forward_func=loss_func)
         output = DataProto(meta_info={"metrics": metrics}).to("cpu")
         return output
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in SFT validation when `use_sequence_packing` is enabled.

In the current implementation, `train_step` wraps the loss function with
`SequencePackingSFTLossWrapper`, while `val_step` directly uses the raw
loss function. This causes validation to fail when sequence packing is enabled.

This PR applies the same loss wrapper logic in `val_step` to keep training and
validation behavior consistent.

## Why is this needed?

When `use_sequence_packing` is enabled:

- Training uses `SequencePackingSFTLossWrapper` to correctly handle packed sequences
- Validation does **not** apply the wrapper
- As a result, `forward_step` receives incompatible inputs and validation fails

This leads to runtime errors during validation and makes SFT training with
sequence packing unusable.

## Changes

- Apply `SequencePackingSFTLossWrapper` in `val_step` when `use_sequence_packing` is enabled
- Align loss handling between `train_step` and `val_step`

## Backward Compatibility

- No behavior change when `use_sequence_packing` is disabled
- Fully backward compatible

## Related Issue

N/A
