### PR TITLE
feat: add npu dockerfile and useage

### DIFF
--- a/docker/Dockerfile.A2
+++ b/docker/Dockerfile.A2
@@ -1,0 +1,66 @@
+FROM quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11
+
+ARG SOC_VERSION="ascend910b1"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV PIP_CONSTRAINT=""
+
+ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/add-ons:/usr/local/Ascend/ascend-toolkit/latest/fwkacllib/lib64:/usr/local/Ascend/ascend-toolkit/latest/acllib/lib64:/usr/local/Ascend/ascend-toolkit/latest/atc/lib64:${LD_LIBRARY_PATH}
+ENV ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev wget git curl jq vim \
+        build-essential iproute2 openjdk-21-jdk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+
+RUN pip config set global.index-url https://mirrors.huaweicloud.com/repository/pypi/simple && \
+    pip config set global.trusted-host mirrors.huaweicloud.com && \
+    pip install --upgrade pip packaging setuptools && \
+    pip cache purge
+
+WORKDIR /workspace
+
+RUN git clone --depth 1 -b v0.13.0 https://github.com/vllm-project/vllm.git && \
+    git clone --depth 1 -b releases/v0.13.0 https://github.com/vllm-project/vllm-ascend.git
+
+RUN cd vllm && \
+    pip install -r requirements/build.txt && \
+    VLLM_TARGET_DEVICE=empty pip install -v -e . && \
+    pip uninstall -y triton && \
+    pip cache purge && \
+    cd ..
+
+RUN pip install torch==2.8.0+cpu torchvision==0.23.0 torchaudio==2.8.0 \
+    --index-url https://download.pytorch.org/whl/cpu
+
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    cd vllm-ascend && \
+    pip install -r requirements.txt && \
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://download.pytorch.org/whl/cpu
+
+WORKDIR /workspace/ROLL
+COPY . .
+
+RUN pip install -r requirements_common.txt
+
+RUN pip install "deepspeed==0.16.4" "transformers==4.57.6" "tensorboard==2.20.0"
+
+RUN pip install -e .
+
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    pip uninstall -y triton && \
+    pip uninstall -y triton-ascend && \
+    pip install triton-ascend==3.2.0 && \
+    pip cache purge
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc && \
+    echo "source /usr/local/Ascend/nnal/atb/set_env.sh" >> /root/.bashrc
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.A3
+++ b/docker/Dockerfile.A3
@@ -1,0 +1,66 @@
+FROM quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11
+
+ARG SOC_VERSION="ascend910_9391"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV PIP_CONSTRAINT=""
+
+ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:/usr/local/Ascend/add-ons:/usr/local/Ascend/ascend-toolkit/latest/fwkacllib/lib64:/usr/local/Ascend/ascend-toolkit/latest/acllib/lib64:/usr/local/Ascend/ascend-toolkit/latest/atc/lib64:${LD_LIBRARY_PATH}
+ENV ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev wget git curl jq vim \
+        build-essential iproute2 openjdk-21-jdk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+
+RUN pip config set global.index-url https://mirrors.huaweicloud.com/repository/pypi/simple && \
+    pip config set global.trusted-host mirrors.huaweicloud.com && \
+    pip install --upgrade pip packaging setuptools && \
+    pip cache purge
+
+WORKDIR /workspace
+
+RUN git clone --depth 1 -b v0.13.0 https://github.com/vllm-project/vllm.git && \
+    git clone --depth 1 -b releases/v0.13.0 https://github.com/vllm-project/vllm-ascend.git
+
+RUN cd vllm && \
+    pip install -r requirements/build.txt && \
+    VLLM_TARGET_DEVICE=empty pip install -v -e . && \
+    pip uninstall -y triton && \
+    pip cache purge && \
+    cd ..
+
+RUN pip install torch==2.8.0+cpu torchvision==0.23.0 torchaudio==2.8.0 \
+    --index-url https://download.pytorch.org/whl/cpu
+
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    cd vllm-ascend && \
+    pip install -r requirements.txt && \
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://download.pytorch.org/whl/cpu
+
+WORKDIR /workspace/ROLL
+COPY . .
+
+RUN pip install -r requirements_common.txt
+
+RUN pip install "deepspeed==0.16.4" "transformers==4.57.6" "tensorboard==2.20.0"
+
+RUN pip install -e .
+
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    pip uninstall -y triton && \
+    pip uninstall -y triton-ascend && \
+    pip install triton-ascend==3.2.0 && \
+    pip cache purge
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc && \
+    echo "source /usr/local/Ascend/nnal/atb/set_env.sh" >> /root/.bashrc
+
+CMD ["/bin/bash"]

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_docker_usage.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_docker_usage.md
@@ -1,0 +1,201 @@
+# Running ROLL on Ascend NPU with Docker
+
+Last updated: 04/27/2026.
+
+This guide explains how to build and run ROLL on **Huawei Ascend NPU** using `Dockerfile.A2` and `Dockerfile.A3`.
+
+## Hardware & Software Requirements
+
+| Item | Dockerfile.A2 | Dockerfile.A3 |
+| ---- | ------------- | ------------- |
+| Hardware | Atlas 900 A2 PODc (Ascend 910B1) | Atlas 900 A3 PODc (Ascend 910_9391) |
+| Host OS | Ubuntu 22.04 | Ubuntu 22.04 |
+| CANN | 8.5.1 | 8.5.1 |
+| Python | 3.11 | 3.11 |
+| Docker | >= 20.10 | >= 20.10 |
+| Ascend NPU Driver | Installed on host | Installed on host |
+
+## Key Components
+
+Both Dockerfiles install the same versions of core dependencies:
+
+| Component | Version |
+| --------- | ------- |
+| PyTorch | 2.8.0+cpu |
+| vLLM | 0.13.0 |
+| vLLM-Ascend | 0.13.0 |
+| DeepSpeed | 0.16.4 |
+| Transformers | 4.57.6 |
+| triton-ascend | 3.2.0 |
+
+The primary difference is the base image and SOC version:
+
+| Item | Dockerfile.A2 | Dockerfile.A3 |
+| ---- | ------------- | ------------- |
+| Base Image | `quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11` | `quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11` |
+| SOC_VERSION | `ascend910b1` | `ascend910_9391` |
+
+## Build the Docker Image
+
+### 1. Clone the ROLL Repository
+
+```bash
+git clone https://github.com/alibaba/ROLL.git
+cd ROLL
+```
+
+### 2. Build the Image
+
+Choose the Dockerfile that matches your hardware:
+
+**For Atlas 900 A2 PODc (Ascend 910B1):**
+
+```bash
+docker build -f docker/Dockerfile.A2 -t roll:ascend-a2 .
+```
+
+**For Atlas 900 A3 PODc (Ascend 910_9391):**
+
+```bash
+docker build -f docker/Dockerfile.A3 -t roll:ascend-a3 .
+```
+
+> **Note:** The build process compiles vLLM and vLLM-Ascend from source, which may take a considerable amount of time. Please ensure sufficient disk space (at least 50GB) and network access.
+
+You can also customize the SOC version at build time:
+
+```bash
+# A2 with custom SOC version
+docker build -f docker/Dockerfile.A2 --build-arg SOC_VERSION=ascend910b1 -t roll:ascend-a2 .
+
+# A3 with custom SOC version
+docker build -f docker/Dockerfile.A3 --build-arg SOC_VERSION=ascend910_9391 -t roll:ascend-a3 .
+```
+
+## Run the Container
+
+### Basic Startup
+
+**For A2:**
+
+```bash
+docker run -dit \
+    --name roll_a2 \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/$USER:/home/$USER \
+    --ipc=host \
+    --net=host \
+    roll:ascend-a2 \
+    /bin/bash
+```
+
+**For A3:**
+
+```bash
+docker run -dit \
+    --name roll_a3 \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/$USER:/home/$USER \
+    --ipc=host \
+    --net=host \
+    roll:ascend-a3 \
+    /bin/bash
+```
+
+### Enter the Container
+
+```bash
+# For A2
+docker exec -it roll_a2 /bin/bash
+
+# For A3
+docker exec -it roll_a3 /bin/bash
+```
+
+## Verify the Environment
+
+After entering the container, verify that the Ascend environment is properly configured:
+
+```bash
+# Verify NPU visibility
+npu-smi info
+
+# Verify CANN environment is loaded
+env | grep -E "ASCEND|LD_LIBRARY_PATH|PATH"
+
+# Verify Python packages
+python -c "import torch; import torch_npu; print(torch_npu.npu.is_available())"
+python -c "import vllm; print(f'vllm: {vllm.__version__}')"
+python -c "import vllm_ascend; print(f'vllm_ascend available')"
+```
+
+## Run ROLL Pipelines
+
+### Important Configuration Notes
+
+Since Megatron-LM training is not yet supported on Ascend NPU, you need to use **DeepSpeed** as the training backend. Make sure your configuration files use the following settings:
+
+1. Set `strategy_args` to use DeepSpeed
+2. Set `device_mapping` to ensure training and inference are performed on different NPUs
+
+### Example: RLVR Pipeline
+
+```bash
+# After modifying model paths and adjusting device_mapping
+python examples/start_rlvr_pipeline.py \
+    --config_path ascend_examples \
+    --config_name qwen3_8b_rlvr_deepspeed
+```
+
+## Troubleshooting
+
+### NPU Not Visible Inside Container
+
+Ensure all required devices and driver paths are mounted correctly. Check with `npu-smi info` inside the container.
+
+### vLLM-Ascend Import Error
+
+Verify that the CANN environment is properly sourced:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+These commands are automatically added to `/root/.bashrc` during the image build. If you switch to a non-root user, you may need to source them manually.
+
+### Out of Memory
+
+Reduce `rollout_batch_size` or `num_return_sequences_in_group` in your configuration file to lower NPU memory usage.
+
+## Disclaimer
+
+The Ascend support provided in ROLL is intended as a reference example. For production use, please consult official channels.

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
@@ -13,7 +13,7 @@ Atlas 900 A3 PODc
 ### Basic Environment Setup
 
 | Software | Version |
