### PR TITLE
docs: add Freshness-Aware-PER to Notable work based on ROLLUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Leveraging a multi-role distributed architecture with Ray for flexible resource 
 ---
 
 ## 🏆 Notable work based on ROLL
+- [Freshness-Aware-PER](https://arxiv.org/abs/2604.16918): A freshness-aware prioritized experience replay framework for LLM/VLM reinforcement learning, combining reward magnitude with exponential age decay (`reward_fresh` priority) and asynchronous full-buffer refresh, providing fresher and higher-signal off-policy samples for both step- and trajectory-level agentic RL. [code](https://github.com/Vision-CAIR/Freshness-Aware-PER)
 - [ComplementaryRL](https://arxiv.org/abs/2603.17621): Complementary RL is a learning framework that enables agents to effectively learn from experience through the seamless co-evolution of an experience extractor and a policy actor within the RL optimization loop.
 - [RLix](https://github.com/rlops/rlix): RLix is an RL job manager that lets more RL jobs run concurrently with less waiting by sharing GPU capacity across jobs, while preserving each pipeline’s training behavior and improving GPU utilization.
 - [TurningPoint-GRPO](https://arxiv.org/abs/2602.06422): A GRPO framework for Flow Matching models in text-to-image generation that alleviates step-wise reward sparsity by modeling step-level incremental rewards and explicitly captures long-term effects via turning points detection, providing dense learning signals for each denoising action.


### PR DESCRIPTION
Hi ROLL team 👋

This PR adds our paper [Freshness-Aware Prioritized Experience Replay for LLM/VLM Reinforcement Learning](https://arxiv.org/abs/2604.16918) to the "Notable work based on ROLL" section.

Code (built on top of ROLL): https://github.com/Vision-CAIR/Freshness-Aware-PER

Brief summary:
- `reward_fresh` priority combining `|reward|` with exponential age decay
- Asynchronous full-buffer priority refresh (`refresh_all_age_decay`) so unsampled old entries stay properly decayed
- Episode-indexed n-step / hierarchical sampling for both step-level and trajectory-level buffers
- Apache 2.0, identical to upstream

Happy to adjust wording, ordering, or description length to match the section's style — thanks for the great library!