### PR TITLE
feat: Add DeepSpeed SFT support and quality-of-life improvements

### DIFF
--- a/roll/configs/base_config.py
+++ b/roll/configs/base_config.py
@@ -82,6 +82,10 @@ class BaseConfig:
         default=50,
         metadata={"help": "Save checkpoint every X update steps."}
     )
+    max_ckpt_to_keep: int = field(
+        default=0,
+        metadata={"help": "Maximum number of checkpoints to keep. 0 means keep all checkpoints."}
+    )
     logging_steps: int = field(
         default=1,
         metadata={"help": "Number of steps between logging information."}

--- a/roll/pipeline/sft/sft_worker.py
+++ b/roll/pipeline/sft/sft_worker.py
@@ -68,4 +68,6 @@ class SFTWorker(Worker):
 
     def loss_func(self, data: DataProto, output_tensor: torch.Tensor):
         labels = data.batch["labels"]
-        return self.strategy.op_compute_language_loss(output_tensor, labels)
+        loss = self.strategy.op_compute_language_loss(output_tensor, labels)
+        metrics = {f"{self.worker_config.name}/loss": loss.detach().float().unsqueeze(0)}
+        return loss, metrics

--- a/roll/utils/tracking.py
+++ b/roll/utils/tracking.py
@@ -59,11 +59,12 @@ class WandbTracker(BaseTracker):
         notes = kwargs.pop("notes", None)
         log_dir = kwargs.pop("log_dir", None)
         api_key = kwargs.pop("api_key", None)
+        mode = kwargs.pop("mode", None)
         settings = kwargs.pop("settings", {"console": "off"})
         import wandb
         if api_key:
             wandb.login(key=api_key)
-        self.run = wandb.init(project=project, tags=tags, name=name, notes=notes, dir=log_dir, settings=settings)
+        self.run = wandb.init(project=project, tags=tags, name=name, notes=notes, dir=log_dir, mode=mode, settings=settings)
 
         self.run.config.update(config, allow_val_change=True)
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="roll",
+    version="0.1.0",
+    description="ROLL - Reinforcement Learning Optimization for Large-Scale Learning",
+    packages=find_packages(include=["roll", "roll.*"]),
+    python_requires=">=3.10",
+)


### PR DESCRIPTION
## DeepSpeed SFT Support

The SFT pipeline was originally designed for Megatron strategy, where the model receives labels and returns per-token losses directly. In DeepSpeed strategy with HuggingFace models, the model returns logits instead.

**Solution:** Override `op_compute_language_loss` in `DeepSpeedTrainStrategy`:
- Compute cross-entropy directly from logits
- DataCollatorForSFT already shifts labels (shift_feature=True by default), so logits and labels are already aligned - no double-shift needed

This follows ROLL's design pattern where Strategy handles backend differences, keeping Worker code generic.

## Quality-of-Life Features

1. **Checkpoint Cleanup (`max_ckpt_to_keep`)**
   - Automatically delete old checkpoints to prevent disk exhaustion
   - Usage: `max_ckpt_to_keep: 3` keeps only latest 3 checkpoints

2. **Wandb Offline Mode**
   - Added `mode` parameter to WandbTracker
   - Usage: `tracker_kwargs: {mode: offline}`

3. **SFT Training Improvements**
   - Enable data shuffling in DataLoader (was False)
   - Add tqdm progress bar for training visualization

4. **pip Installation Support**
   - Added setup.py for `pip install -e .`