-| -------- |---------|
+| -------- | ------- |
 | Python   | 3.11    |
 | CANN     | 8.5.1   |
 

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_docker_usage.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_docker_usage.md
@@ -1,0 +1,241 @@
+# 使用 Docker 在昇腾 NPU 上运行 ROLL
+
+最后更新：2026/04/27。
+
+本指南介绍如何使用 `Dockerfile.A2` 和 `Dockerfile.A3` 在**华为昇腾 NPU** 上构建并运行 ROLL。
+
+## 硬件与软件要求
+
+| 项目 | Dockerfile.A2 | Dockerfile.A3 |
+| ---- | ------------- | ------------- |
+| 硬件 | Atlas 900 A2 PODc（Ascend 910B1） | Atlas 900 A3 PODc（Ascend 910_9391） |
+| 宿主机操作系统 | Ubuntu 22.04 | Ubuntu 22.04 |
+| CANN | 8.5.1 | 8.5.1 |
+| Python | 3.11 | 3.11 |
+| Docker | >= 20.10 | >= 20.10 |
+| 昇腾 NPU 驱动 | 已安装在宿主机上 | 已安装在宿主机上 |
+
+## 主要组件
+
+两个 Dockerfile 安装的核心依赖版本相同：
+
+| 组件 | 版本 |
+| ---- | ---- |
+| PyTorch | 2.8.0+cpu |
+| vLLM | 0.13.0 |
+| vLLM-Ascend | 0.13.0 |
+| DeepSpeed | 0.16.4 |
+| Transformers | 4.57.6 |
+| triton-ascend | 3.2.0 |
+
+主要区别在于基础镜像和 SOC 版本：
+
+| 项目 | Dockerfile.A2 | Dockerfile.A3 |
+| ---- | ------------- | ------------- |
+| 基础镜像 | `quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11` | `quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11` |
+| SOC_VERSION | `ascend910b1` | `ascend910_9391` |
+
+## 构建 Docker 镜像
+
+### 1. 克隆 ROLL 仓库
+
+```bash
+git clone https://github.com/alibaba/ROLL.git
+cd ROLL
+```
+
+### 2. 构建镜像
+
+根据你的硬件选择对应的 Dockerfile：
+
+**Atlas 900 A2 PODc（Ascend 910B1）：**
+
+```bash
+docker build -f docker/Dockerfile.A2 -t roll:ascend-a2 .
+```
+
+**Atlas 900 A3 PODc（Ascend 910_9391）：**
+
+```bash
+docker build -f docker/Dockerfile.A3 -t roll:ascend-a3 .
+```
+
+> **注意：** 构建过程会从源码编译 vLLM 和 vLLM-Ascend，耗时较长，请确保有足够的磁盘空间（至少 50GB）和网络访问。
+
+你也可以在构建时自定义 SOC 版本：
+
+```bash
+# A2 自定义 SOC 版本
+docker build -f docker/Dockerfile.A2 --build-arg SOC_VERSION=ascend910b1 -t roll:ascend-a2 .
+
+# A3 自定义 SOC 版本
+docker build -f docker/Dockerfile.A3 --build-arg SOC_VERSION=ascend910_9391 -t roll:ascend-a3 .
+```
+
+## 运行容器
+
+### 基本启动
+
+**A2：**
+
+```bash
+docker run -dit \
+    --name roll_a2 \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/$USER:/home/$USER \
+    --ipc=host \
+    --net=host \
+    roll:ascend-a2 \
+    /bin/bash
+```
+
+**A3：**
+
+```bash
+docker run -dit \
+    --name roll_a3 \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/$USER:/home/$USER \
+    --ipc=host \
+    --net=host \
+    roll:ascend-a3 \
+    /bin/bash
+```
+
+### 多卡启动（训练推荐）
+
+多 NPU 训练时，需要挂载所有可用的 NPU 设备。根据节点上的 NPU 数量调整 `--device /dev/davinciX` 的数量：
+
+```bash
+docker run -dit \
+    --name roll_ascend \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/$USER:/home/$USER \
+    -v /path/to/models:/path/to/models \
+    -v /path/to/data:/path/to/data \
+    --ipc=host \
+    --net=host \
+    roll:ascend-a3 \
+    /bin/bash
+```
+
+> **注意：**
+> - `--device /dev/davinciX`：挂载 NPU 设备，根据可用 NPU 数量增减。
+> - `--device /dev/davinci_manager`、`--device /dev/devmm_svm`、`--device /dev/hisi_hdc`：昇腾 NPU 必需的管理设备。
+> - `-v /usr/local/Ascend/driver`：挂载宿主机昇腾驱动。
+> - `-v /path/to/models` 和 `-v /path/to/data`：根据需要挂载模型权重和训练数据目录。
+
+### 进入容器
+
+```bash
+# A2
+docker exec -it roll_a2 /bin/bash
+
+# A3
+docker exec -it roll_a3 /bin/bash
+```
+
+## 验证环境
+
+进入容器后，验证昇腾环境是否正确配置：
+
+```bash
+# 验证 NPU 可见性
+npu-smi info
+
+# 验证 CANN 环境已加载
+env | grep -E "ASCEND|LD_LIBRARY_PATH|PATH"
+
+# 验证 Python 包
+python -c "import torch; import torch_npu; print(torch_npu.npu.is_available())"
+python -c "import vllm; print(f'vllm: {vllm.__version__}')"
+python -c "import vllm_ascend; print(f'vllm_ascend available')"
+```
+
+## 运行 ROLL 流水线
+
+### 重要配置说明
+
+由于昇腾 NPU 上暂不支持 Megatron-LM 训练，需要使用 **DeepSpeed** 作为训练后端。请确保配置文件中使用以下设置：
+
+1. 将 `strategy_args` 设置为使用 DeepSpeed
+2. 设置 `device_mapping`，确保训练和推理在不同的 NPU 卡上执行
+
+
+### 示例：RLVR 流水线
+
+```bash
+python examples/start_rlvr_pipeline.py \
+    --config_path qwen2.5-7B-rlvr_megatron \
+    --config_name rlvr_config_amd
+```
+
+> **注意：** `rlvr_config_amd` 配置专为非 NVIDIA 硬件设计，使用 DeepSpeed 作为训练后端。请根据你的 NPU 拓扑调整配置文件中的 `device_mapping`。
+
+## 常见问题
+
+### 容器内 NPU 不可见
+
+确保所有必需的设备和管理路径已正确挂载。在容器内使用 `npu-smi info` 检查。
+
+### vLLM-Ascend 导入错误
+
+验证 CANN 环境是否正确加载：
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+这些命令在镜像构建时已自动添加到 `/root/.bashrc`。如果切换到非 root 用户，可能需要手动执行。
+
+### 显存不足
+
+在配置文件中减小 `rollout_batch_size` 或 `num_return_sequences_in_group` 以降低 NPU 显存占用。
+
+## 声明
+
+ROLL 中提供的 Ascend 支持代码皆为参考样例，生产环境使用请通过官方正式途径沟通。

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
@@ -1,26 +1,23 @@
 # ROLL x Ascend
 
