### PR TITLE
Fix template name resolution and argument order in RLVRRolloutPipeline

### DIFF
--- a/roll/pipeline/rlvr/rlvr_rollout_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_rollout_pipeline.py
@@ -49,9 +49,12 @@ class RLVRRolloutPipeline(RLVRPipeline):
         self.val_dataset = datasets.load_dataset("json", data_files=val_dataset_paths)["train"]
 
         # 加上format，然后转ids的func
-        template_name = self.pipeline_config.global_template
-        encode_function = get_encode_function(template_name, self.tokenizer, self.pipeline_config.actor_train.data_args)
-
+        template_name = (
+            self.pipeline_config.global_template
+            if self.pipeline_config.global_template
+            else self.pipeline_config.actor_train.data_args.template
+        )
+        encode_function = get_encode_function(template_name, self.pipeline_config.actor_train.data_args, self.tokenizer)
         self.val_dataset = preprocess_dataset(
             self.val_dataset,
             self.pipeline_config.prompt_length,


### PR DESCRIPTION
1.  Template Name Resolution: The code previously relied solely on global_template, causing a ValueError if it wasn't explicitly set in the config. Added a fallback mechanism to use actor_train.data_args.template when  global_template is None, consistent with the logic in RLVRPipeline.
2.  Argument Order Mismatch: Corrected the argument order in the get_encode_function call. Previously, tokenizer and data_args were swapped, which would lead to runtime errors due to type mismatch.