### PR TITLE
fix: mask token-mean loss aggregation

### DIFF
--- a/roll/utils/functionals.py
+++ b/roll/utils/functionals.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import inspect
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from roll.distributed.scheduler.protocol import DataProto
-import enum
-import traceback
 import heapq
-from typing import Dict, List, Optional, Tuple, Union
+import inspect
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -20,6 +14,9 @@ from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 from roll.platforms import current_platform
 from roll.utils.kl_controller import AdaptiveKLController
 from roll.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from roll.distributed.scheduler.protocol import DataProto
 
 logger = get_logger()
 
@@ -225,8 +222,14 @@ def entropy_from_logits(logits: torch.Tensor):
     return entropy
 
 
-def agg_loss(loss_mat: torch.Tensor, loss_mask: torch.Tensor, loss_agg_mode: str, batch_num_tokens: int = None,
-             global_valid_samples: int = None, weights: Optional[torch.Tensor] = None):
+def agg_loss(
+    loss_mat: torch.Tensor,
+    loss_mask: torch.Tensor,
+    loss_agg_mode: str,
+    batch_num_tokens: int = None,
+    global_valid_samples: int = None,
+    weights: Optional[torch.Tensor] = None,
+):
     """
     ref: https://github.com/volcengine/verl/blob/78532923368aeb058f62201489546d013df47710/verl/trainer/ppo/core_algos.py#L370
     Aggregate the loss matrix into a scalar.
@@ -251,8 +254,9 @@ def agg_loss(loss_mat: torch.Tensor, loss_mask: torch.Tensor, loss_agg_mode: str
         global_valid_samples = loss_mat.size(0)
     if loss_agg_mode == "token-mean":
         if weights is None:
-            weights = torch.ones(loss_mask.shape[0], device=loss_mask.device)
-        loss = (loss_mat * weights.unsqueeze(-1)).sum() / batch_num_tokens
+            weights = torch.ones(loss_mask.shape[0], dtype=loss_mat.dtype, device=loss_mask.device)
+        masked_loss = torch.where(loss_mask.bool(), loss_mat, torch.zeros_like(loss_mat))
+        loss = (masked_loss * weights.unsqueeze(-1)).sum() / batch_num_tokens
     elif loss_agg_mode == "seq-mean-token-sum":
         seq_losses = masked_sum(loss_mat, loss_mask, dim=-1)  # token-sum
         valid_samples = torch.any(loss_mask > 0, dim=-1).float()
@@ -287,6 +291,7 @@ def masked_mean(tensor: torch.Tensor, mask: torch.Tensor, dim: int = None) -> to
         return torch.where(mask_sum > 0, (tensor * mask).sum(axis=dim) / (mask_sum + 1e-8), torch.zeros_like(mask_sum))
     else:
         return (tensor * mask).sum() / (mask.sum() + 1e-8)
+
 
 def masked_sum(tensor: torch.Tensor, mask: torch.Tensor, dim: int = None) -> torch.Tensor:
     if dim is not None:
@@ -445,6 +450,7 @@ def reduce_metrics(metrics: dict, reduce_func=np.mean) -> dict:
 
     return metrics
 
+
 def reduce_metrics_list(metrics_list: list, reduce_func=np.mean) -> dict:
     if len(metrics_list) == 0:
         return {}
@@ -574,7 +580,7 @@ def reward_norm(
         reward_mean = reshape_reward.mean(dim=-1, keepdim=True)
     elif norm_mean_type == "running":
         reward_mean = running.mean
-    elif norm_mean_type == None:
+    elif norm_mean_type is None:
         reward_mean = 0.0
     # 标准差计算
     if norm_std_type == "batch":
@@ -589,7 +595,7 @@ def reward_norm(
     if norm_std_type is not None:
         normalized_rewards = (rewards - reward_mean) / (reward_std + 1e-6)
     else:
-        normalized_rewards = (rewards - reward_mean)
+        normalized_rewards = rewards - reward_mean
 
     # 如果是对 group mean 归一化，需要恢复原始形状
     if norm_mean_type == "group":
@@ -653,12 +659,12 @@ def reward_postprocess(data: "DataProto", pipeline_config: RLVRConfig, running_c
         pipeline_config.norm_mean_type, pipeline_config.norm_std_type = "group", "group"
 
     response_level_rewards = reward_norm(
-                    response_level_rewards,
-                    n_sample=pipeline_config.actor_infer.generating_args.num_return_sequences,
-                    running_ctrl=running_ctrl,
-                    norm_mean_type=pipeline_config.norm_mean_type,
-                    norm_std_type=pipeline_config.norm_std_type
-                    )
+        response_level_rewards,
+        n_sample=pipeline_config.actor_infer.generating_args.num_return_sequences,
+        running_ctrl=running_ctrl,
+        norm_mean_type=pipeline_config.norm_mean_type,
+        norm_std_type=pipeline_config.norm_std_type,
+    )
 
     # 对reward进行clip
     if pipeline_config.reward_clip:
@@ -798,7 +804,9 @@ def compute_advantage(
     kld = None
     if is_pure_opd or use_opd:
         kld = compute_approx_kl(
-            log_probs=data.batch["old_log_probs"] if getattr(pipeline_config, "enable_old_logprobs_recompute", False) else data.batch["infer_logprobs"],
+            log_probs=data.batch["old_log_probs"]
+            if getattr(pipeline_config, "enable_old_logprobs_recompute", False)
+            else data.batch["infer_logprobs"],
             log_probs_base=data.batch["ref_log_probs"],
             action_mask=response_mask,
             kl_penalty=getattr(pipeline_config, "kl_penalty", "kl"),
@@ -847,6 +855,7 @@ def compute_advantage(
     data.batch["advantages"] = advantages
     data.batch["returns"] = returns
     return data
+
 
 def postprocess_generate(
     prompts: "DataProto",
@@ -991,6 +1000,7 @@ def separate_prompt_response(
     response_ids = torch.where(response_mask_valid, input_ids, torch.full_like(input_ids, pad_id))
     return prompt_ids, response_ids
 
+
 def filter_func_args(func, forward_args):
     signature = inspect.signature(func)
     forward_params = signature.parameters.keys()
@@ -1119,9 +1129,9 @@ def adjust_sequence_length(sequence, target_length, origin_seq_len, pad_value=0)
         return sequence[tuple(slices)]
 
 
-def get_seqlen_balanced_partitions(seqlen_list: List[float],
-                                   k_partitions: int,
-                                   equal_size: bool = False) -> List[List[int]]:
+def get_seqlen_balanced_partitions(
+    seqlen_list: List[float], k_partitions: int, equal_size: bool = False
+) -> List[List[int]]:
     """
     Reference: https://github.com/volcengine/verl/blob/468adf22c43b744348051fccd7a5d830c6c3c36a/verl/utils/seqlen_balancing.py
 