-Last updated: 11/25/2025.
+最后更新：2026/03/13。
 
 我们在 ROLL 上增加对华为昇腾设备的支持。
 
 ## 硬件支持
 
-Atlas 900 A2 PODc
-
+Atlas 900 A3 PODc
 
 ## 安装
 
-
 ### 基础环境准备
 
-| software  | version     |
-|-----------|-------------|
-| Python    |  3.11       |
-| CANN      |  8.3.RC1    |
+| 软件 | 版本 |
+| ---- | ---- |
+| Python | 3.11 |
+| CANN | 8.5.1 |
 
 ### 创建 conda 环境
-
 
 使用以下命令在 Miniconda 中创建新的 conda 环境：
 
@@ -29,27 +26,25 @@ conda create --name roll python=3.11
 conda activate roll
 ```
 
-### 安装 torch & torch_npu:
+### 安装 torch & torch_npu
 
-
-为了能在 ROLL 中正常使用 torch 和 torch_npu，需使用以下命令安装 torch 和 torch_npu。
+为了能在 ROLL 中正常使用 torch 和 torch_npu，需使用以下命令安装 torch 和 torch_npu：
 
 ```
 # 安装 torch 的 CPU 版本
-pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cpu
 
-# 安装 torch_npu
-pip install torch_npu==2.7.1
+# 安装 torch_npu 2.9.0
+pip install torch_npu==2.9.0
 ```
 
+### 安装 vllm & vllm-ascend
 
-### 安装vllm & vllm-ascend:
-
-为了能够在 ROLL 中正常使用 vllm，需使用以下命令编译安装 vllm 和 vllm-ascend。
+为了能够在 ROLL 中正常使用 vllm，需使用以下命令编译安装 vllm 和 vllm-ascend：
 
 ```
 # vllm
