### PR TITLE
fix: preserve multi_modal_data in generate_opt_level=0 path

### DIFF
--- a/roll/distributed/scheduler/generate_scheduler.py
+++ b/roll/distributed/scheduler/generate_scheduler.py
@@ -567,7 +567,16 @@ class DynamicSamplingScheduler(RolloutMockMixin):
             request_data: DataProto = DataProto.from_single_dict(collect_data, meta_info=data.meta_info)
             request_data.batch["prompt_id"] = torch.arange(request_data.batch.batch_size[0], device=request_data.batch.device)
 
-            gen_batch = request_data.pop(batch_keys=["input_ids", "attention_mask", "position_ids"])
+            generate_non_tensor_batch_keys = []
+            if "multi_modal_data" in request_data.non_tensor_batch:
+                generate_non_tensor_batch_keys.append("multi_modal_data")
+
+            gen_batch = request_data.pop(
+                batch_keys=["input_ids", "attention_mask", "position_ids"],
+                non_tensor_batch_keys=generate_non_tensor_batch_keys,
+            )
+            for key in generate_non_tensor_batch_keys:
+                request_data.non_tensor_batch[key] = gen_batch.non_tensor_batch[key]
             gen_batch.meta_info = request_data.meta_info
             num_return_sequences = generation_config["num_return_sequences"]
             request_data = request_data.repeat(repeat_times=num_return_sequences)


### PR DESCRIPTION
## Summary

This PR fixes VLM generation in `generate_scheduler.py` by preserving `multi_modal_data` when constructing `gen_batch`.

Previously, `request_data.pop(...)` only kept tensor fields such as `input_ids`, `attention_mask`, and `position_ids`. For multimodal generation, `multi_modal_data` is stored in `non_tensor_batch`, so it was dropped before calling `actor_cluster.generate(...)`.

As a result, VLM backends such as vLLM/SGLang could receive text-only prompts without image payloads.

For Qwen3-VL in vLLM, this could fail during M-RoPE position initialization with an error like:

IndexError: list index out of range

File ".../vllm/model_executor/models/qwen3_vl.py", line 1521, in get_mrope_input_positions
    image_grid_thw[image_index][0]

## Changes

- Preserve `multi_modal_data` from `request_data.non_tensor_batch` when building `gen_batch`.
- Keep behavior unchanged for text-only models.

## Why

For VLM models, `multi_modal_data` contains image payloads and prompt token ids required by generation backends. Dropping it causes multimodal sampling to fail or silently degrade to text-only generation.

## Test

- Verified with Qwen3-VL RLVR pipeline using `generate_opt_level: 0`.
- Confirmed that `multi_modal_data` is preserved and passed to the generation backend.