@@ -1193,16 +1203,14 @@ def get_seqlen_balanced_partitions(seqlen_list: List[float],
                 return self.spread > other.spread
             return self.sets[0] > other.sets[0]
 
-    assert len(seqlen_list) >= k_partitions, \
-        f"number of items:[{len(seqlen_list)}] < k_partitions:[{k_partitions}]"
+    assert len(seqlen_list) >= k_partitions, f"number of items:[{len(seqlen_list)}] < k_partitions:[{k_partitions}]"
 
     # Sort by sequence length
     sorted_seqlen_list = sorted([(seqlen, i) for i, seqlen in enumerate(seqlen_list)])
     states_pq = []
 
     if equal_size:
-        assert len(seqlen_list) % k_partitions == 0, \
-            f"{len(seqlen_list)} % {k_partitions} != 0"
+        assert len(seqlen_list) % k_partitions == 0, f"{len(seqlen_list)} % {k_partitions} != 0"
         for offset in range(0, len(sorted_seqlen_list), k_partitions):
             items = []
             for i in range(k_partitions):
@@ -1262,7 +1270,7 @@ def log_seqlen_unbalance(seqlen_list: list[int], partitions: list[list[int]], pr
 
     # Iterate over each batch of sequence lengths
     for offset in range(0, len(seqlen_list), batch_size):
-        cur_sum_seqlen = sum(seqlen_list[offset: offset + batch_size])
+        cur_sum_seqlen = sum(seqlen_list[offset : offset + batch_size])
         if min_sum_seqlen is None or cur_sum_seqlen < min_sum_seqlen:
             min_sum_seqlen = cur_sum_seqlen
         if max_sum_seqlen is None or cur_sum_seqlen > max_sum_seqlen:
@@ -1305,16 +1313,14 @@ def batch_balance(batch: DataProto, dp_size, minibatch_size, logging_prefix="glo
         global_partition_lst = [[] for _ in range(world_size)]
         for i in range(minibatch_num):
             rearrange_minibatch_lst = get_seqlen_balanced_partitions(
-                workload_lst[i * minibatch_size: (i + 1) * minibatch_size],
+                workload_lst[i * minibatch_size : (i + 1) * minibatch_size],
                 k_partitions=world_size,
                 equal_size=True,
             )
             for j, part in enumerate(rearrange_minibatch_lst):
                 global_partition_lst[j].extend([x + minibatch_size * i for x in part])
     else:
-        global_partition_lst = get_seqlen_balanced_partitions(
-            workload_lst, k_partitions=world_size, equal_size=True
-        )
+        global_partition_lst = get_seqlen_balanced_partitions(workload_lst, k_partitions=world_size, equal_size=True)
     # Place smaller micro-batches at both ends to reduce the bubbles in pipeline parallel.
     for idx, partition in enumerate(global_partition_lst):
         partition.sort(key=lambda x: (workload_lst[x], x))
@@ -1329,4 +1335,3 @@ def batch_balance(batch: DataProto, dp_size, minibatch_size, logging_prefix="glo
     metrics = {}
     metrics.update(global_balance_stats)
     return metrics
-

--- a/tests/utils/test_functionals.py
+++ b/tests/utils/test_functionals.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 import torch
 
-from roll.utils.functionals import traverse_obj, divide_by_chunk_size, pad_to_length
+from roll.utils.functionals import (
+    agg_loss,
+    divide_by_chunk_size,
+    pad_to_length,
+    traverse_obj,
+)
 
 
 def visitor(obj: object, path: Tuple):
@@ -22,6 +27,7 @@ def test_traverse_obj():
                 "nested_key1": torch.tensor([[1, 2], [3, 4]]),
                 "nested_key2": [torch.tensor(5), np.array([6, 7])],
             }
+
     class CustomObject:
         def __init__(self):
             self.attr1 = torch.tensor([1, 2, 3])
@@ -53,6 +59,25 @@ def test_pad_to_length():
 
     padded_tensor = pad_to_length(tensor, length, pad_value, dim=-1)
     print(padded_tensor)
+
+
+def test_agg_loss_token_mean_masks_loss_numerator_and_gradients():
+    loss_mat = torch.tensor([[1.0, 100.0], [1.0, -50.0]], requires_grad=True)
+    loss_mask = torch.tensor([[1, 0], [1, 0]])
+
+    loss = agg_loss(
+        loss_mat=loss_mat,
+        loss_mask=loss_mask,
+        loss_agg_mode="token-mean",
+        batch_num_tokens=int(loss_mask.sum().item()),
+    )
+    loss.backward()
+
+    assert loss.item() == pytest.approx(1.0)
+    torch.testing.assert_close(
+        loss_mat.grad,
+        torch.tensor([[0.5, 0.0], [0.5, 0.0]]),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

`roll.utils.functionals.agg_loss(..., loss_agg_mode="token-mean")` currently divides by the number of valid tokens but sums the entire `loss_mat` numerator. When padding, filtered rollout tokens, or tool/observation tokens have `loss_mask=0`, their per-token losses can still change actor loss, entropy loss, clip metrics, and gradients without crashing.

This patch applies `loss_mask` to the token-mean numerator before summing, using `torch.where(loss_mask.bool(), loss_mat, 0)` so masked tokens do not contribute values or gradients. It also adds a focused regression test for the scalar loss and per-token gradients.

# Concrete triggering example

The bug is visible with two valid tokens and two masked tokens:

```python
loss_mat = torch.tensor([[1.0, 100.0], [1.0, -50.0]], requires_grad=True)
loss_mask = torch.tensor([[1, 0], [1, 0]])
batch_num_tokens = 2
loss = agg_loss(loss_mat, loss_mask, "token-mean", batch_num_tokens=batch_num_tokens)
```

Current behavior computes `(1 + 100 + 1 - 50) / 2 = 26.0` and gives every position gradient `0.5`, including masked positions. Mask-respecting behavior computes `(1 + 1) / 2 = 1.0` and gives gradients `[[0.5, 0.0], [0.5, 0.0]]`.

Wrong intermediate value: `token_mean_loss=26.0` with `masked_token_gradient_abs_sum=1.0`.
Fixed value: `token_mean_loss=1.0` with `masked_token_gradient_abs_sum=0.0`.

# Reproduction recipe

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "bug_id": "ROLL-AGGLOSS-TOKENMEAN-MASK",
  "target": "roll",
  "validation_mode": "real_roll_boundary_tensor_hook",
  "hooked_boundary": "roll.utils.functionals.agg_loss",
  "requirements": {
    "target_repo": "${TARGET_REPO}",
    "output_dir": "${OUTPUT_DIR}",
    "python": "python3",
    "required_modules": ["roll.utils.functionals", "torch"],
    "backend_required": false
  },
  "constructed_scenario": {
    "loss_agg_mode": "token-mean",
    "loss_mat": [[1.0, 100.0], [1.0, -50.0]],
    "loss_mask": [[1, 0], [1, 0]],
    "batch_num_tokens": 2
  },
  "expected_unpatched": {
    "token_mean_loss": 26.0,
    "masked_token_gradient_abs_sum": 1.0,
    "parameter_update_delta": -2.6
  },
  "expected_fixed": {
    "token_mean_loss": 1.0,
    "masked_token_gradient_abs_sum": 0.0,
    "parameter_update_delta": -0.1
  }
}
```

# Validation runner

```python
#!/usr/bin/env python3
import contextlib
import json
import math
import os
import subprocess
import sys
from pathlib import Path

import torch

BUG_ID = os.environ.get("BUG_ID", "ROLL-AGGLOSS-TOKENMEAN-MASK")
TARGET_REPO = Path(os.environ["TARGET_REPO"]).resolve()
OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", ".")).resolve()
OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

sys.path.insert(0, str(TARGET_REPO))
with contextlib.redirect_stdout(sys.stderr):
    from roll.utils.functionals import agg_loss
import roll.utils.functionals as functionals

module_path = Path(functionals.__file__).resolve()
if not str(module_path).startswith(str(TARGET_REPO)):
    raise RuntimeError(f"roll.utils.functionals imported from {module_path}, expected under {TARGET_REPO}")

loss_values = torch.tensor([[1.0, 100.0], [1.0, -50.0]], dtype=torch.float32)
loss_mask = torch.tensor([[1, 0], [1, 0]], dtype=torch.long)
batch_num_tokens = int(loss_mask.sum().item())
learning_rate = 0.1

theta = torch.nn.Parameter(torch.tensor(1.0))
loss = agg_loss(theta * loss_values, loss_mask, "token-mean", batch_num_tokens=batch_num_tokens)
loss.backward()
theta_grad = float(theta.grad.detach().item())
update_delta = -learning_rate * theta_grad

leaf = loss_values.clone().detach().requires_grad_(True)
leaf_loss = agg_loss(leaf, loss_mask, "token-mean", batch_num_tokens=batch_num_tokens)
leaf_loss.backward()
leaf_grad = leaf.grad.detach()

result = {
    "bug_id": BUG_ID,
    "module_file": str(module_path),
    "commit": subprocess.check_output(["git", "-C", str(TARGET_REPO), "rev-parse", "HEAD"], text=True).strip(),
    "token_mean_loss": float(loss.detach().item()),
    "theta_gradient": theta_grad,
    "parameter_update_delta": update_delta,
    "per_token_gradient": leaf_grad.tolist(),
    "masked_token_gradient_abs_sum": float((leaf_grad * (1 - loss_mask)).abs().sum().item()),
}
(OUTPUT_DIR / "agg_loss_token_mean_validation.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\\n")
print(json.dumps(result, indent=2, sort_keys=True))

if not math.isfinite(result["token_mean_loss"]):
    raise SystemExit(2)
```

# Observed output

Unpatched ROLL produced:

```json
{
  "status": "reproduced",
  "observed_bad_behavior": {
    "token_mean_loss": 26.0,
    "theta_gradient": 26.0,
    "parameter_update_delta": -2.6,
    "per_token_gradient": [[0.5, 0.5], [0.5, 0.5]],
    "masked_token_gradient_abs_sum": 1.0
  },
  "expected_safe_behavior": {
    "token_mean_loss": 1.0,
    "theta_gradient": 1.0,
    "parameter_update_delta": -0.1,
    "per_token_gradient": [[0.5, 0.0], [0.5, 0.0]],
    "masked_token_gradient_abs_sum": 0.0
  },
  "attack_effect": {
    "silent": true,
    "crashed": false,
    "loss_delta": 25.0,
    "parameter_update_delta_difference": -2.5
  }
}
```

After the patch, the same boundary returned:

```json
{
  "status": "fixed",
  "not_triggered": true,
  "observed_fixed_behavior": {
    "token_mean_loss": 1.0,
    "theta_gradient": 1.0,
    "parameter_update_delta": -0.1,
    "per_token_gradient": [[0.5, 0.0], [0.5, 0.0]],
    "masked_token_gradient_abs_sum": 0.0
  }
}
```

# Root cause

`agg_loss` used the mask to derive `batch_num_tokens`, then ignored `loss_mask` in the `token-mean` numerator:

```python
loss = (loss_mat * weights.unsqueeze(-1)).sum() / batch_num_tokens
```

That makes token-mean inconsistent with the mask contract used by the other aggregation modes and by ROLL actor workers that pass `response_mask` or `final_response_mask` into `agg_loss`.

# Fix

The patch masks the numerator before applying sample weights and summing:

```python
masked_loss = torch.where(loss_mask.bool(), loss_mat, torch.zeros_like(loss_mat))
loss = (masked_loss * weights.unsqueeze(-1)).sum() / batch_num_tokens
```

The regression test checks the scalar result and verifies that masked token positions receive zero gradient.

# Tests and checks

```bash
python3 -m pytest -q tests/utils/test_functionals.py

git diff --check HEAD^ HEAD -- roll/utils/functionals.py tests/utils/test_functionals.py

python3 -m pre_commit install
python3 -m pre_commit run --files roll/utils/functionals.py tests/utils/test_functionals.py
```

All listed checks passed on the local fix branch. The fixed-boundary validation also passed with `status="fixed"` and `not_triggered=true`.

# Contribution and duplicate checks

Target upstream repo: `alibaba/ROLL`.

Contribution evidence read from the local checkout: `README.md`, `.pre-commit-config.yaml`, and `pyproject.toml`. No root `CONTRIBUTING.md` was present in the refreshed checkout.

Duplicate checks performed before creating the fix branch:

- `BUG_FINDINGS.md` search for `ROLL`, `myROLL`, `alibaba/ROLL`, `agg_loss`, `token-mean`, `loss_mask`, and `batch_num_tokens` found no exact ROLL duplicate. It found same-family non-ROLL mask/aggregation bugs only.
- Local and remote `myROLL` branch search found no existing fix branch for this boundary before `fix/agg-loss-token-mean-mask` was created.
- Local `myROLL/pr_drafts` was empty before this draft.
- Historical RL-Sentinel loop artifacts and the bug DB had no exact ROLL `agg_loss` token-mean duplicate.
- Upstream `alibaba/ROLL` GitHub issue/PR search returned `alibaba/ROLL#420`, an unrelated LVLM LoRA question, not this aggregation bug.
- Refreshed upstream main still had the token-mean numerator summing `loss_mat` without applying `loss_mask`.

# Related PRs or fixes

No exact upstream ROLL PR or issue was found. Same-family RL-Sentinel findings exist in other projects for mask-before-reduction invariants, including veRL `agg_loss` sequence-mode masked invalid values, but those are not duplicates: this bug is ROLL-specific and affects `token-mean` by including finite masked-token loss values in the numerator.