-git clone -b v0.11.0 --depth 1 https://github.com/vllm-project/vllm.git
+git clone -b v0.13.0 --depth 1 https://github.com/vllm-project/vllm.git
 cd vllm
 pip install -r requirements/build.txt
 
@@ -57,7 +52,7 @@ VLLM_TARGET_DEVICE=empty pip install -v -e .
 cd ..
 
 # vllm-ascend
-git clone -b v0.11.0rc1 --depth 1 https://github.com/vllm-project/vllm-ascend.git
+git clone -b v0.13.0 --depth 1 https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
 
 pip install -e .
@@ -65,12 +60,13 @@ cd ..
 ```
 
 或者可以从预编译的 wheel 包安装 `vllm` 和 `vllm-ascend`：
-```
-# Install vllm-project/vllm. The newest supported version is v0.11.0.
-pip install vllm==0.11.0
 
-# Install vllm-project/vllm-ascend from pypi.
-pip install vllm-ascend==0.11.0rc1
+```
+# 安装 vllm-project/vllm，最新支持版本为 v0.13.0
+pip install vllm==0.13.0
+
+# 从 pypi 安装 vllm-project/vllm-ascend
+pip install vllm-ascend==0.13.0
 ```
 
 ### 安装 ROLL
@@ -85,54 +81,55 @@ cd ..
 
 ### 其他三方库说明
 
