### PR TITLE
fix: resolve HCCL port conflict in colocate mode for NPU

### DIFF
--- a/roll/distributed/executor/cluster.py
+++ b/roll/distributed/executor/cluster.py
@@ -140,6 +140,9 @@ class Cluster:
             if "ROLL_LOG_DIR" in os.environ:
                 env_vars["ROLL_LOG_DIR"] = os.environ["ROLL_LOG_DIR"]
             env_vars.update(self.worker_config.system_envs)
+            if current_platform.is_npu():
+                env_vars["HCCL_HOST_SOCKET_PORT_RANGE"] = "auto"
+                env_vars["HCCL_NPU_SOCKET_PORT_RANGE"] = "auto"
 
             runtime_env = RuntimeEnv(env_vars=env_vars)
             self.worker_config.resource_placement_groups = pgs


### PR DESCRIPTION
Set HCCL_HOST_SOCKET_PORT_RANGE and HCCL_NPU_SOCKET_PORT_RANGE to 'auto' to let OS dynamically allocate ports for single-NPU multi-process scenarios.

This fixes the Bind_Failed error when multiple clusters (actor_train, actor_infer, reference) share the same GPUs in colocate mode.

Verification results of colocation mode test cases:
<img width="2542" height="555" alt="截屏2026-04-10 10 43 45" src="https://github.com/user-attachments/assets/53a930da-cbaf-490c-98ef-fc3245c1fa9d" />
