### PR TITLE
feat: NPU `device_memory_used` fix

### DIFF
--- a/roll/distributed/strategy/strategy.py
+++ b/roll/distributed/strategy/strategy.py
@@ -23,6 +23,7 @@ class InferenceStrategy(ABC):
         self.worker = worker
         self.model = None
         self.tokenizer = None
+        self.running = False
 
         self.worker_config = self.worker.worker_config
         self.thread_executor: futures.ThreadPoolExecutor = futures.ThreadPoolExecutor(max_workers=5)

--- a/roll/pipeline/rlvr/actor_pg_worker.py
+++ b/roll/pipeline/rlvr/actor_pg_worker.py
@@ -275,6 +275,10 @@ class ActorPGWorker(ActorWorker):
             "topr_negative_total_clipfrac": negative_total_clipped.mean().detach().item(),
             "topr_scores_mean": scores.mean().detach().item(),
             "topr_scores_std": scores.std().detach().item(),
+            "topr_positive_loss": positive_loss,
+            "topr_negative_loss": negative_loss,
+            "topr_weighted_positive_loss": weighted_positive_loss,
+            "topr_weighted_negative_loss": weighted_negative_loss,
         })
         
         return topr_loss

--- a/roll/platforms/npu.py
+++ b/roll/platforms/npu.py
@@ -1,6 +1,8 @@
 from .platform import Platform
 from ..utils.logging import get_logger
 
+import torch
+
 logger = get_logger()
 
 
@@ -74,3 +76,7 @@ class NpuPlatform(Platform):
     @classmethod
     def apply_ulysses_patch(cls) -> None:
         return
+
+    @classmethod
+    def device_memory_used(cls) -> None:
+        return torch.npu.mem_get_info()[0]


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue encountered when running an RLVR pipeline using an NPU.
- add `device_memory_used` support
- add `topr_positive_loss` `topr_negative_loss` into cache
- init running flag in strategy

## Why is this needed?

- The NPU does not support the `device_memory_used` function; a custom function is required.
- `topr_positive_loss` used in `ActorPGWorker._compute_topr_loss` without set