-| software                      | description   |
-|-------------------------------|---------------|
-| transformers                  | >= v4.57.1    |
-| flash_attn                    | not supported |
-| transformer-engine[pytorch]   | not supported |
+| 软件 | 说明 |
+| ---- | ---- |
+| transformers | >= v4.57.6 |
+| flash_attn | 不支持 |
+| transformer-engine[pytorch] | 不支持 |
 
-1. 支持通过 transformers 使能 --flash_attention_2， transformers 需大于等于 4.57.1 版本。
-2. 不支持通过 flash_attn 使能 flash attention 加速。
-3. 暂不支持 transformer-engine[pytorch] 
+1. `transformers` v4.57.6 支持启用 `--flash_attention_2`。
+2. 目前不支持 `flash_attn` 加速。
+3. 目前不支持 `transformer-engine[pytorch]`。
 
 ```
-pip install transformers==4.57.1
+pip install transformers==4.57.6
 ```
 
-## 快速开始，单节点部署指引
+## 快速开始：单节点部署指引
 
 正式使用前，建议您通过对单节点流水线的训练尝试以检验环境准备和安装的正确性。
-由于目前暂不支持 Megatron-LM 训练，请首先将对应文件中 
-strategy_args 参数修改为 deepspeed 选项。
+由于目前暂不支持 Megatron-LM 训练，请首先将对应文件中 `strategy_args` 参数修改为 `deepspeed` 选项。
 
-1. 使用 shell 执行单节点流水线
+**注意：** 目前 NPU 上不支持 colocated 模式。你需要修改 `device_mapping`，确保训练和推理在不同的卡上执行。
+
+1. 使用 shell 执行单节点流水线：
 
 ```
 bash examples/agentic_demo/run_agentic_pipeline_frozen_lake_single_node_demo.sh  
 ```
 
-2. 使用配置文件执行 agentic pipeline
+2. 使用配置文件执行 agentic pipeline：
 
 ```
-# 确保当前位于ROLL项目目录的根目录下
+# 确保当前位于 ROLL 项目目录的根目录下
 
 python examples/start_agentic_pipeline.py \
         --config_path qwen2.5-0.5B-agentic \
         --config_name agentic_val_sokoban
-
-- ``--config_path`` – 包含您的YAML配置文件的目录。
-- ``--config_name`` – 文件名（不含.yaml后缀）。
 ```
+
+- `--config_path` – 包含您的 YAML 配置文件的目录。
+- `--config_name` – 文件名（不含 `.yaml` 后缀）。
 
 ## 支持现状
 
-| Feature         | Example                                                      | Training Backend | Inference Backend | Hardware          |
-| --------------- | ------------------------------------------------------------ | ---------------- | ----------------- | ----------------- |
-| Agentic         | examples/qwen2.5-0.5B-agentic/run_agentic_pipeline_sokoban.sh | DeepSpeed        | vLLM              | Atlas 900 A2 PODc |
-| Agentic-Rollout | examples/qwen2.5-0.5B-agentic/run_agentic_rollout_sokoban.sh | DeepSpeed        | vLLM              | Atlas 900 A2 PODc |
-| DPO             | examples/qwen2.5-3B-dpo_megatron/run_dpo_pipeline.sh         | DeepSpeed        | vLLM              | Atlas 900 A2 PODc |
-| RLVR            | examples/qwen2.5-7B-rlvr_megatron/run_rlvr_pipeline.sh       | DeepSpeed        | vLLM              | Atlas 900 A2 PODc |
-
+| 功能 | 示例 | 训练后端 | 推理后端 | 硬件 |
+| ---- | ---- | -------- | -------- | ---- |
+| Agentic | examples/qwen2.5-0.5B-agentic/run_agentic_pipeline_sokoban.sh | DeepSpeed | vLLM | Atlas 900 A3 PODc |
+| Agentic-Rollout | examples/qwen2.5-0.5B-agentic/run_agentic_rollout_sokoban.sh | DeepSpeed | vLLM | Atlas 900 A3 PODc |
+| DPO | examples/qwen2.5-3B-dpo_megatron/run_dpo_pipeline.sh | DeepSpeed | vLLM | Atlas 900 A3 PODc |
+| RLVR | examples/qwen2.5-7B-rlvr_megatron/run_rlvr_pipeline.sh | DeepSpeed | vLLM | Atlas 900 A3 PODc |
 
 ## 声明
-ROLL 中提供的 Ascend 支持代码皆为参考样例，生产环境使用请通过官方正式途径沟通，谢谢。
+
+ROLL 中提供的 Ascend 支持代码皆为参考样例，生产环境使用请通过官方正式途径沟通。

--- a/docs_roll/package.json
+++ b/docs_roll/package.json
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpackbar": "7.0.0"
   }
 }

--- a/examples/ascend_examples/qwen3_8b_rlvr_deepspeed.yaml
+++ b/examples/ascend_examples/qwen3_8b_rlvr_deepspeed.yaml
@@ -1,0 +1,167 @@
+defaults:
+  - ../config/deepspeed_zero@_here_
+  - ../config/deepspeed_zero2@_here_
+  - ../config/deepspeed_zero3@_here_
+  - ../config/deepspeed_zero3_cpuoffload@_here_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+
+pg_variant: ppo # topr, vanilla, tis, cispo, kimi15, ppo
+exp_name: Qwen3-8B-RLVR-${pg_variant}
+seed: 42
+logging_dir: ./output/logs
+output_dir: ./output
+system_envs:
+  USE_MODELSCOPE: '1'
+
+checkpoint_config:
+  type: file_system
+  output_dir: ./ckpt
+
+num_gpus_per_node: 16
+
+
+max_steps: 200
+save_steps: 100
+logging_steps: 1
+eval_steps: 10
+resume_from_checkpoint: false
+
+
+rollout_batch_size: 16  # prompt
+prompt_length: 2048
+response_length: 8192
+
+num_return_sequences_in_group: 8
+ppo_epochs: 1
+adv_estimator: "reinforce"
+
+# clip
+value_clip: 0.5
+reward_clip: 10
+advantage_clip: 2.0
+dual_clip_loss: true
+
+# normalize
+norm_mean_type: batch
+norm_std_type: batch
+
+# data mask
+max_len_mask: true
+difficulty_mask: true
+difficulty_low_threshold: 0.2
+difficulty_high_threshold: 0.95
+error_max_len_clip: false
+
+# data weight
+difficulty_loss_weight: false
+length_loss_weight: false
+
+# reward
+add_token_level_kl: false
+
+# advantage
+whiten_advantages: true
+
+# dynamic sampling scheduler
+# use_additional_prompts: true
+# max_running_requests: 256
+# is_num_return_sequences_expand: false
+
+pretrain: Qwen/Qwen3-8B-Base
+reward_pretrain: Qwen/Qwen3-8B-Base
+
+validation:
+  data_args:
+    template: qwen3
+    file_name:
+      - data/math_benchmarks.jsonl
+  generating_args:
+    top_p: 0.6
+    top_k: 50
+    num_beams: 1
+    temperature: 0.6
+    num_return_sequences: 1
+  eval_steps: 10
+
+actor_train:
+  worker_cls: roll.pipeline.rlvr.actor_pg_worker.ActorPGWorker
+  pg_variant: ppo # topr, vanilla, tis, cispo, kimi15, ppo
+  model_args:
+    flash_attn: fa2
+    disable_gradient_checkpointing: false
+    dtype: bf16
+    model_type: ~
+  training_args:
+    learning_rate: 1.0e-6
+    weight_decay: 0
+    per_device_train_batch_size: 1
+    gradient_accumulation_steps: 8
+    warmup_steps: 20
+    num_train_epochs: 50
+  data_args:
+    template: qwen3
+    file_name:
+      - data/math_deepmath_deal.jsonl
+    domain_interleave_probs:
+      math_rule: 1
+    dataset_dir: data
+    messages: messages
+    interleave_probs: "1.0"
+    preprocessing_num_workers: 16
+  strategy_args:
+    strategy_name: deepspeed_train
+    strategy_config: ${deepspeed_zero3_cpuoffload}
+  device_mapping: list(range(0,8))
+  infer_batch_size: 1
+
+actor_infer:
+  model_args:
+    flash_attn: fa2
+    disable_gradient_checkpointing: true
+    dtype: bf16
+  generating_args:
+    max_new_tokens: ${response_length}
+    top_p: 0.99
+    top_k: 100
+    num_beams: 1
+    temperature: 0.99
+    num_return_sequences: ${num_return_sequences_in_group}
+  data_args:
+    template: qwen3
+  strategy_args:
+    strategy_name: vllm
+    strategy_config:
+      gpu_memory_utilization: 0.6
+      block_size: 16
+      max_model_len: 8000
+  device_mapping: list(range(8,12))
+  infer_batch_size: 4
+
+reference:
+  model_args:
+    flash_attn: fa2
+    disable_gradient_checkpointing: true
+    dtype: bf16
+    model_type: ~
+  data_args:
+    template: qwen3
+  strategy_args:
+    strategy_name: hf_infer
+    strategy_config: ~
+  device_mapping: list(range(12,16))
+  infer_batch_size: 1
+
+rewards:
+  math_rule:
+    worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
+    model_args:
+      model_name_or_path: ${reward_pretrain}
+    data_args:
+      template: qwen3
+    tag_included: [deepmath_103k, 'MATH-500', 'OlympiadBench', 'minervamath', 'aime2025', 'gsm8k', 'aime', 'amc23', 'math_rule']
+    world_size: 8
+    infer_batch_size: 1


### PR DESCRIPTION
## PR: feat: add NPU Dockerfile and Ascend documentation

### Summary

Add Docker build files and documentation for running ROLL on Huawei Ascend NPU (Atlas 900 A2/A3 PODc), enabling users to deploy RLVR and other pipelines on Ascend hardware.

### Changes

**Docker**
- Add `Dockerfile.A2` for Atlas 900 A2 PODc (Ascend 910B1, CANN 8.5.1)
- Add `Dockerfile.A3` for Atlas 900 A3 PODc (Ascend 910_9391, CANN 8.5.1)
- Both images include: PyTorch 2.8.0+cpu, vLLM 0.13.0, vLLM-Ascend 0.13.0, DeepSpeed 0.16.4, Transformers 4.57.6, triton-ascend 3.2.0

**Documentation (English + Chinese)**
- Add `ascend_docker_usage.md` — Docker image build/pull, container startup, environment verification, and RLVR pipeline example
- Update `ascend_usage.md` — Revise Ascend support status and installation instructions

**Example Config**
- Add `examples/ascend_examples/qwen3_8b_rlvr_deepspeed.yaml` — Qwen3-8B RLVR config using DeepSpeed ZeRO-3 + CPU offloading on NPU

### Files Changed (7 files, +808 / -68)

| File | Change |
|------|--------|
| `docker/Dockerfile.A2` | New |
| `docker/Dockerfile.A3` | New |
| `docs_roll/docs/User Guides/Hardware Support/ascend_docker_usage.md` | New |
| `docs_roll/docs/User Guides/Hardware Support/ascend_usage.md` | Updated |
| `docs_roll/i18n/.../ascend_docker_usage.md` | New (Chinese) |
| `docs_roll/i18n/.../ascend_usage.md` | Updated (Chinese) |
| `examples/ascend_examples/qwen3_8b_rlvr_deepspeed.yaml` | New |

### Key Notes

- NPU does **not** support Megatron-LM; DeepSpeed is the only supported training backend
- NPU does **not** support colocated mode; training and inference must use separate NPU devices
- `flash_attn` package is not supported; use `fa2` via `transformers` instead