### PR TITLE
feat: add npu ci yaml and fix tests

### DIFF
--- a/.github/workflows/ci-npu-test.yml
+++ b/.github/workflows/ci-npu-test.yml
@@ -1,0 +1,318 @@
+name: Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs_roll/**"
+      - "**/*.md"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/daily-stats.yml"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs_roll/**"
+      - "**/*.md"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/daily-stats.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    name: Unit Tests (CPU)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements_common.txt
+            mcore_adapter/pyproject.toml
+            mcore_adapter/requirements.txt
+            setup.py
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          # Install PyTorch CPU-only to keep CI lightweight
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          # Install core test dependencies (subset of requirements_common.txt)
+          pip install pytest pytest-timeout pytest-asyncio numpy tensordict pydantic dacite \
+            more_itertools hydra-core omegaconf peft==0.12.0 datasets==3.1.0 \
+            trl==0.9.6 transformers ray[default] sympy deprecated codetiming pybase64 imageio \
+            jsonschema mcp gem-llm==0.0.4 openai==2.31.0 gym 'gymnasium[toy-text]' gym_sokoban rl-rock
+          # Install mcore_adapter and roll itself
+          pip install -e ./mcore_adapter
+          pip install -e .
+          rock admin start
+
+      - name: Run CPU-compatible unit tests
+        run: |
+          pytest tests/utils \
+                 tests/datasets \
+                 tests/agentic \
+                 tests/test_ref_worker_type_consistency.py \
+                 -v --timeout=300 --durations=0 --durations-min=0 -x
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ROLL_RUN_EXTERNAL_AGENTIC_TESTS: "0"
+          ROLL_RUN_AGENTIC_SANDBOX_TESTS: "0"
+          ROLL_RUN_AGENTIC_ENV_MANAGER_DEBUG_TESTS: "0"
+
+  npu-test:
+    name: NPU Integration Tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: linux-aarch64-a3-8
+    timeout-minutes: 120
+    container:
+      # Pre-built NPU docker image (built from docker/Dockerfile.A3) with all deps pre-installed
+      image: quay.io/ascend/vllm-ascend:v0.18.0-a3
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache
+      PIP_INDEX_URL: https://repo.huaweicloud.com/repository/pypi/simple
+      PIP_TRUSTED_HOST: repo.huaweicloud.com
+      HF_ENDPOINT: https://hf-mirror.com
+      # vLLM-Ascend sleep/offload uses memory pools that are incompatible with
+      # expandable segments.
+      PYTORCH_NPU_ALLOC_CONF: ""
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_USE_V1: "1"
+      # The CI vLLM smoke uses TP=1; FlashComm sequence parallelism requires TP>1.
+      VLLM_ASCEND_ENABLE_FLASHCOMM: "0"
+      # vLLM-Ascend sleep/wake rejects FRACTAL_NZ for RL-style weight reload flows.
+      VLLM_ASCEND_ENABLE_NZ: "0"
+      SGLANG_KERNEL_NPU_REPO: https://github.com/sgl-project/sgl-kernel-npu.git
+      SGLANG_KERNEL_NPU_BRANCH: main
+      SGLANG_KERNEL_NPU_CACHE_KEY: main
+      SGLANG_REPO: https://github.com/sgl-project/sglang.git
+      SGLANG_BRANCH: ifmn/eagle-dp-attn
+      SGLANG_CACHE_KEY: ifmn-eagle-dp-attn
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache NPU pip packages
+        uses: actions/cache@v4
+        with:
+          path: .pip-cache
+          key: ${{ runner.os }}-npu-pip-${{ env.SGLANG_KERNEL_NPU_CACHE_KEY }}-${{ env.SGLANG_CACHE_KEY }}-${{ hashFiles('requirements_common.txt', 'requirements_vision.txt', 'mcore_adapter/pyproject.toml', 'mcore_adapter/requirements.txt', 'setup.py', 'pyproject.toml', '.github/workflows/ci-npu-test.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-npu-pip-${{ env.SGLANG_KERNEL_NPU_CACHE_KEY }}-${{ env.SGLANG_CACHE_KEY }}-
+            ${{ runner.os }}-npu-pip-${{ env.SGLANG_CACHE_KEY }}-
+            ${{ runner.os }}-npu-pip-
+
+      - name: Configure pip cache
+        run: |
+          mkdir -p "$PIP_CACHE_DIR"
+          python3 -m pip cache dir
+
+      - name: Configure Ascend runtime
+        shell: bash
+        run: |
+          set -eo pipefail
+          if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then
+            source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          fi
+          if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then
+            source /usr/local/Ascend/nnal/atb/set_env.sh
+          fi
+
+          export ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-/usr/local/Ascend/ascend-toolkit/latest}"
+          export ASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME:-${ASCEND_HOME_PATH}}"
+          export ASCEND_OPP_PATH="${ASCEND_OPP_PATH:-${ASCEND_HOME_PATH}/opp}"
+          export ASCEND_AICPU_PATH="${ASCEND_AICPU_PATH:-${ASCEND_HOME_PATH}}"
+          export LD_LIBRARY_PATH="/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/runtime/lib64:/usr/local/Ascend/ascend-toolkit/latest/runtime/lib64/stub:/usr/local/Ascend/ascend-toolkit/latest/tools/hccl/lib64:/usr/local/Ascend/ascend-toolkit/latest/hccl/lib64:${LD_LIBRARY_PATH:-}"
+
+          cann_python_paths=()
+          for path in \
+            "${ASCEND_HOME_PATH}/python/site-packages" \
+            "${ASCEND_HOME_PATH}/opp/built-in/op_impl/ai_core/tbe"; do
+            if [ -d "$path" ]; then
+              cann_python_paths+=("$path")
+            fi
+          done
+          if [ ${#cann_python_paths[@]} -gt 0 ]; then
+            export PYTHONPATH="$(IFS=:; echo "${cann_python_paths[*]}"):${PYTHONPATH:-}"
+          fi
+
+          echo "ASCEND_HOME_PATH=${ASCEND_HOME_PATH}" >> "$GITHUB_ENV"
+          echo "ASCEND_TOOLKIT_HOME=${ASCEND_TOOLKIT_HOME}" >> "$GITHUB_ENV"
+          echo "ASCEND_OPP_PATH=${ASCEND_OPP_PATH}" >> "$GITHUB_ENV"
+          echo "ASCEND_AICPU_PATH=${ASCEND_AICPU_PATH}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          echo "PYTHONPATH=${PYTHONPATH:-}" >> "$GITHUB_ENV"
+          echo "${ASCEND_HOME_PATH}/bin" >> "$GITHUB_PATH"
+          echo "${ASCEND_HOME_PATH}/compiler/ccec_compiler/bin" >> "$GITHUB_PATH"
+
+      - name: Show environment info
+        run: |
+          python3 - <<'PY'
+          import importlib.util
+          import importlib.metadata as metadata
+          import sys
+
+          import torch
+          import torch_npu
+
+          def module_available(name):
+              return importlib.util.find_spec(name) is not None
+
+          print(f"python={sys.version.split()[0]}")
+          print(f"pip={metadata.version('pip')}")
+          print(f"torch={torch.__version__}")
+          print(f'torch_npu={torch_npu.__version__}')
+
+          modules = ('tbe', 'decorator', 'attrs', 'psutil', 'scipy', 'cloudpickle', 'tornado', 'ml_dtypes')
+          for module_name in modules:
+              print(f'{module_name}_module={module_available(module_name)}')
+
+          if not module_available('tbe'):
+              raise RuntimeError('CANN tbe Python module is not visible in PYTHONPATH')
+          if not torch.npu.is_available():
+              raise RuntimeError('torch.npu.is_available() is False')
+          print(f'npu_device_count={torch.npu.device_count()}')
+          PY
+          npu-smi info
+
+      - name: Install pytest dependencies
+        run: |
+          pip install pytest-timeout
+
+      - name: Install ROLL requirements
+        run: |
+          python3 -m pip install -r requirements_common.txt
+          python3 -m pip install deepspeed==0.16.4 tensorboard
+
+      - name: Install SGLang NPU kernel from source
+        shell: bash
+        run: |
+          set -eo pipefail
+          export SGLANG_KERNEL_NPU_SRC="/tmp/sgl-kernel-npu"
+          rm -rf "${SGLANG_KERNEL_NPU_SRC}"
+          git clone --depth 1 --branch "${SGLANG_KERNEL_NPU_BRANCH}" --recurse-submodules --shallow-submodules "${SGLANG_KERNEL_NPU_REPO}" "${SGLANG_KERNEL_NPU_SRC}"
+          cd "${SGLANG_KERNEL_NPU_SRC}"
+          git submodule status --recursive
+          python3 -m pip install pybind11 wheel
+          bash build.sh -a kernels
+          python3 -m pip install output/sgl_kernel_npu*.whl
+          python3 - <<'PY'
+          import sgl_kernel_npu
+
+          print(f"sgl_kernel_npu={sgl_kernel_npu.__path__}")
+          PY
+
+      - name: Install SGLang from source
+        shell: bash
+        run: |
+          set -eo pipefail
+          export SGLANG_SRC="/tmp/sglang"
+          rm -rf "${SGLANG_SRC}"
+          git clone --depth 1 --branch "${SGLANG_BRANCH}" "${SGLANG_REPO}" "${SGLANG_SRC}"
+          python3 - <<'PY' > "${SGLANG_SRC}/ci-requirements.txt"
+          import importlib.metadata
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          skip_packages = {
+              "cuda-python",
+              "flashinfer-cubin",
+              "flashinfer-python",
+              "nvidia-cutlass-dsl",
+              "nvidia-ml-py",
+              "sgl-kernel",
+              "sglang-router",
+              "torch",
+              "torch-memory-saver",
+              "torchaudio",
+              "torchao",
+              "torchcodec",
+              "torchvision",
+              "transformers",
+          }
+
+          pyproject = Path(os.environ["SGLANG_SRC"]) / "python" / "pyproject.toml"
+          dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+          for dependency in dependencies:
+              package_name = re.split(r"[\[<>=!~; ]", dependency, maxsplit=1)[0]
+              package_name = package_name.replace("_", "-").lower()
+              if package_name in skip_packages:
+                  continue
+              try:
+                  importlib.metadata.version(package_name)
+              except importlib.metadata.PackageNotFoundError:
+                  print(dependency)
+          PY
+          echo "Missing SGLang dependencies for CI:"
+          cat "${SGLANG_SRC}/ci-requirements.txt"
+          python3 -m pip install -r "${SGLANG_SRC}/ci-requirements.txt"
+          python3 -m pip install --no-deps -e "${SGLANG_SRC}/python"
+          python3 - <<'PY'
+          import importlib.metadata
+
+          print(f"sglang={importlib.metadata.version('sglang')}")
+          PY
+
+      - name: Install ROLL
+        run: |
+          python3 -m pip install -e .
+
+      - name: Show vLLM Ascend info
+        run: |
+          python3 - <<'PY'
+          import importlib.metadata as metadata
+
+          import vllm
+          from roll.platforms import current_platform
+
+          def package_version(name):
+              try:
+                  return metadata.version(name)
+              except metadata.PackageNotFoundError:
+                  return "not installed"
+
+          packages = ("vllm-ascend", "transformers", "deepspeed", "triton-ascend")
+          for package_name in packages:
+              print(f"{package_name}={package_version(package_name)}")
+
+          print(f"vllm={vllm.__version__}")
+          print(f"platform={current_platform.device_type}")
+          PY
+
+      - name: Run remaining NPU-compatible unit tests
+        run: |
+          export PYTHONPATH="${GITHUB_WORKSPACE}:${PYTHONPATH:-}"
+          python3 -m pytest tests/third_party/sglang \
+                            tests/third_party/vllm \
+                            tests/third_party/deepspeed \
+                            tests/distributed \
+                            tests/models \
+                            tests/pipeline \
+                            tests/test_ref_worker_type_consistency.py \
+                            --ignore=tests/models/cuda_mem \
+                            --ignore=tests/distributed/scheduler/test_generate_scheduler.py \
+                            --ignore=tests/distributed/scheduler/test_initialize.py \
+                            --ignore=tests/distributed/scheduler/test_resource_manager.py \
+                            --ignore=tests/distributed/executor/test_ray_thread_actor_cuda_mem_leak.py \
+                            -v --timeout=600 --durations=0 --durations-min=0 -x
+        env:
+          ROLL_NPU_CI: "1"
+          DS_UNITTEST_TIMEOUT: "600"

--- a/roll/platforms/npu.py
+++ b/roll/platforms/npu.py
@@ -1,7 +1,9 @@
-from .platform import Platform
-from ..utils.logging import get_logger
+from importlib import import_module
 
 import torch
+
+from .platform import Platform
+from ..utils.logging import get_logger
 
 logger = get_logger()
 
@@ -48,20 +50,32 @@ class NpuPlatform(Platform):
 
     @classmethod
     def get_vllm_worker_class(cls):
+        def import_worker(candidate_modules):
+            errors = []
+            for module_name in candidate_modules:
+                try:
+                    module = import_module(module_name)
+                    worker = getattr(module, "NPUWorker")
+                except (ImportError, AttributeError) as e:
+                    errors.append(f"{module_name}: {e}")
+                    continue
+                logger.info("Successfully imported vLLM NPU Worker from %s.", module_name)
+                return worker
+            raise ImportError("; ".join(errors))
+
         try:
             from vllm import envs
 
             # VLLM_USE_V1 is deprecated in vllm>=0.11.1
             if not hasattr(envs, "VLLM_USE_V1") or envs.VLLM_USE_V1:
-                from vllm_ascend.worker.worker_v1 import NPUWorker as Worker
-
-                logger.info("Successfully imported vLLM V1 Worker.")
-                return Worker
+                return import_worker(
+                    [
+                        "vllm_ascend.worker.worker_v1",
+                        "vllm_ascend.worker.worker",
+                    ]
+                )
             else:
-                from vllm_ascend.worker.worker import NPUWorker as Worker
-
-                logger.info("Successfully imported vLLM V0 Worker.")
-                return Worker
+                return import_worker(["vllm_ascend.worker.worker"])
         except ImportError as e:
             logger.error("Failed to import vLLM Worker. Make sure vLLM is installed correctly: %s", e)
             raise RuntimeError("vLLM is not installed or not properly configured.") from e
@@ -72,6 +86,13 @@ class NpuPlatform(Platform):
             "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
             "ASCEND_RT_VISIBLE_DEVICES": f"{gpu_rank}",
             "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+            # vLLM-Ascend graph/NPU worker initialization is more stable with
+            # task queue mode 1; broader training jobs may use mode 2.
+            "TASK_QUEUE_ENABLE": "1",
+            "VLLM_ASCEND_ENABLE_NZ": "0",
+            # vLLM-Ascend's memory pool is incompatible with expandable
+            # segments, even if the broader NPU test job enables them.
+            "PYTORCH_NPU_ALLOC_CONF": "",
         }
         return env_vars
     

--- a/roll/third_party/sglang/__init__.py
+++ b/roll/third_party/sglang/__init__.py
@@ -16,7 +16,7 @@ elif sgl.__version__ == '0.5.2':
 elif sgl.__version__ == '0.5.4.post2':
     from roll.third_party.sglang import v054_patch
     patch = v054_patch
-elif sgl.__version__ == '0.5.5.post3':
+elif sgl.__version__ == '0.5.5.post3' or sgl.__version__ == '0.5.6.post2':
     from roll.third_party.sglang import v054_patch
     patch = v054_patch
 else:

--- a/roll/utils/fsdp_utils.py
+++ b/roll/utils/fsdp_utils.py
@@ -137,10 +137,16 @@ def apply_fsdp2(model, fsdp_kwargs, config, is_lora=False):
         default_transformer_cls_names_to_wrap,
     )
 
-    if isinstance(fsdp_transformer_layer_cls_to_wrap, str):
+    if fsdp_transformer_layer_cls_to_wrap is None:
+        fsdp_transformer_layer_cls_to_wrap = []
+    elif isinstance(fsdp_transformer_layer_cls_to_wrap, str):
         fsdp_transformer_layer_cls_to_wrap = [fsdp_transformer_layer_cls_to_wrap]
+    else:
+        fsdp_transformer_layer_cls_to_wrap = list(fsdp_transformer_layer_cls_to_wrap)
 
-    assert len(fsdp_transformer_layer_cls_to_wrap) > 0 and fsdp_transformer_layer_cls_to_wrap[0] is not None
+    assert len(fsdp_transformer_layer_cls_to_wrap) > 0 and all(
+        layer_cls is not None for layer_cls in fsdp_transformer_layer_cls_to_wrap
+    )
 
     wrap_embeddings = bool(config.get("wrap_policy", {}).get("wrap_embeddings", False))
     wrap_lm_output = bool(config.get("wrap_policy", {}).get("wrap_lm_output", False))

--- a/tests/agentic/env/test_frozen_lake.py
+++ b/tests/agentic/env/test_frozen_lake.py
@@ -1,34 +1,23 @@
-from roll.pipeline.agentic.env import FrozenLakeEnvConfig, FrozenLakeEnv
-from roll.pipeline.agentic.utils import dump_frames_as_gif
+from numbers import Real
+
+from roll.pipeline.agentic.env.frozen_lake import FrozenLakeEnv
 
 
 def test_frozen_lake():
-    config = FrozenLakeEnvConfig(size=4, p=0.8, is_slippery=False, map_seed=42)
-    env = FrozenLakeEnv(config)
-    frames = []
-    print(env.reset(seed=42))
-    while True:
-        keyboard = input("Enter action: ")
-        if keyboard.lower() == "q":
-            break
-        try:
-            action = int(keyboard)
-        except Exception as e:
-            print("Invalid action, please enter a number")
-            continue
-        if action not in env.ACTION_LOOKUP:
-            print(f"Invalid action {action}, please enter a number between 1 and 4")
-            continue
-        obs, reward, done, info = env.step(action)
-        print()
-        print(obs, reward, done, info)
-        if action in env.ACTION_LOOKUP:
-            frames.append(env.render(mode="rgb_array"))
-        if done:
-            break
+    env = FrozenLakeEnv(size=4, p=0.8, is_slippery=False, map_seed=42)
 
-    # save the image
-    dump_frames_as_gif(filename="./frozen_lake_result.gif", frames=frames)
+    obs, info = env.reset(seed=42)
+    assert isinstance(obs, str)
+    assert "env_instruction" in info
+
+    action_text = f"<answer>{env.ACTION_LOOKUP[0]}</answer>"
+    obs, reward, terminated, truncated, info = env.step(action_text)
+    assert isinstance(obs, str)
+    assert isinstance(reward, Real)
+    assert not isinstance(reward, bool)
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert info["metrics"]["action_is_valid"]
 
 
 if __name__ == "__main__":

--- a/tests/agentic/env/test_mcp_client.py
+++ b/tests/agentic/env/test_mcp_client.py
@@ -2,6 +2,7 @@ import pytest
 import json
 from roll.pipeline.agentic.env.mcp.mcp_client import MCPClient
 
+@pytest.mark.skip_on_github_ci
 @pytest.mark.asyncio
 async def test_sokoban_mcp_server_interaction():
     async with MCPClient("http://sokoban-mcp.alibaba-inc.com/sse") as client: 

--- a/tests/agentic/env/test_sokoban_mcp.py
+++ b/tests/agentic/env/test_sokoban_mcp.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from unittest.mock import MagicMock
 from roll.pipeline.agentic.env.mcp.mcp_client import MCPClient
@@ -12,6 +13,7 @@ TEST_ACTION_STR = "Left"
 MOCK_ENV_INSTRUCTION = "Solve the puzzle."
 MOCK_ACTION_LOOKUP = {1: "Up", 2: "Down", 3: "Left", 4: "Right"}
 MOCK_FORMAT_PENALTY = -0.15
+MOCK_SPECIAL_TOKEN_LIST = ("<think>", "</think>", "<|im_start|>", "<|im_end|>")
 
 # =============================================================================
 # / Pytest Fixtures                                                           /
@@ -29,6 +31,7 @@ def real_sokoban_env():
         env_instruction=MOCK_ENV_INSTRUCTION,
         action_lookup=MOCK_ACTION_LOOKUP,
         format_penalty=MOCK_FORMAT_PENALTY,
+        special_token_list=MOCK_SPECIAL_TOKEN_LIST,
     )
     yield env
     
@@ -43,6 +46,7 @@ def isolated_mock_env():
         env_instruction=MOCK_ENV_INSTRUCTION,
         action_lookup=MOCK_ACTION_LOOKUP,
         format_penalty=MOCK_FORMAT_PENALTY,
+        special_token_list=MOCK_SPECIAL_TOKEN_LIST,
         client=MagicMock(spec_set=MCPClient),
     )
     env._last_obs = "A previous observation state."
@@ -51,6 +55,7 @@ def isolated_mock_env():
 # =============================================================================
 # / Integration Tests (Requires Real Server)                                  /
 # =============================================================================
+@pytest.mark.skip_on_github_ci
 def test_sokoban_mcp_env_with_valid_action(real_sokoban_env: SokobanMCPEnv):
     """Integration test for SokobanMCPEnv with real server connection"""   
     # 1. Test environment reset
@@ -106,14 +111,14 @@ def test_step_handles_invalid_action(isolated_mock_env: SokobanMCPEnv):
     obs, reward, terminated, truncated, info = env.step("<answer>Go Up</answer>")
         
     # Check the final output to confirm the error handling flow completed.
-    assert "provided an invalid action" in obs
+    assert obs == "A previous observation state."
     assert reward == MOCK_FORMAT_PENALTY, "Reward should be the format penalty"
     assert not terminated
     assert not truncated
     assert info["metrics"]["action_is_valid"] is False
     assert info["metrics"]["action_is_effective"] is False
     assert info["metrics"]["success"] is False
-    assert "The game state has not changed. Please provide a valid action in the correct format." in info["suffix"], "Suffix should contain the old state"
+    assert "suffix" not in info
     
 # ============================================================================
 # / Unit Tests - Pure Functions and Parsers                                   /

--- a/tests/agentic/env_manager/config_load_utils.py
+++ b/tests/agentic/env_manager/config_load_utils.py
@@ -1,11 +1,14 @@
 from dacite import from_dict
-from hydra.experimental import compose, initialize
+from hydra import compose, initialize
+from hydra.core.global_hydra import GlobalHydra
 from omegaconf import OmegaConf
 
 def make_pipeline_config(config_path, config_name, data_class):
 
-    initialize(config_path=config_path)
-    cfg = compose(config_name=config_name)
+    if GlobalHydra.instance().is_initialized():
+        GlobalHydra.instance().clear()
+    with initialize(config_path=config_path, version_base=None):
+        cfg = compose(config_name=config_name)
     pipeline_config = from_dict(data_class=data_class, data=OmegaConf.to_container(cfg, resolve=True))
 
     return pipeline_config

--- a/tests/agentic/env_manager/test_traj_env_manager.py
+++ b/tests/agentic/env_manager/test_traj_env_manager.py
@@ -8,8 +8,10 @@ pip install -r requirements_em_local_debug.txt
 
 python tests/agentic/env_manager/test_traj_env_manager.py
 """
+import os
 import threading
 
+import pytest
 import ray
 
 from roll.distributed.scheduler.rollout_scheduler import GroupQueueManager
@@ -22,6 +24,26 @@ from roll.pipeline.agentic.env_manager.vl_traj_env_manager import VLTrajEnvManag
 from tests.agentic.env_manager.config_load_utils import make_pipeline_config
 
 
+_RUN_ENV_MANAGER_DEBUG_TESTS = os.getenv("ROLL_RUN_AGENTIC_ENV_MANAGER_DEBUG_TESTS") == "1"
+skip_env_manager_debug = pytest.mark.skipif(
+    not _RUN_ENV_MANAGER_DEBUG_TESTS,
+    reason="agentic env-manager debug tests require model assets and are opt-in",
+)
+
+
+def _configure_model_download(pipeline_config):
+    model_download_type = os.getenv("MODEL_DOWNLOAD_TYPE", "MODELSCOPE")
+    pipeline_config.model_download_type = model_download_type
+    os.environ["MODEL_DOWNLOAD_TYPE"] = model_download_type
+    if model_download_type == "MODELSCOPE":
+        pytest.importorskip(
+            "modelscope.hub.snapshot_download",
+            reason="MODELSCOPE model download requires `modelscope`",
+        )
+
+
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_traj_env_manager():
     ray.init(log_to_driver=True)
     current_step = 0
@@ -31,7 +53,7 @@ def test_debug_traj_env_manager():
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
 
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
 
     worker_config = pipeline_config.train_env_manager
@@ -61,6 +83,8 @@ def test_debug_traj_env_manager():
     env_manager.stop()
 
 
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_vl_traj_env_manager():
     ray.init(log_to_driver=True)
     current_step = 0
@@ -69,7 +93,7 @@ def test_debug_vl_traj_env_manager():
     config_name = "vl_traj_env_manager_debug"
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
     worker_config = pipeline_config.train_env_manager
     tokenizer = default_tokenizer_provider(model_args=worker_config.model_args)
@@ -103,6 +127,8 @@ def test_debug_vl_traj_env_manager():
     env_manager.stop()
 
 
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_step_env_manager():
     ray.init(log_to_driver=True)
     current_step = 0
@@ -112,7 +138,7 @@ def test_debug_step_env_manager():
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
 
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
 
     worker_config = pipeline_config.train_env_manager

--- a/tests/agentic/env_manager/test_traj_env_manager_debug.py
+++ b/tests/agentic/env_manager/test_traj_env_manager_debug.py
@@ -8,22 +8,76 @@ pip install -r requirements_em_local_debug.txt
 
 python tests/agentic/env_manager/test_traj_env_manager.py
 """
+import os
 import threading
 
-import ray
+import pytest
 
-from roll.distributed.scheduler.rollout_scheduler import GroupQueueManager
-from roll.distributed.scheduler.protocol import DataProto
-from roll.models.model_providers import default_tokenizer_provider, default_processor_provider, get_extra_data_provider
-from roll.pipeline.agentic.agentic_config import AgenticConfig
-from roll.pipeline.agentic.env_manager.step_env_manager import StepEnvManager
-from roll.pipeline.agentic.env_manager.traj_env_manager import TrajEnvManager
-from roll.pipeline.agentic.env_manager.vl_traj_env_manager import VLTrajEnvManager
-from roll.utils.import_utils import safe_import_class
-from tests.agentic.env_manager.config_load_utils import make_pipeline_config
+_RUN_ENV_MANAGER_DEBUG_TESTS = os.getenv("ROLL_RUN_AGENTIC_ENV_MANAGER_DEBUG_TESTS") == "1"
+skip_env_manager_debug = pytest.mark.skipif(
+    not _RUN_ENV_MANAGER_DEBUG_TESTS,
+    reason="agentic env-manager debug tests require model assets and are opt-in",
+)
 
 
+def _configure_model_download(pipeline_config):
+    model_download_type = os.getenv("MODEL_DOWNLOAD_TYPE", "MODELSCOPE")
+    pipeline_config.model_download_type = model_download_type
+    os.environ["MODEL_DOWNLOAD_TYPE"] = model_download_type
+    if model_download_type == "MODELSCOPE":
+        pytest.importorskip(
+            "modelscope.hub.snapshot_download",
+            reason="MODELSCOPE model download requires `modelscope`",
+        )
+
+
+def _load_debug_deps():
+    import ray
+
+    from roll.distributed.scheduler.protocol import DataProto
+    from roll.distributed.scheduler.rollout_scheduler import GroupQueueManager
+    from roll.models.model_providers import default_processor_provider, default_tokenizer_provider, get_extra_data_provider
+    from roll.pipeline.agentic.agentic_config import AgenticConfig
+    from roll.pipeline.agentic.env_manager.step_env_manager import StepEnvManager
+    from roll.pipeline.agentic.env_manager.traj_env_manager import TrajEnvManager
+    from roll.pipeline.agentic.env_manager.vl_traj_env_manager import VLTrajEnvManager
+    from roll.utils.import_utils import safe_import_class
+    from tests.agentic.env_manager.config_load_utils import make_pipeline_config
+
+    return (
+        ray,
+        DataProto,
+        GroupQueueManager,
+        default_processor_provider,
+        default_tokenizer_provider,
+        get_extra_data_provider,
+        AgenticConfig,
+        StepEnvManager,
+        TrajEnvManager,
+        VLTrajEnvManager,
+        safe_import_class,
+        make_pipeline_config,
+    )
+
+
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_traj_env_manager():
+    (
+        ray,
+        DataProto,
+        GroupQueueManager,
+        _default_processor_provider,
+        default_tokenizer_provider,
+        _get_extra_data_provider,
+        AgenticConfig,
+        _StepEnvManager,
+        _TrajEnvManager,
+        _VLTrajEnvManager,
+        safe_import_class,
+        make_pipeline_config,
+    ) = _load_debug_deps()
+
     ray.init(log_to_driver=True)
     current_step = 0
 
@@ -32,7 +86,7 @@ def test_debug_traj_env_manager():
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
 
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
 
     worker_config = pipeline_config.train_env_manager
@@ -65,7 +119,24 @@ def test_debug_traj_env_manager():
     env_manager.stop()
 
 
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_vl_traj_env_manager():
+    (
+        ray,
+        DataProto,
+        GroupQueueManager,
+        default_processor_provider,
+        default_tokenizer_provider,
+        get_extra_data_provider,
+        AgenticConfig,
+        _StepEnvManager,
+        _TrajEnvManager,
+        VLTrajEnvManager,
+        _safe_import_class,
+        make_pipeline_config,
+    ) = _load_debug_deps()
+
     ray.init(log_to_driver=True)
     current_step = 0
 
@@ -73,7 +144,7 @@ def test_debug_vl_traj_env_manager():
     config_name = "vl_traj_env_manager_debug"
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
     worker_config = pipeline_config.train_env_manager
     tokenizer = default_tokenizer_provider(model_args=worker_config.model_args)
@@ -107,7 +178,24 @@ def test_debug_vl_traj_env_manager():
     env_manager.stop()
 
 
+@pytest.mark.skip_on_npu
+@skip_env_manager_debug
 def test_debug_step_env_manager():
+    (
+        ray,
+        DataProto,
+        GroupQueueManager,
+        _default_processor_provider,
+        default_tokenizer_provider,
+        _get_extra_data_provider,
+        AgenticConfig,
+        StepEnvManager,
+        _TrajEnvManager,
+        _VLTrajEnvManager,
+        _safe_import_class,
+        make_pipeline_config,
+    ) = _load_debug_deps()
+
     ray.init(log_to_driver=True)
     current_step = 0
 
@@ -116,7 +204,7 @@ def test_debug_step_env_manager():
 
     pipeline_config: AgenticConfig = make_pipeline_config(config_path, config_name, AgenticConfig)
 
-    pipeline_config.model_download_type = "MODELSCOPE"
+    _configure_model_download(pipeline_config)
     pipeline_config.async_generation_ratio = 2
 
     worker_config = pipeline_config.train_env_manager

--- a/tests/agentic/rollout/test_rollout_scheduler.py
+++ b/tests/agentic/rollout/test_rollout_scheduler.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import threading
 import sys
 import ray
+import pytest
 
 from roll.distributed.scheduler.rollout_scheduler import GroupQueueManager
 
@@ -14,6 +15,7 @@ class AgenticConfig:
 class EnvManagerConfig:
     pass
 
+@pytest.mark.skip_on_github_ci
 async def async_test_GroupQueueManager(rollout_batch_size, async_generation_ratio):
     print(f">>>>>>>>>>>>>>>>>>>>>>>> TEST rollout_batch_size {rollout_batch_size} async_generation_ratio {async_generation_ratio}")
     config = AgenticConfig()
@@ -104,6 +106,7 @@ async def async_test_GroupQueueManager(rollout_batch_size, async_generation_rati
 
     await rollout_task
 
+@pytest.mark.skip_on_github_ci
 def test_GroupQueueManager():
     loop = asyncio.get_event_loop()
 

--- a/tests/agentic/tools/test_mcp_tools.py
+++ b/tests/agentic/tools/test_mcp_tools.py
@@ -293,6 +293,7 @@ def test_execute_action_handles_server_business_logic_error(connected_mock_tool:
     # Verify that the tool was still called correctly.
     tool._client.call_tool.assert_called_once_with("play", {"action": 9})  
 
+@pytest.mark.skip_on_github_ci
 def test_mcp_tool_end_to_end_with_sokoban_mcp_server():
     """
     Tests the full lifecycle of MCPTool against a running MCP server.
@@ -377,6 +378,7 @@ def test_mcp_tool_end_to_end_with_sokoban_mcp_server():
     
     tool.close()
     
+@pytest.mark.skip_on_github_ci
 def test_calculator_tool_with_subset_of_tools():
     """
     Integration test for MCPTool using a real calculator server.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,8 @@ def pytest_configure(config):
     config.option.durations = 0
     config.option.durations_min = 1
     config.option.verbose = True
+    config.addinivalue_line("markers", "skip_on_npu: skip test when running on Ascend NPU")
+    config.addinivalue_line("markers", "skip_on_github_ci: skip test when running on GitHub Actions CI")
 
 
 def pytest_addoption(parser):
@@ -63,6 +65,18 @@ def check_environment(pytestconfig):
             returncode=2,
         )
 
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    if item.get_closest_marker("skip_on_github_ci") is not None:
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.skip("skip_on_github_ci: skipped on GitHub Actions CI")
+
+    if item.get_closest_marker("skip_on_npu") is not None:
+        from roll.platforms import current_platform
+
+        if current_platform.is_npu():
+            pytest.skip("skip_on_npu: skipped on Ascend NPU")
 
 # Override of pytest "runtest" for DistributedTest class
 # This hook is run before the default pytest_runtest_call

--- a/tests/datasets/test_collator.py
+++ b/tests/datasets/test_collator.py
@@ -1,13 +1,58 @@
 import torch
-from transformers import PreTrainedTokenizerFast, AutoTokenizer
 
 from roll.datasets.collator import DataCollatorWithPaddingForPaddedKeys
 
 
-def test_data_collator_with_padding_for_padded_keys():
-    tokenizer = AutoTokenizer.from_pretrained("/Users/pan/Downloads/huggingface/gpt2-imdb", padding_side="left")
+class DummyTokenizer:
+    pad_token_id = 0
 
-    tokenizer.pad_token_id = tokenizer.eos_token_id
+    def __init__(self, padding_side="left"):
+        self.padding_side = padding_side
+
+    def encode(self, text, return_tensors=None):
+        token_ids = list(range(1, len(text.split()) + 1))
+        if return_tensors == "pt":
+            return torch.tensor([token_ids], dtype=torch.long)
+        return token_ids
+
+    def pad(
+        self,
+        encoded_inputs,
+        padding=True,
+        max_length=None,
+        pad_to_multiple_of=None,
+        return_tensors=None,
+        **kwargs,
+    ):
+        max_input_len = max(len(feature["input_ids"]) for feature in encoded_inputs)
+        target_len = max_length if padding == "max_length" and max_length is not None else max_input_len
+        if pad_to_multiple_of is not None and target_len % pad_to_multiple_of:
+            target_len = ((target_len + pad_to_multiple_of - 1) // pad_to_multiple_of) * pad_to_multiple_of
+
+        batch = {"input_ids": [], "attention_mask": [], "labels": []}
+        for feature in encoded_inputs:
+            input_ids = feature["input_ids"].tolist()
+            attention_mask = list(feature["attention_mask"])
+            pad_len = target_len - len(input_ids)
+            if self.padding_side == "left":
+                input_ids = [self.pad_token_id] * pad_len + input_ids
+                attention_mask = [0] * pad_len + attention_mask
+            else:
+                input_ids = input_ids + [self.pad_token_id] * pad_len
+                attention_mask = attention_mask + [0] * pad_len
+            batch["input_ids"].append(input_ids)
+            batch["attention_mask"].append(attention_mask)
+            batch["labels"].append(feature["labels"])
+
+        return {
+            "input_ids": torch.tensor(batch["input_ids"], dtype=torch.long),
+            "attention_mask": torch.tensor(batch["attention_mask"], dtype=torch.long),
+            "labels": torch.stack(batch["labels"]),
+        }
+
+
+def test_data_collator_with_padding_for_padded_keys():
+    tokenizer = DummyTokenizer(padding_side="left")
 
     max_length = 32
     data_collator = DataCollatorWithPaddingForPaddedKeys(

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -71,15 +71,24 @@ def test_ratio_calculation():
     assert sampler.domain_batch_num == {"a": 9, "b": 1}
 
 
-def test_randomness(sample_dataset):
+def test_randomness(sample_dataset, monkeypatch):
+    from roll.datasets import sampler as sampler_module
+
+    def reverse_shuffle(values):
+        values[:] = values[::-1]
+
+    monkeypatch.setattr(sampler_module.np.random, "shuffle", reverse_shuffle)
+    monkeypatch.setattr(sampler_module.random, "shuffle", reverse_shuffle)
+
     sampler = BatchStratifiedSampler(sample_dataset, domain_ratios={"a": 5, "b": 3, "c": 2}, batch_size=10)
-    batches1 = list(sampler.__iter__())
-    batches2 = list(sampler.__iter__())
+    batches = list(sampler.__iter__())
 
-    assert batches1 != batches2
-
-    for batch in batches1:
+    for batch in batches:
         domains = [sample_dataset[i]["domain"] for i in batch]
+        counts = Counter(domains)
+        assert counts["a"] == 5
+        assert counts["b"] == 3
+        assert counts["c"] == 2
         assert domains != ["a"] * 5 + ["b"] * 3 + ["c"] * 2
 
 

--- a/tests/distributed/executor/test_async_cluster.py
+++ b/tests/distributed/executor/test_async_cluster.py
@@ -33,34 +33,39 @@ class TestWorker(Worker):
     async def test_dp_mp_dispatch_first(self):
         return 1
 
+async def _assert_async_cluster_calls(cluster):
+    ret = await asyncio.gather(*cluster.test_one_to_all(blocking=False))
+    assert ret == [1, 1]
+
+    ret = await asyncio.gather(*[ref.obj_ref for ref in cluster.test_one_to_all_one(blocking=False)])
+    assert ret == [1, 1]
+
+    ret = await asyncio.gather(*cluster.test_all_to_all(blocking=False))
+    assert ret == [1, 1]
+
+    ret = await asyncio.gather(*[ref.obj_ref for ref in cluster.test_dp_mp_compute(blocking=False)])
+    assert ret == [1, 1]
+
+    ret = await asyncio.gather(*[ref.obj_ref for ref in cluster.test_dp_mp_dispatch_first(blocking=False)])
+    assert ret == [1, 1]
+
 def test_async_cluster():
+    ray.shutdown()
     ray.init()
-    resource_manager = ResourceManager(0, 1)
-    worker_config = WorkerConfig(name="test_worker", world_size=2)
+    try:
+        resource_manager = ResourceManager(0, 1)
+        worker_config = WorkerConfig(name="test_worker", world_size=2)
 
-    cluster: Any = Cluster(
-        name=worker_config.name,
-        resource_manager=resource_manager,
-        worker_cls=TestWorker,
-        worker_config=worker_config,
-    )
+        cluster: Any = Cluster(
+            name=worker_config.name,
+            resource_manager=resource_manager,
+            worker_cls=TestWorker,
+            worker_config=worker_config,
+        )
 
-    loop = asyncio.get_event_loop()
-
-    ret = loop.run_until_complete(asyncio.gather(*cluster.test_one_to_all(blocking=False)))
-    assert ret == [1, 1]
-
-    ret = loop.run_until_complete(asyncio.gather(*[ref.obj_ref for ref in cluster.test_one_to_all_one(blocking=False)]))
-    assert ret == [1, 1]
-
-    ret = loop.run_until_complete(asyncio.gather(*cluster.test_all_to_all(blocking=False)))
-    assert ret == [1, 1]
-
-    ret = loop.run_until_complete(asyncio.gather(*[ref.obj_ref for ref in cluster.test_dp_mp_compute(blocking=False)]))
-    assert ret == [1, 1]
-
-    ret = loop.run_until_complete(asyncio.gather(*[ref.obj_ref for ref in cluster.test_dp_mp_dispatch_first(blocking=False)]))
-    assert ret == [1, 1]
+        asyncio.run(_assert_async_cluster_calls(cluster))
+    finally:
+        ray.shutdown()
 
 if __name__ == "__main__":
     test_async_cluster()

--- a/tests/distributed/executor/test_cluster.py
+++ b/tests/distributed/executor/test_cluster.py
@@ -61,48 +61,54 @@ class TestDPWorker(Worker):
 
 
 def test_cluster_run():
+    ray.shutdown()
     ray.init(log_to_driver=True)
+    try:
+        resource_manager = ResourceManager(0, 1)
 
-    resource_manager = ResourceManager()
-
-    test_worker_config = WorkerConfig(name="test_worker", world_size=2)
-    test_cluster: Any = Cluster(
-        name=test_worker_config.name,
-        resource_manager=resource_manager,
-        worker_cls=TestWorker,
-        worker_config=test_worker_config,
-    )
-    x = 1
-    res = test_cluster.add(x=x)
-    print(res)
-    assert res == [1, 2]
+        test_worker_config = WorkerConfig(name="test_worker", world_size=2)
+        test_cluster: Any = Cluster(
+            name=test_worker_config.name,
+            resource_manager=resource_manager,
+            worker_cls=TestWorker,
+            worker_config=test_worker_config,
+        )
+        x = 1
+        res = test_cluster.add(x=x)
+        print(res)
+        assert res == [1, 2]
+    finally:
+        ray.shutdown()
 
 
 def test_cluster_dp_mp_compute():
+    ray.shutdown()
     ray.init(log_to_driver=True)
+    try:
+        resource_manager = ResourceManager(0, 1)
 
-    resource_manager = ResourceManager()
-
-    test_worker_config = WorkerConfig(name="test_worker", world_size=8)
-    test_cluster: Any = Cluster(
-        name=test_worker_config.name,
-        resource_manager=resource_manager,
-        worker_cls=TestDPWorker,
-        worker_config=test_worker_config,
-    )
-    x = [1, 2, 3, 4, 5, 6, 7, 8]
-    res = test_cluster.add(x=x)
-    print(res)
-    assert res == [
-        [0, 0, 1, 1],
-        [0, 0, 1, 2],
-        [0, 0, 1, 3],
-        [0, 0, 1, 4],
-        [1, 0, 1, 5],
-        [1, 0, 1, 6],
-        [1, 0, 1, 7],
-        [1, 0, 1, 8],
-    ]
+        test_worker_config = WorkerConfig(name="test_worker", world_size=8)
+        test_cluster: Any = Cluster(
+            name=test_worker_config.name,
+            resource_manager=resource_manager,
+            worker_cls=TestDPWorker,
+            worker_config=test_worker_config,
+        )
+        x = [1, 2, 3, 4, 5, 6, 7, 8]
+        res = test_cluster.add(x=x)
+        print(res)
+        assert res == [
+            [0, 0, 1, 1],
+            [0, 0, 1, 2],
+            [0, 0, 1, 3],
+            [0, 0, 1, 4],
+            [1, 0, 1, 5],
+            [1, 0, 1, 6],
+            [1, 0, 1, 7],
+            [1, 0, 1, 8],
+        ]
+    finally:
+        ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/distributed/executor/test_ray_debugger.py
+++ b/tests/distributed/executor/test_ray_debugger.py
@@ -4,15 +4,6 @@ debug code from: https://docs.ray.io/en/latest/ray-observability/ray-distributed
 import ray
 import sys
 
-# Add the RAY_DEBUG_POST_MORTEM=1 environment variable
-# if you want to activate post-mortem debugging
-ray.init(
-    runtime_env={
-        "env_vars": {"RAY_DEBUG": "1"},
-    },
-    log_to_driver=True,
-)
-
 
 @ray.remote
 def my_task(x):
@@ -29,7 +20,21 @@ def post_mortem(x):
     return x
 
 
-if len(sys.argv) == 1:
-    ray.get(my_task.remote(10))
-else:
-    ray.get(post_mortem.remote(10))
+def main():
+    # Add the RAY_DEBUG_POST_MORTEM=1 environment variable
+    # if you want to activate post-mortem debugging
+    ray.init(
+        runtime_env={
+            "env_vars": {"RAY_DEBUG": "1"},
+        },
+        log_to_driver=True,
+    )
+
+    if len(sys.argv) == 1:
+        ray.get(my_task.remote(10))
+    else:
+        ray.get(post_mortem.remote(10))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/scheduler/test_decorator.py
+++ b/tests/distributed/scheduler/test_decorator.py
@@ -84,7 +84,9 @@ def test_collect_dp_mp_compute():
     cluster = Mock()
     cluster.world_size = 4
 
-    cluster.get_rank_info = Mock(side_effect=lambda rank: Mock(tp_rank=rank % 2))
+    cluster.get_rank_info = Mock(
+        side_effect=lambda rank: Mock(tp_rank=rank % 2, cp_rank=0, is_pipeline_last_stage=True)
+    )
 
     output = [[0], [1], [2], [3]]
     collected_output = collect_dp_mp_compute(cluster, output)

--- a/tests/distributed/scheduler/test_resource_manager.py
+++ b/tests/distributed/scheduler/test_resource_manager.py
@@ -1,100 +1,82 @@
-import os
+from types import SimpleNamespace
 
-from ray.runtime_env import RuntimeEnv
-
-os.environ["RAY_DEDUP_LOGS"] = "0"
 import ray
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-from roll.distributed.scheduler.driver_utils import get_driver_world_size
-from roll.distributed.scheduler.initialize import init
 from roll.distributed.scheduler.resource_manager import ResourceManager
 
 
-@ray.remote
-class TestResourceManagerActor:
-    def __init__(self, rank, world_size):
-        self.rank = rank
-        self.world_size = world_size
-
-    def say_hello(self):
-        msg = f"Hello from {self.world_size}_{self.rank}! get_gpu_ids: {ray.get_gpu_ids()} current GPU: {os.environ['CUDA_VISIBLE_DEVICES']}"
-        print(msg)
-        return msg
-
-
-def test_resource_manager():
-    init()
-
-    resource_manager = ResourceManager(num_nodes=get_driver_world_size())
-    num_gpus_per_worker = 1
-    device_mapping = eval("list(range(0,8))")
-    print(f"device_mapping: {device_mapping}")
-    world_size = len(device_mapping) // num_gpus_per_worker
-    pgs = resource_manager.allocate_placement_group(world_size=world_size, device_mapping=device_mapping)
-
-    actor_list = []
-    world_size = len(pgs)
-    for rank, pg in enumerate(pgs):
-        runtime_env = RuntimeEnv(
-            env_vars={
-                "CUDA_VISIBLE_DEVICES": ",".join(map(str, pg.gpu_ranks)),
-                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
-            }
-        )
-        actor_list.append(
-            TestResourceManagerActor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg.placement_group),
-                num_gpus=0.01,
-                runtime_env=runtime_env,
-            ).remote(rank=rank, world_size=world_size)
-        )
-
-    refs = []
-    for actor in actor_list:
-        refs.append(actor.say_hello.remote())
-    res = ray.get(refs)
-    print(res)
+def _make_resource_manager(num_nodes=2, num_gpus_per_node=4):
+    resource_manager = ResourceManager.__new__(ResourceManager)
+    resource_manager.num_nodes = num_nodes
+    resource_manager.gpu_per_node = num_gpus_per_node
+    resource_manager.node2pg = {
+        node_rank: f"pg-{node_rank}"
+        for node_rank in range(num_nodes)
+    }
+    return resource_manager
 
 
-def test_resource_manager_num_gpus_per_worker_gt_1():
-    init()
-
-    resource_manager = ResourceManager(num_nodes=get_driver_world_size())
-    num_gpus_per_worker = 2
-    device_mapping = eval("list(range(0,8))")
-    print(f"device_mapping: {device_mapping}")
-    world_size = len(device_mapping) // num_gpus_per_worker
-    pgs = resource_manager.allocate_placement_group(world_size=world_size, device_mapping=device_mapping)
-
-    actor_list = []
-    world_size = len(pgs)
-    for rank, pg in enumerate(pgs):
-        runtime_env = RuntimeEnv(
-            env_vars={
-                "CUDA_VISIBLE_DEVICES": ",".join(map(str, pg.gpu_ranks)),
-                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
-            }
-        )
-        actor_list.append(
-            TestResourceManagerActor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg.placement_group),
-                num_gpus=0.01,
-                runtime_env=runtime_env,
-            ).remote(rank=rank, world_size=world_size)
-        )
-
-    refs = []
-    for actor in actor_list:
-        refs.append(actor.say_hello.remote())
-    res = ray.get(refs)
-    print(res)
+def _mock_runtime_context(monkeypatch):
+    monkeypatch.setattr(
+        ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="127.0.0.1:6379"),
+    )
 
 
-if __name__ == "__main__":
-    """
-    RANK=0 WORLD_SIZE=2 MASTER_ADDR='33.195.52.67' MASTER_PORT=54893 python tests/distributed/scheduler/test_resource_manager.py
-    RANK=1 WORLD_SIZE=2 MASTER_ADDR='33.195.52.67' MASTER_PORT=54893 python tests/distributed/scheduler/test_resource_manager.py
-    """
-    # test_resource_manager()
-    test_resource_manager_num_gpus_per_worker_gt_1()
+def _placement(node_rank, gpu_rank, placement_group):
+    return {
+        "node_rank": node_rank,
+        "gpu_rank": gpu_rank,
+        "placement_group": placement_group,
+        "ray_address": "127.0.0.1:6379",
+    }
+
+
+def test_allocate_placement_group_single_device_per_worker(monkeypatch):
+    _mock_runtime_context(monkeypatch)
+    resource_manager = _make_resource_manager()
+
+    allocated = resource_manager.allocate_placement_group(
+        world_size=8,
+        device_mapping=list(range(8)),
+    )
+
+    assert len(allocated) == 8
+    assert allocated[0] == [_placement(node_rank=0, gpu_rank=0, placement_group="pg-0")]
+    assert allocated[3] == [_placement(node_rank=0, gpu_rank=3, placement_group="pg-0")]
+    assert allocated[4] == [_placement(node_rank=1, gpu_rank=0, placement_group="pg-1")]
+    assert allocated[7] == [_placement(node_rank=1, gpu_rank=3, placement_group="pg-1")]
+
+
+def test_allocate_placement_group_multi_device_per_worker(monkeypatch):
+    _mock_runtime_context(monkeypatch)
+    resource_manager = _make_resource_manager()
+
+    allocated = resource_manager.allocate_placement_group(
+        world_size=4,
+        device_mapping=list(range(8)),
+    )
+
+    assert len(allocated) == 4
+    assert allocated[0] == [
+        _placement(node_rank=0, gpu_rank=0, placement_group="pg-0"),
+        _placement(node_rank=0, gpu_rank=1, placement_group="pg-0"),
+    ]
+    assert allocated[2] == [
+        _placement(node_rank=1, gpu_rank=0, placement_group="pg-1"),
+        _placement(node_rank=1, gpu_rank=1, placement_group="pg-1"),
+    ]
+
+
+def test_allocate_placement_group_without_device_mapping_spreads_workers(monkeypatch):
+    _mock_runtime_context(monkeypatch)
+    resource_manager = _make_resource_manager(num_nodes=2)
+
+    allocated = resource_manager.allocate_placement_group(world_size=3)
+
+    assert allocated == [
+        [_placement(node_rank=0, gpu_rank=None, placement_group="pg-0")],
+        [_placement(node_rank=1, gpu_rank=None, placement_group="pg-1")],
+        [_placement(node_rank=0, gpu_rank=None, placement_group="pg-0")],
+    ]

--- a/tests/distributed/scheduler/test_rollout_scheduler.py
+++ b/tests/distributed/scheduler/test_rollout_scheduler.py
@@ -1,8 +1,9 @@
 import asyncio
 import random
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import ray
+import pytest
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 from roll.distributed.scheduler.rollout_scheduler import (
@@ -12,11 +13,12 @@ from roll.distributed.scheduler.rollout_scheduler import (
 from roll.distributed.executor.worker import Worker
 from roll.distributed.scheduler.protocol import DataProto
 from roll.pipeline.agentic.agentic_pipeline import GroupFilter
+from roll.pipeline.agentic.agentic_config import EnvMonitorConfig
 
 
 FULL_DATASET_ITER=4
 
-class TestGroupFilter(GroupFilter):
+class MockGroupFilter(GroupFilter):
     def filter(self, group_id: int, episode_id: int, group: list[DataProto]):
         return episode_id % 3 == 0
 
@@ -24,6 +26,7 @@ class TestGroupFilter(GroupFilter):
 class MockAgenticConfig:
     async_generation_ratio: int
     rollout_batch_size: int
+    env_monitor: EnvMonitorConfig = field(default_factory=lambda: EnvMonitorConfig(enable=False))
 
 class MockEnvManagerConfig:
     def __init__(
@@ -42,7 +45,7 @@ class MockEnvManagerConfig:
         self.group_size_redundancy = group_size_redundancy if enable_redundancy else 0
         self.final_group_size = group_size + self.group_size_redundancy
         if enable_filter:
-            self.group_filter_cls = "tests.distributed.scheduler.test_rollout_scheduler.TestGroupFilter"
+            self.group_filter_cls = "tests.distributed.scheduler.test_rollout_scheduler.MockGroupFilter"
         else:
             self.group_filter_cls = "roll.pipeline.agentic.agentic_pipeline.GroupFilter"
 
@@ -76,8 +79,8 @@ class MockEnvironmentWorker:
             else:
                 start_step = self.current_step
             assert start_step is not None
-            DataProto(meta_info={"global_step": start_step})
-            ray.get(self.output_queue.put.remote(self.group_id, episode_id, start_step, (start_step, episode_id)))
+            rollout = DataProto(meta_info={"rollout": (start_step, episode_id)})
+            ray.get(self.output_queue.put.remote(self.group_id, episode_id, start_step, rollout))
         ray.get(self.output_queue.put.remote(self.group_id, episode_id, start_step, None))
 
 class MockEnvManager(Worker):
@@ -157,6 +160,17 @@ class MockRolloutScheduler(RolloutScheduler):
 
         self.rollout_task = None
 
+    async def suspend(self):
+        await self.generate_scheduler.suspend.remote()
+
+    async def shutdown(self):
+        if self.rollout_task is None:
+            return
+        await asyncio.gather(*self.es_manager.stop(blocking=False))
+        await self.env_output_queue.shutdown.remote()
+        await self.rollout_task
+        self.rollout_task = None
+
     # FIXME use RolloutScheduler.get_batch
     async def get_batch(self, data: DataProto, batch_size):
         global_step = data.meta_info["global_step"]
@@ -204,51 +218,56 @@ async def async_test_GroupQueueManager(rollout_batch_size, async_generation_rati
         await scheduler.suspend.remote()
         batch = await scheduler.get_batch.remote(data=data, batch_size=rollout_batch_size)
 
-        print(f"batch on step({current_step}): {[rollout[0] for rollout in batch]}")
+        rollout_steps = [rollout.meta_info["rollout"][0] for rollout in batch]
+        print(f"batch on step({current_step}): {rollout_steps}")
         expected = FULL_DATASET_ITER * env_manager_config.env_groups * env_manager_config.group_size if rollout_batch_size <= 0 else rollout_batch_size
         assert len(batch) == expected, f"{len(batch)=} expected={expected}"
-        assert all(rollout[0] == batch[0][0] for rollout in batch), "Not all start_step are equal"
+        assert all(step == rollout_steps[0] for step in rollout_steps), "Not all start_step are equal"
         assert (
-            all(max(0, current_step - async_generation_ratio) == rollout[0] for rollout in batch)
-        ), f"current_step({current_step}) - rollout_step({batch[0][0]}) exceed async_generation_ratio"
+            all(max(0, current_step - async_generation_ratio) == step for step in rollout_steps)
+        ), f"current_step({current_step}) - rollout_step({rollout_steps[0]}) exceed async_generation_ratio"
 
         await asyncio.sleep(1)
     await scheduler.shutdown.remote()
 
-def test_GroupQueueManager():
-    loop = asyncio.get_event_loop()
-
+async def _run_GroupQueueManager():
     # default_setting:
     #   env_num=16
 
     # batch_size = -1
-    loop.run_until_complete(async_test_GroupQueueManager(-1, 0, enable_filter=False, enable_redundancy=False))
+    await async_test_GroupQueueManager(-1, 0, enable_filter=False, enable_redundancy=False)
 
     # sync training
-    loop.run_until_complete(async_test_GroupQueueManager(16, 0))
-    loop.run_until_complete(async_test_GroupQueueManager(8, 0))
-    loop.run_until_complete(async_test_GroupQueueManager(24, 0))
-    loop.run_until_complete(async_test_GroupQueueManager(32, 0))
-    loop.run_until_complete(async_test_GroupQueueManager(64, 0))
+    await async_test_GroupQueueManager(16, 0)
+    await async_test_GroupQueueManager(8, 0)
+    await async_test_GroupQueueManager(24, 0)
+    await async_test_GroupQueueManager(32, 0)
+    await async_test_GroupQueueManager(64, 0)
 
     # async training: 2
-    loop.run_until_complete(async_test_GroupQueueManager(16, 2))
-    loop.run_until_complete(async_test_GroupQueueManager(8, 2))
+    await async_test_GroupQueueManager(16, 2)
+    await async_test_GroupQueueManager(8, 2)
     # do not test batch_size 12, because 12 % group_size != 0
-    loop.run_until_complete(async_test_GroupQueueManager(24, 2))
-    loop.run_until_complete(async_test_GroupQueueManager(32, 2))
-    loop.run_until_complete(async_test_GroupQueueManager(64, 2))
+    await async_test_GroupQueueManager(24, 2)
+    await async_test_GroupQueueManager(32, 2)
+    await async_test_GroupQueueManager(64, 2)
 
     # async training: 7
-    loop.run_until_complete(async_test_GroupQueueManager(16, 7))
-    loop.run_until_complete(async_test_GroupQueueManager(8, 7))
+    await async_test_GroupQueueManager(16, 7)
+    await async_test_GroupQueueManager(8, 7)
 
     # async training: 1
-    loop.run_until_complete(async_test_GroupQueueManager(16, 1))
-    loop.run_until_complete(async_test_GroupQueueManager(8, 1))
-    loop.run_until_complete(async_test_GroupQueueManager(24, 1))
-    loop.run_until_complete(async_test_GroupQueueManager(32, 1))
-    loop.run_until_complete(async_test_GroupQueueManager(64, 1))
+    await async_test_GroupQueueManager(16, 1)
+    await async_test_GroupQueueManager(8, 1)
+    await async_test_GroupQueueManager(24, 1)
+    await async_test_GroupQueueManager(32, 1)
+    await async_test_GroupQueueManager(64, 1)
+
+
+# Takes about 10 minutes in NPU CI, so skip this full queue-manager matrix there.
+@pytest.mark.skip_on_npu
+def test_GroupQueueManager():
+    asyncio.run(_run_GroupQueueManager())
 
 if __name__ == "__main__":
     test_GroupQueueManager()

--- a/tests/distributed/strategy/context_parallel/test_fsdp2_cp_ulysses_equivalence.py
+++ b/tests/distributed/strategy/context_parallel/test_fsdp2_cp_ulysses_equivalence.py
@@ -1,7 +1,10 @@
 import os
 
+import pytest
 import torch
 import torch.distributed as dist
+
+pytest.importorskip("flash_attn")
 
 from roll.utils.context_parallel.globals import get_ulysses_group, get_ulysses_size, set_upg_manager
 from roll.utils.context_parallel.hf_flash_attention_patch import make_ulysses_flash_attention_forward

--- a/tests/distributed/strategy/grad_norm/test_grad_norm_unit.py
+++ b/tests/distributed/strategy/grad_norm/test_grad_norm_unit.py
@@ -2,6 +2,15 @@ import pytest
 import torch
 import torch.nn as nn
 
+from roll.platforms import current_platform
+
+
+def _has_accelerator() -> bool:
+    if current_platform.device_type == "cpu":
+        return False
+    is_available = getattr(current_platform, "is_available", None)
+    return callable(is_available) and bool(is_available())
+
 
 class TestGradientNormBasic:
     """Basic unit tests for gradient norm computation."""
@@ -119,18 +128,19 @@ class TestGradientNormBasic:
             clipped_norm, torch.tensor(max_norm), rtol=1e-5, atol=1e-5
         ), f"Clipped norm {clipped_norm:.6f} != max_norm {max_norm}"
 
-    @pytest.mark.skipif(
-        not torch.cuda.is_available(), reason="CUDA not available"
-    )
-    def test_grad_norm_cuda(self):
-        """Test gradient norm computation on CUDA."""
+    @pytest.mark.skipif(not _has_accelerator(), reason="accelerator not available")
+    def test_grad_norm_accelerator(self):
+        """Test gradient norm computation on the active accelerator."""
 
-        device = torch.device("cuda")
+        device = torch.device(current_platform.device_type)
 
         class SimpleModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.linear = nn.Linear(10, 5, bias=True)
+
+            def forward(self, x):
+                return self.linear(x)
 
         model = SimpleModel().to(device)
 

--- a/tests/distributed/strategy/log_probs/test_fsdp_log_probs.py
+++ b/tests/distributed/strategy/log_probs/test_fsdp_log_probs.py
@@ -1,6 +1,10 @@
 import json
+import os
+import time
 from typing import Any, Dict
 
+import pytest
+import ray
 import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -12,15 +16,128 @@ from roll.distributed.scheduler.initialize import init
 from roll.distributed.scheduler.protocol import DataProto
 from roll.models.model_providers import default_tokenizer_provider
 from roll.pipeline.base_pipeline import BasePipeline
-from roll.pipeline.base_worker import ActorWorker, InferWorker
+from roll.pipeline.base_worker import ActorWorker
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
+from roll.platforms import current_platform
 from roll.utils.logging import get_logger
 from tests.distributed.strategy.make_baseline_config import make_baseline_config
 
 logger = get_logger()
 
 
-class TestFSDPLogProbsPipeline(BasePipeline):
+def _available_ray_nodes_for_config(num_gpus_per_node: int) -> int:
+    """Count Ray nodes that have enough devices for the configured per-node requirement."""
+    count = 0
+    for node in ray.nodes():
+        if int(node["Resources"].get(current_platform.ray_device_key, 0)) >= num_gpus_per_node:
+            count += 1
+    return count
+
+
+def _skip_if_cluster_insufficient(config: RLVRConfig, test_name: str) -> None:
+    required_nodes = getattr(config, "num_nodes", None)
+    required_gpus_per_node = getattr(config, "num_gpus_per_node", 1)
+    if required_nodes is None:
+        return
+    available_nodes = _available_ray_nodes_for_config(required_gpus_per_node)
+    if available_nodes < required_nodes:
+        pytest.skip(
+            f"{test_name} requires {required_nodes} Ray nodes with >= {required_gpus_per_node} "
+            f"{current_platform.ray_device_key} each, but only {available_nodes} available in CI."
+        )
+
+
+def _reset_model_download_cache_actor() -> None:
+    from roll.utils import checkpoint_manager
+
+    checkpoint_manager.shared_storage = None
+
+
+def _looks_like_local_path(path: str) -> bool:
+    return (
+        os.path.isabs(path)
+        or path.startswith((".", "~"))
+        or "\\" in path
+        or path.count("/") != 1
+    )
+
+
+def _skip_if_local_model_unavailable(config: RLVRConfig, test_name: str) -> None:
+    model_paths = set()
+    for config_name in ("actor_train", "actor_infer", "reference"):
+        worker_config = getattr(config, config_name, None)
+        model_args = getattr(worker_config, "model_args", None)
+        model_path = getattr(model_args, "model_name_or_path", None)
+        if model_path:
+            model_paths.add(str(model_path))
+
+    for model_path in sorted(model_paths):
+        if _looks_like_local_path(model_path) and not os.path.isdir(os.path.expanduser(model_path)):
+            pytest.skip(f"{test_name} requires local model path {model_path}, but it is not available on this CI node.")
+
+
+def _data_files_exist(data_args) -> bool:
+    file_names = getattr(data_args, "file_name", None)
+    if file_names is None:
+        return False
+    if isinstance(file_names, str):
+        file_names = [file_names]
+
+    dataset_dir = os.path.expanduser(str(getattr(data_args, "dataset_dir", ".") or "."))
+    for file_name in file_names:
+        path = os.path.expanduser(str(file_name))
+        if os.path.exists(path):
+            continue
+        if os.path.exists(os.path.join(dataset_dir, path)):
+            continue
+        return False
+    return True
+
+
+def _make_synthetic_vlm_dataset(processor, size: int = 2):
+    from PIL import Image
+    from torch.utils.data import Dataset
+
+    from roll.pipeline.rlvr.rlvr_vlm_pipeline import format_prompt
+
+    prompt = format_prompt("What color is the image?", processor, use_image=True)
+    size = max(1, int(size))
+
+    class SyntheticVLMDataset(Dataset):
+        def __len__(self):
+            return size
+
+        def __getitem__(self, index):
+            return {
+                "images": [Image.new("RGB", (64, 64), (255, 255, 255))],
+                "prompt": prompt,
+                "ground_truth": "white",
+                "image_flag": True,
+                "tag": "synthetic",
+            }
+
+    return SyntheticVLMDataset()
+
+
+def _cleanup_pipeline(pipeline) -> None:
+    for cluster_name in ("actor_train", "actor_infer", "reference"):
+        cluster = getattr(pipeline, cluster_name, None)
+        for worker in getattr(cluster, "workers", []) or []:
+            ray.kill(worker, no_restart=True)
+    resource_manager = getattr(pipeline, "resource_manager", None)
+    if resource_manager is not None:
+        resource_manager.destroy_placement_group()
+    time.sleep(1)
+
+
+def _run_pipeline_and_cleanup(pipeline, *args, **kwargs):
+    try:
+        return pipeline.run(*args, **kwargs)
+    finally:
+        _cleanup_pipeline(pipeline)
+
+
+class FSDPLogProbsPipeline(BasePipeline):
     def __init__(self, pipeline_config: RLVRConfig):
         super().__init__(pipeline_config)
 
@@ -60,12 +177,6 @@ class TestFSDPLogProbsPipeline(BasePipeline):
             resource_manager=self.resource_manager,
             worker_config=self.pipeline_config.actor_train,
         )
-        self.actor_infer: Any = Cluster(
-            name=self.pipeline_config.actor_infer.name,
-            worker_cls=InferWorker,
-            resource_manager=self.resource_manager,
-            worker_config=self.pipeline_config.actor_infer,
-        )
         self.reference: Any = Cluster(
             name=self.pipeline_config.reference.name,
             worker_cls=ActorWorker,
@@ -74,7 +185,6 @@ class TestFSDPLogProbsPipeline(BasePipeline):
         )
 
         self.actor_train.initialize(pipeline_config=self.pipeline_config, blocking=True)
-        self.actor_infer.initialize(pipeline_config=self.pipeline_config, blocking=True)
         self.reference.initialize(pipeline_config=self.pipeline_config, blocking=True)
 
     @torch.no_grad()
@@ -91,16 +201,8 @@ class TestFSDPLogProbsPipeline(BasePipeline):
 
             batch_dict: Dict
             batch: DataProto = DataProto.from_single_dict(batch_dict)
-            batch.meta_info = {"global_step": global_step}
-
-            # Generate responses using actor_infer
-            gen_batch = batch.pop(batch_keys=["input_ids", "attention_mask", "position_ids"])
-            gen_batch.meta_info = {"global_step": global_step}
-            generate_output: DataProto = self.actor_infer.generate(data=gen_batch)
-
-            # Combine generated output with original batch
-            batch.batch = generate_output.batch
-            batch = batch.union(generate_output)
+            batch.meta_info = {"global_step": global_step, "loss_mask_keys": ["response_mask"]}
+            batch.batch["response_mask"] = batch.batch["attention_mask"].clone()
 
             if self.pipeline_config.actor_train.model_args.lora_target is not None:
                 batch.meta_info["disable_adapter"] = True
@@ -116,9 +218,10 @@ class TestFSDPLogProbsPipeline(BasePipeline):
             # Compute log probs from reference (should also use HF)
             logprobs_ref = self.reference.compute_log_probs(batch)
 
-            # Extract prompt and response for logging
-            prompt_ids = generate_output.batch["prompts"]
-            response_ids = generate_output.batch["responses"]
+            # These tests validate logprob computation, not generation. Use the
+            # collated token sequence directly to avoid depending on vLLM startup.
+            prompt_ids = batch.batch["input_ids"]
+            response_ids = batch.batch["input_ids"]
             prompts = self.tokenizer.batch_decode(prompt_ids, skip_special_tokens=True)
             responses = self.tokenizer.batch_decode(response_ids, skip_special_tokens=True)
 
@@ -226,6 +329,7 @@ class TestFSDPLogProbsPipeline(BasePipeline):
                     f"avg_diff_fsdp_hf_mean: {sum_diff_fsdp_hf_mean / count_fsdp_hf}"
                 )
             global_step += 1
+            break
 
         logger.info("pipeline complete!")
         return results
@@ -233,9 +337,11 @@ class TestFSDPLogProbsPipeline(BasePipeline):
 
 def test_fsdp_log_probs_full():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_config")
-    pipeline = TestFSDPLogProbsPipeline(config)
-    results = pipeline.run()
+    _skip_if_cluster_insufficient(config, "test_fsdp_log_probs_full")
+    pipeline = FSDPLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_log_probs_full.json"
     with open(output_file, "w") as f:
@@ -247,9 +353,11 @@ def test_fsdp_log_probs_full():
 
 def test_fsdp_log_probs_lora():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_lora_config")
-    pipeline = TestFSDPLogProbsPipeline(config)
-    results = pipeline.run()
+    _skip_if_cluster_insufficient(config, "test_fsdp_log_probs_lora")
+    pipeline = FSDPLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_log_probs_lora.json"
     with open(output_file, "w") as f:
@@ -261,14 +369,16 @@ def test_fsdp_log_probs_lora():
 
 def test_fsdp_log_probs_cp():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_cp_config")
+    _skip_if_cluster_insufficient(config, "test_fsdp_log_probs_cp")
 
-    if torch.cuda.device_count() < 8:
-        logger.warning(f"Skipping CP test, need at least 8 GPUs (have {torch.cuda.device_count()})")
-        return
+    device_count = current_platform.device_count()
+    if device_count < 8:
+        pytest.skip(f"Need at least 8 {current_platform.ray_device_key} devices, got {device_count}.")
 
-    pipeline = TestFSDPLogProbsPipeline(config)
-    results = pipeline.run()
+    pipeline = FSDPLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_log_probs_cp.json"
     with open(output_file, "w") as f:
@@ -280,9 +390,11 @@ def test_fsdp_log_probs_cp():
 
 def test_fsdp_log_probs_cp_rmpad():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_cp_rmpad_config")
-    pipeline = TestFSDPLogProbsPipeline(config)
-    results = pipeline.run()
+    _skip_if_cluster_insufficient(config, "test_fsdp_log_probs_cp_rmpad")
+    pipeline = FSDPLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_log_probs_cp_rmpad.json"
     with open(output_file, "w") as f:

--- a/tests/distributed/strategy/log_probs/test_fsdp_vlm_layer_states.py
+++ b/tests/distributed/strategy/log_probs/test_fsdp_vlm_layer_states.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import ray
 import torch
@@ -24,10 +24,18 @@ from roll.distributed.scheduler.initialize import init
 from roll.distributed.scheduler.protocol import DataProto
 from roll.models.model_providers import default_processor_provider, get_extra_data_provider
 from roll.pipeline.base_pipeline import BasePipeline
-from roll.pipeline.base_worker import ActorWorker, InferWorker
+from roll.pipeline.base_worker import ActorWorker
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 from roll.utils.logging import get_logger
 from tests.distributed.strategy.log_probs.analyze_layer_divergence import analyze_divergence
+from tests.distributed.strategy.log_probs.test_fsdp_log_probs import (
+    _data_files_exist,
+    _make_synthetic_vlm_dataset,
+    _reset_model_download_cache_actor,
+    _run_pipeline_and_cleanup,
+    _skip_if_cluster_insufficient,
+    _skip_if_local_model_unavailable,
+)
 from tests.distributed.strategy.make_baseline_config import make_baseline_config
 
 logger = get_logger()
@@ -68,14 +76,6 @@ def _set_capture_env_on_cluster(cluster: Cluster, save_dir: Path, prefix: str, s
     ray.get([w.set_capture_env.remote(env) for w in cluster.workers])
 
 
-def _as_list(x: Union[str, List[str], None]) -> List[str]:
-    if x is None:
-        return []
-    if isinstance(x, str):
-        return [x]
-    return list(x)
-
-
 def save_inputs_and_embeddings(data: DataProto, save_dir: Path, prefix: str, global_step: int, batch_idx: int = 0):
     """Save input tensors for comparison."""
     save_dir.mkdir(parents=True, exist_ok=True)
@@ -104,7 +104,7 @@ def save_inputs_and_embeddings(data: DataProto, save_dir: Path, prefix: str, glo
             json.dump(mm_metadata, f, indent=2)
 
 
-class TestFSDPVLMLayerStatesPipeline(BasePipeline):
+class FSDPVLMLayerStatesPipeline(BasePipeline):
     def __init__(self, pipeline_config: RLVRConfig, output_dir: str = "./layer_states_output"):
         super().__init__(pipeline_config)
         self.pipeline_config = pipeline_config
@@ -135,6 +135,7 @@ class TestFSDPVLMLayerStatesPipeline(BasePipeline):
                 self.pipeline_config.actor_train.model_args.model_name_or_path,
                 processor=self.processor,
             ),
+            image_key="images",
             max_length=self.pipeline_config.prompt_length,
             padding="max_length",
         )
@@ -156,12 +157,6 @@ class TestFSDPVLMLayerStatesPipeline(BasePipeline):
             resource_manager=self.resource_manager,
             worker_config=self.pipeline_config.actor_train,
         )
-        self.actor_infer: Any = Cluster(
-            name=self.pipeline_config.actor_infer.name,
-            worker_cls=InferWorker,
-            resource_manager=self.resource_manager,
-            worker_config=self.pipeline_config.actor_infer,
-        )
         self.reference: Any = Cluster(
             name=self.pipeline_config.reference.name,
             worker_cls=ActorWorker,
@@ -170,28 +165,15 @@ class TestFSDPVLMLayerStatesPipeline(BasePipeline):
         )
 
         self.actor_train.initialize(pipeline_config=self.pipeline_config, blocking=True)
-        self.actor_infer.initialize(pipeline_config=self.pipeline_config, blocking=True)
         self.reference.initialize(pipeline_config=self.pipeline_config, blocking=True)
 
     def _build_dataset_or_skip(self):
         data_args = self.pipeline_config.actor_train.data_args
-        file_names = _as_list(getattr(data_args, "file_name", None))
+        if _data_files_exist(data_args):
+            from roll.pipeline.rlvr.rlvr_vlm_pipeline import encode_function, get_vlm_dataset
 
-        if file_names and all(os.path.exists(p) for p in file_names):
-            import datasets
-
-            from roll.pipeline.rlvr.rlvr_math_vlm_pipeline import encode_function, get_dataset
-
-            features = datasets.Features(
-                {
-                    "image": datasets.Sequence(feature=datasets.Image(decode=True)),
-                    "prompt": datasets.Value("string"),
-                    "ground_truth": datasets.Value("string"),
-                    "image_flag": datasets.Value("bool"),
-                    "tag": datasets.Value("string"),
-                }
-            )
-            return get_dataset(data_args, encode_function, self.processor, features)
+            return get_vlm_dataset(data_args, encode_function, self.processor)
+        return _make_synthetic_vlm_dataset(self.processor, size=self.pipeline_config.rollout_batch_size)
 
     @torch.no_grad()
     def run(self, max_batches: Optional[int] = None):
@@ -218,22 +200,15 @@ class TestFSDPVLMLayerStatesPipeline(BasePipeline):
             logger.info(f"vlm layer states pipeline step {global_step} batch {batch_idx} start...")
 
             batch: DataProto = DataProto.from_single_dict(batch_dict)
-            batch.meta_info = {"global_step": global_step, "_broadcast_non_tensor_batch": True}
+            batch.meta_info = {
+                "global_step": global_step,
+                "_broadcast_non_tensor_batch": True,
+                "loss_mask_keys": ["response_mask"],
+            }
+            batch.batch["response_mask"] = batch.batch["attention_mask"].clone()
 
             # Save inputs and embeddings
             save_inputs_and_embeddings(batch, inputs_dir, "input", global_step, batch_idx)
-
-            # Generate responses using actor_infer (vLLM)
-            gen_batch = batch.pop(
-                batch_keys=["input_ids", "attention_mask", "position_ids"],
-                non_tensor_batch_keys=["multi_modal_data"],
-            )
-            gen_batch.meta_info = {"global_step": global_step}
-            generate_output: DataProto = self.actor_infer.generate(data=gen_batch)
-
-            # Merge generated full sequences back
-            batch.batch = generate_output.batch
-            batch = batch.union(generate_output)
 
             _set_capture_env_on_cluster(
                 self.actor_train,
@@ -297,9 +272,12 @@ class TestFSDPVLMLayerStatesPipeline(BasePipeline):
 
 def test_fsdp_vlm_layer_states_cp2():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_vlm_cp2_config")
-    pipeline = TestFSDPVLMLayerStatesPipeline(config, output_dir="./layer_states_output")
-    results = pipeline.run(max_batches=1)  # Start with 1 batch for testing
+    _skip_if_cluster_insufficient(config, "test_fsdp_vlm_layer_states_cp2")
+    _skip_if_local_model_unavailable(config, "test_fsdp_vlm_layer_states_cp2")
+    pipeline = FSDPVLMLayerStatesPipeline(config, output_dir="./layer_states_output")
+    results = _run_pipeline_and_cleanup(pipeline, max_batches=1)  # Start with 1 batch for testing
 
     logger.info(f"Test FSDP VLM layer states (CP2) completed, results saved to {pipeline.output_dir}")
 

--- a/tests/distributed/strategy/log_probs/test_fsdp_vlm_log_probs.py
+++ b/tests/distributed/strategy/log_probs/test_fsdp_vlm_log_probs.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import torch
 from torch.utils.data import DataLoader
@@ -12,23 +12,23 @@ from roll.distributed.scheduler.initialize import init
 from roll.distributed.scheduler.protocol import DataProto
 from roll.models.model_providers import default_processor_provider, get_extra_data_provider
 from roll.pipeline.base_pipeline import BasePipeline
-from roll.pipeline.base_worker import ActorWorker, InferWorker
+from roll.pipeline.base_worker import ActorWorker
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 from roll.utils.logging import get_logger
+from tests.distributed.strategy.log_probs.test_fsdp_log_probs import (
+    _data_files_exist,
+    _make_synthetic_vlm_dataset,
+    _reset_model_download_cache_actor,
+    _run_pipeline_and_cleanup,
+    _skip_if_cluster_insufficient,
+    _skip_if_local_model_unavailable,
+)
 from tests.distributed.strategy.make_baseline_config import make_baseline_config
 
 logger = get_logger()
 
 
-def _as_list(x: Union[str, List[str], None]) -> List[str]:
-    if x is None:
-        return []
-    if isinstance(x, str):
-        return [x]
-    return list(x)
-
-
-class TestFSDPVLMLogProbsPipeline(BasePipeline):
+class FSDPVLMLogProbsPipeline(BasePipeline):
     """
     VLM logprob precision test:
     - use VLM processor + DataCollatorWithPaddingForMM (same data path as RLVRVLMPipeline)
@@ -77,6 +77,7 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
                 self.pipeline_config.actor_train.model_args.model_name_or_path,
                 processor=self.processor,
             ),
+            image_key="images",
             max_length=self.pipeline_config.prompt_length,
             padding="max_length",
         )
@@ -98,12 +99,6 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
             resource_manager=self.resource_manager,
             worker_config=self.pipeline_config.actor_train,
         )
-        # self.actor_infer: Any = Cluster(
-        #     name=self.pipeline_config.actor_infer.name,
-        #     worker_cls=InferWorker,
-        #     resource_manager=self.resource_manager,
-        #     worker_config=self.pipeline_config.actor_infer,
-        # )
         self.reference: Any = Cluster(
             name=self.pipeline_config.reference.name,
             worker_cls=ActorWorker,
@@ -116,30 +111,12 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
         self.reference.initialize(pipeline_config=self.pipeline_config, blocking=True)
 
     def _build_dataset_or_skip(self):
-        # Follow RLVRVLMPipeline data path when real files exist.
         data_args = self.pipeline_config.actor_train.data_args
-        file_names = _as_list(getattr(data_args, "file_name", None))
+        if _data_files_exist(data_args):
+            from roll.pipeline.rlvr.rlvr_vlm_pipeline import encode_function, get_vlm_dataset
 
-        # Common pattern in configs: absolute paths only exist on the training machine.
-        if file_names and all(os.path.exists(p) for p in file_names):
-            import datasets
-
-            from roll.pipeline.rlvr.rlvr_math_vlm_pipeline import encode_function, get_dataset
-
-            features = datasets.Features(
-                {
-                    # only support single image temporarily since sglang usage
-                    # "image": datasets.Image(decode=True),
-                    "image": datasets.Sequence(feature=datasets.Image(decode=True)),
-                    "prompt": datasets.Value("string"),
-                    "ground_truth": datasets.Value("string"),
-                    # for text and multi-modal mixed data usage, indicating valid image
-                    "image_flag": datasets.Value("bool"),
-                    # for area seperated validation, dummy currently
-                    "tag": datasets.Value("string"),
-                }
-            )
-            return get_dataset(data_args, encode_function, self.processor, features)
+            return get_vlm_dataset(data_args, encode_function, self.processor)
+        return _make_synthetic_vlm_dataset(self.processor, size=self.pipeline_config.rollout_batch_size)
 
     @torch.no_grad()
     def run(self):
@@ -150,7 +127,11 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
             logger.info(f"vlm logprob pipeline step {global_step} start...")
 
             batch: DataProto = DataProto.from_single_dict(batch_dict)
-            batch.meta_info = {"global_step": global_step, "_broadcast_non_tensor_batch": True}
+            batch.meta_info = {
+                "global_step": global_step,
+                "_broadcast_non_tensor_batch": True,
+                "loss_mask_keys": ["response_mask"],
+            }
             batch.batch["response_mask"] = batch.batch["attention_mask"].clone()
 
             # Generate responses using actor_infer (vLLM). Needs multi_modal_data for VLM prompts.
@@ -198,9 +179,12 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
 
 def test_fsdp_vlm_log_probs_cp2():
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_vlm_cp2_config")
-    pipeline = TestFSDPVLMLogProbsPipeline(config)
-    results = pipeline.run()
+    _skip_if_cluster_insufficient(config, "test_fsdp_vlm_log_probs_cp2")
+    _skip_if_local_model_unavailable(config, "test_fsdp_vlm_log_probs_cp2")
+    pipeline = FSDPVLMLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_vlm_log_probs_cp2.json"
     with open(output_file, "w", encoding="utf-8") as f:

--- a/tests/distributed/strategy/log_probs/test_fsdp_vlm_log_probs_perf.py
+++ b/tests/distributed/strategy/log_probs/test_fsdp_vlm_log_probs_perf.py
@@ -1,10 +1,9 @@
 import json
 import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import torch
-import torch.distributed as dist
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -14,20 +13,20 @@ from roll.distributed.scheduler.initialize import init
 from roll.distributed.scheduler.protocol import DataProto
 from roll.models.model_providers import default_processor_provider, get_extra_data_provider
 from roll.pipeline.base_pipeline import BasePipeline
-from roll.pipeline.base_worker import ActorWorker, InferWorker
+from roll.pipeline.base_worker import ActorWorker
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 from roll.utils.logging import get_logger
+from tests.distributed.strategy.log_probs.test_fsdp_log_probs import (
+    _data_files_exist,
+    _make_synthetic_vlm_dataset,
+    _reset_model_download_cache_actor,
+    _run_pipeline_and_cleanup,
+    _skip_if_cluster_insufficient,
+    _skip_if_local_model_unavailable,
+)
 from tests.distributed.strategy.make_baseline_config import make_baseline_config
 
 logger = get_logger()
-
-
-def _as_list(x: Union[str, List[str], None]) -> List[str]:
-    if x is None:
-        return []
-    if isinstance(x, str):
-        return [x]
-    return list(x)
 
 
 def get_timer_stats():
@@ -58,7 +57,7 @@ def get_memory_stats():
     }
 
 
-class TestFSDPVLMLogProbsPipeline(BasePipeline):
+class FSDPVLMLogProbsPipeline(BasePipeline):
     """
     VLM logprob precision test with performance statistics:
     - use VLM processor + DataCollatorWithPaddingForMM (same data path as RLVRVLMPipeline)
@@ -106,6 +105,7 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
                 self.pipeline_config.actor_train.model_args.model_name_or_path,
                 processor=self.processor,
             ),
+            image_key="images",
             max_length=self.pipeline_config.prompt_length,
             padding="max_length",
         )
@@ -139,23 +139,11 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
 
     def _build_dataset_or_skip(self):
         data_args = self.pipeline_config.actor_train.data_args
-        file_names = _as_list(getattr(data_args, "file_name", None))
+        if _data_files_exist(data_args):
+            from roll.pipeline.rlvr.rlvr_vlm_pipeline import encode_function, get_vlm_dataset
 
-        if file_names and all(os.path.exists(p) for p in file_names):
-            import datasets
-
-            from roll.pipeline.rlvr.rlvr_math_vlm_pipeline import encode_function, get_dataset
-
-            features = datasets.Features(
-                {
-                    "image": datasets.Sequence(feature=datasets.Image(decode=True)),
-                    "prompt": datasets.Value("string"),
-                    "ground_truth": datasets.Value("string"),
-                    "image_flag": datasets.Value("bool"),
-                    "tag": datasets.Value("string"),
-                }
-            )
-            return get_dataset(data_args, encode_function, self.processor, features)
+            return get_vlm_dataset(data_args, encode_function, self.processor)
+        return _make_synthetic_vlm_dataset(self.processor, size=self.pipeline_config.rollout_batch_size)
 
     @torch.no_grad()
     def run(self):
@@ -173,7 +161,11 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
             logger.info(f"vlm logprob pipeline step {global_step} start...")
 
             batch: DataProto = DataProto.from_single_dict(batch_dict)
-            batch.meta_info = {"global_step": global_step, "_broadcast_non_tensor_batch": True}
+            batch.meta_info = {
+                "global_step": global_step,
+                "_broadcast_non_tensor_batch": True,
+                "loss_mask_keys": ["response_mask"],
+            }
             batch.batch["response_mask"] = batch.batch["attention_mask"].clone()
 
             # Get initial memory stats
@@ -280,9 +272,12 @@ class TestFSDPVLMLogProbsPipeline(BasePipeline):
 def test_fsdp_vlm_log_probs_cp2_with_perf():
     """Test VLM logprobs with CP2 and comprehensive performance statistics."""
     init()
+    _reset_model_download_cache_actor()
     config = make_baseline_config(config_path="./log_probs", config_name="log_probs_fsdp_vlm_cp2_config")
-    pipeline = TestFSDPVLMLogProbsPipeline(config)
-    results = pipeline.run()
+    _skip_if_cluster_insufficient(config, "test_fsdp_vlm_log_probs_cp2_with_perf")
+    _skip_if_local_model_unavailable(config, "test_fsdp_vlm_log_probs_cp2_with_perf")
+    pipeline = FSDPVLMLogProbsPipeline(config)
+    results = _run_pipeline_and_cleanup(pipeline)
 
     output_file = "test_fsdp_vlm_log_probs_cp2_with_perf.json"
     with open(output_file, "w", encoding="utf-8") as f:

--- a/tests/distributed/strategy/make_baseline_config.py
+++ b/tests/distributed/strategy/make_baseline_config.py
@@ -1,5 +1,6 @@
 from dacite import from_dict
-from hydra.experimental import compose, initialize
+from hydra import compose, initialize
+from hydra.core.global_hydra import GlobalHydra
 from omegaconf import OmegaConf
 
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
@@ -7,8 +8,10 @@ from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 
 def make_baseline_config(config_path, config_name):
 
-    initialize(config_path=config_path)
-    cfg = compose(config_name=config_name)
+    if GlobalHydra.instance().is_initialized():
+        GlobalHydra.instance().clear()
+    with initialize(config_path=config_path, version_base=None):
+        cfg = compose(config_name=config_name)
     ppo_config = from_dict(data_class=RLVRConfig, data=OmegaConf.to_container(cfg, resolve=True))
 
     return ppo_config

--- a/tests/distributed/strategy/test_fsdp_strategy_collection.py
+++ b/tests/distributed/strategy/test_fsdp_strategy_collection.py
@@ -43,6 +43,89 @@ class _PlatformStub:
     def apply_ulysses_patch(self):
         return None
 
+    def empty_cache(self):
+        if self.device_type == "cuda":
+            torch.cuda.empty_cache()
+
+    def get_rng_state(self):
+        if self.device_type == "cuda":
+            return torch.cuda.get_rng_state()
+        return torch.get_rng_state()
+
+    def set_rng_state(self, state):
+        if self.device_type == "cuda":
+            torch.cuda.set_rng_state(state)
+        else:
+            torch.set_rng_state(state)
+
+
+def _accelerator_device_count() -> int:
+    if current_platform.device_type == "cpu":
+        return 0
+    device_count = getattr(current_platform, "device_count", None)
+    if not callable(device_count):
+        return 0
+    return int(device_count())
+
+
+def _has_accelerator_devices(min_devices: int = 1) -> bool:
+    if current_platform.device_type == "cpu":
+        return False
+    is_available = getattr(current_platform, "is_available", None)
+    return (
+        callable(is_available)
+        and bool(is_available())
+        and _accelerator_device_count() >= min_devices
+    )
+
+
+def _distributed_backend_for_current_platform() -> str:
+    if current_platform.device_type == "cpu":
+        return "gloo"
+    return f"cpu:gloo,{current_platform.device_type}:{current_platform.communication_backend}"
+
+
+def _device_from_current_platform_device(device_id) -> torch.device:
+    if isinstance(device_id, torch.device):
+        return device_id
+    return torch.device(current_platform.device_type, int(device_id))
+
+
+def _current_test_device() -> torch.device:
+    if current_platform.device_type == "cpu":
+        return torch.device("cpu")
+    current_device = getattr(current_platform, "current_device", None)
+    if callable(current_device):
+        return _device_from_current_platform_device(current_device())
+    return torch.device(current_platform.device_type)
+
+
+def _set_test_device_for_rank(rank: int) -> torch.device:
+    if current_platform.device_type == "cpu":
+        return torch.device("cpu")
+    device_index = rank % _accelerator_device_count()
+    set_device = getattr(current_platform, "set_device", None)
+    if callable(set_device):
+        set_device(device_index)
+    return torch.device(current_platform.device_type, device_index)
+
+
+def _mixed_precision_policy_for_current_platform():
+    if current_platform.device_type == "cpu":
+        return None
+    param_dtype = torch.float16 if current_platform.device_type == "cuda" else torch.bfloat16
+    return MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=torch.float32,
+        cast_forward_inputs=True,
+    )
+
+
+def _cpu_offload_policy_for_current_platform():
+    if current_platform.device_type == "cpu":
+        return None
+    return CPUOffloadPolicy(pin_memory=current_platform.is_cuda())
+
 
 class DummyTrainingArgs:
     def __init__(self):
@@ -80,6 +163,7 @@ def make_worker(
         use_remove_padding=use_remove_padding,
         checkpoint_config=None,
         offload_nccl=False,
+        apply_loss_scale=False,
     )
     worker = SimpleNamespace(
         worker_config=worker_config,
@@ -447,12 +531,8 @@ def test_clip_grad_norm_cpu_offload_uses_dummy_helper(
 
 
 def _fsdp2_cpu_offload_grad_clip_worker(rank, world_size, port):
-    use_cuda = torch.cuda.is_available()
-    backend = "nccl" if use_cuda else "gloo"
-    fsdp2_strategy.current_platform = _PlatformStub(
-        device_type="cuda" if use_cuda else "cpu",
-        backend=backend,
-    )
+    backend = _distributed_backend_for_current_platform()
+    fsdp2_strategy.current_platform = current_platform
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     os.environ["RANK"] = str(rank)
@@ -463,28 +543,14 @@ def _fsdp2_cpu_offload_grad_clip_worker(rank, world_size, port):
         world_size=world_size,
     )
     try:
-        if use_cuda:
-            torch.cuda.set_device(rank % torch.cuda.device_count())
-            device = torch.device("cuda", torch.cuda.current_device())
-        else:
-            device = torch.device("cpu")
+        device = _set_test_device_for_rank(rank)
 
         model = _TinyMLP(input_dim=4, hidden_dim=4, output_dim=2).to(device)
         mesh = create_device_mesh_with_ulysses(
             world_size=world_size, fsdp_size=world_size
         )
-        mp_policy = (
-            MixedPrecisionPolicy(
-                param_dtype=torch.float16,
-                reduce_dtype=torch.float32,
-                cast_forward_inputs=True,
-            )
-            if use_cuda
-            else None
-        )
-        offload_policy = (
-            CPUOffloadPolicy(pin_memory=True) if use_cuda else False
-        )
+        mp_policy = _mixed_precision_policy_for_current_platform()
+        offload_policy = _cpu_offload_policy_for_current_platform()
         fsdp_kwargs = {
             "mesh": mesh,
             "reshard_after_forward": True,
@@ -503,7 +569,7 @@ def _fsdp2_cpu_offload_grad_clip_worker(rank, world_size, port):
 
         strategy = FSDP2TrainStrategy.__new__(FSDP2TrainStrategy)
         strategy.model = model
-        strategy.cpu_offload_enabled = True
+        strategy.cpu_offload_enabled = offload_policy is not None
 
         total_norm = strategy._clip_grad_norm(max_norm=0.5)
         scalar_norm = (
@@ -532,11 +598,11 @@ def _fsdp2_cpu_offload_grad_clip_worker(rank, world_size, port):
     reason="torch.distributed is not available",
 )
 @pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CPU-offload grad clip test requires CUDA",
+    not _has_accelerator_devices(),
+    reason="CPU-offload grad clip test requires an accelerator",
 )
 def test_fsdp2_cpu_offload_grad_clip_distributed():
-    world_size = min(2, torch.cuda.device_count())
+    world_size = min(2, _accelerator_device_count())
     port = _find_free_port()
     mp.spawn(
         _fsdp2_cpu_offload_grad_clip_worker,
@@ -611,6 +677,8 @@ def test_forward_step_uses_cp_slice(strategy_factory):
     logits = torch.zeros(1, 2, 3)
     strategy.model = DummyForwardModel(logits=logits)
     strategy.param_dtype = torch.float32
+    strategy._get_batch_num_tokens = lambda batch: {}
+    strategy._get_global_valid_samples = lambda batch: {}
 
     seq_len = 4
     batch = TensorDict(
@@ -622,7 +690,10 @@ def test_forward_step_uses_cp_slice(strategy_factory):
         },
         batch_size=[1],
     )
-    data = DataProto(batch=batch, meta_info={"micro_batch_size": 1})
+    data = DataProto(
+        batch=batch,
+        meta_info={"micro_batch_size": 1, "loss_mask_keys": []},
+    )
 
     def dummy_forward_func(local_data, output_tensor):
         zeros = torch.zeros_like(local_data.batch["input_ids"]).float()
@@ -699,14 +770,13 @@ def test_offload_states_moves_to_cpu_and_clears_cuda_cache(
         non_blocking=True,
     )
 
-    assert strategy.model.cpu_called
-    assert isinstance(captured["device"], torch.device)
-    assert captured["device"].type == "cpu"
-    assert captured["non_blocking"] is True
+    assert strategy.model.to_calls == [("cpu", True)]
+    assert captured == {}
     assert cache_cleared["flag"] is True
 
 
-def test_rng_state_roundtrip(monkeypatch):
+def test_rng_state_roundtrip(monkeypatch, platform_stub):
+    platform_stub.device_type = "cuda"
     cpu_state = torch.arange(4, dtype=torch.uint8)
     cuda_state = torch.arange(5, dtype=torch.uint8)
     numpy_state = ("MT19937", np.arange(624, dtype=np.uint32), 0, 0, 0.0)
@@ -746,7 +816,7 @@ def test_rng_state_roundtrip(monkeypatch):
 
     assert torch.equal(rng_state["cpu"], cpu_state)
     assert torch.equal(captured["cpu"], cpu_state)
-    assert torch.equal(rng_state["cuda"], cuda_state)
+    assert torch.equal(rng_state["device"], cuda_state)
     assert torch.equal(captured["cuda"], cuda_state)
     assert rng_state["numpy"] == numpy_state
     assert captured["numpy"] == numpy_state
@@ -768,7 +838,8 @@ class _TinyMLP(torch.nn.Module):
         self.loss_fn = torch.nn.MSELoss()
 
     def forward(self, inputs, targets):
-        return self.loss_fn(self.layers(inputs), targets)
+        outputs = self.layers(inputs)
+        return self.loss_fn(outputs.float(), targets.float())
 
 
 def _find_free_port():
@@ -793,22 +864,16 @@ def _collect_full_state(model):
     for name, param in model.named_parameters():
         tensor = param.detach()
         if DTensor is not None and isinstance(tensor, DTensor):
-            if tensor.device.type == "cpu" and torch.cuda.is_available():
-                tensor = tensor.to("cuda")
+            if tensor.device.type == "cpu" and _has_accelerator_devices():
+                tensor = tensor.to(_current_test_device())
             tensor = tensor.full_tensor()
         state[name] = tensor.cpu().numpy()
     return state
 
 
 def _fsdp2_training_worker(rank, world_size, port, steps):
-    use_cuda = torch.cuda.is_available()
-    backend = "nccl" if use_cuda else "gloo"
-    fsdp2_strategy.current_platform = _PlatformStub(
-        device_type="cuda" if use_cuda else "cpu", backend=backend
-    )
-    current_platform = _PlatformStub(
-        device_type="cuda" if use_cuda else "cpu", backend=backend
-    )
+    backend = _distributed_backend_for_current_platform()
+    fsdp2_strategy.current_platform = current_platform
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     os.environ["RANK"] = str(rank)
@@ -817,31 +882,21 @@ def _fsdp2_training_worker(rank, world_size, port, steps):
         backend=backend, rank=rank, world_size=world_size
     )
     try:
-        if use_cuda:
-            torch.cuda.set_device(rank)
-            device = torch.device("cuda", rank)
-        else:
-            device = torch.device("cpu")
+        device = _set_test_device_for_rank(rank)
         torch.manual_seed(0)
         np.random.seed(0)
         random.seed(0)
 
-        model = _TinyMLP()
+        model = _TinyMLP().to(device)
         model.train()
         mesh = create_device_mesh_with_ulysses(
             world_size=world_size, fsdp_size=world_size
         )
-        mp_policy = (
-            MixedPrecisionPolicy(
-                param_dtype=torch.float16,
-                reduce_dtype=torch.float32,
-                cast_forward_inputs=True,
-            )
-            if use_cuda
-            else None
-        )
+        mp_policy = _mixed_precision_policy_for_current_platform()
         offload_policy = (
-            CPUOffloadPolicy(pin_memory=True) if use_cuda else False
+            _cpu_offload_policy_for_current_platform()
+            if current_platform.is_cuda()
+            else None
         )
         fsdp_kwargs = {
             "mesh": mesh,
@@ -904,8 +959,8 @@ def _fsdp2_training_worker(rank, world_size, port, steps):
     reason="torch.distributed is not available",
 )
 @pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="FSDP2 distributed training sync test requires CUDA",
+    not _has_accelerator_devices(2),
+    reason="FSDP2 distributed training sync test requires >=2 accelerator devices",
 )
 def test_fsdp2_distributed_training_keeps_states_in_sync():
     world_size = 2

--- a/tests/distributed/strategy/test_vllm_strategy_beam_search.py
+++ b/tests/distributed/strategy/test_vllm_strategy_beam_search.py
@@ -1,18 +1,11 @@
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 import torch
-import sys
-from unittest.mock import Mock, patch, MagicMock
-
-# Mock vllm modules before importing
-mock_vllm = Mock()
-mock_vllm.__version__ = "0.8.4"
-sys.modules['vllm'] = mock_vllm
-sys.modules['vllm.sampling_params'] = Mock()
-sys.modules['vllm.beam_search'] = Mock()
-sys.modules['vllm.lora'] = Mock()
-sys.modules['vllm.lora.request'] = Mock()
-sys.modules['vllm.utils'] = Mock()
-sys.modules['roll.third_party.vllm'] = Mock()
 
 # Create mock classes
 class MockRequestOutput:
@@ -53,20 +46,64 @@ class MockLoRARequest:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-# Set up the mocks
-sys.modules['vllm'].RequestOutput = MockRequestOutput
-sys.modules['vllm'].SamplingParams = MockSamplingParams
-sys.modules['vllm.sampling_params'].RequestOutputKind = Mock()
-sys.modules['vllm.sampling_params'].BeamSearchParams = MockBeamSearchParams
-sys.modules['vllm.beam_search'].BeamSearchOutput = MockBeamSearchOutput
-sys.modules['vllm.beam_search'].BeamSearchSequence = MockBeamSearchSequence
-sys.modules['vllm.lora.request'].LoRARequest = MockLoRARequest
-sys.modules['vllm.utils'].random_uuid = Mock(return_value="test_uuid")
+class MockTokensPrompt(dict):
+    pass
 
-# Now import the actual modules
+
 from roll.distributed.scheduler.protocol import DataProto
-from roll.distributed.strategy.vllm_strategy import VllmStrategy
-from roll.distributed.executor.worker import Worker
+
+
+def _install_mock_vllm_modules(monkeypatch):
+    mock_vllm = ModuleType("vllm")
+    mock_vllm.__path__ = []
+    mock_vllm.__version__ = "0.8.4"
+    mock_vllm.RequestOutput = MockRequestOutput
+    mock_vllm.SamplingParams = MockSamplingParams
+
+    sampling_params = ModuleType("vllm.sampling_params")
+    sampling_params.RequestOutputKind = Mock()
+    sampling_params.BeamSearchParams = MockBeamSearchParams
+
+    beam_search = ModuleType("vllm.beam_search")
+    beam_search.BeamSearchOutput = MockBeamSearchOutput
+    beam_search.BeamSearchSequence = MockBeamSearchSequence
+
+    lora = ModuleType("vllm.lora")
+    lora.__path__ = []
+    lora_request = ModuleType("vllm.lora.request")
+    lora_request.LoRARequest = MockLoRARequest
+
+    inputs = ModuleType("vllm.inputs")
+    inputs.__path__ = []
+    inputs_data = ModuleType("vllm.inputs.data")
+    inputs_data.TokensPrompt = MockTokensPrompt
+
+    utils = ModuleType("vllm.utils")
+    utils.random_uuid = Mock(return_value="test_uuid")
+
+    monkeypatch.setitem(sys.modules, "vllm", mock_vllm)
+    monkeypatch.setitem(sys.modules, "vllm.sampling_params", sampling_params)
+    monkeypatch.setitem(sys.modules, "vllm.beam_search", beam_search)
+    monkeypatch.setitem(sys.modules, "vllm.lora", lora)
+    monkeypatch.setitem(sys.modules, "vllm.lora.request", lora_request)
+    monkeypatch.setitem(sys.modules, "vllm.inputs", inputs)
+    monkeypatch.setitem(sys.modules, "vllm.inputs.data", inputs_data)
+    monkeypatch.setitem(sys.modules, "vllm.utils", utils)
+    monkeypatch.setitem(sys.modules, "roll.third_party.vllm", Mock())
+
+
+@pytest.fixture
+def vllm_strategy_module(monkeypatch):
+    module_name = "roll.distributed.strategy.vllm_strategy"
+    original_module = sys.modules.pop(module_name, None)
+    _install_mock_vllm_modules(monkeypatch)
+    module = importlib.import_module(module_name)
+    try:
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module
 
 
 class TestVllmStrategyBeamSearch:
@@ -75,7 +112,7 @@ class TestVllmStrategyBeamSearch:
     @pytest.fixture
     def mock_worker(self):
         """Create a mock worker for testing."""
-        worker = Mock(spec=Worker)
+        worker = Mock()
         worker.pipeline_config = Mock()
         worker.pipeline_config.seed = 42
         worker.worker_config = Mock()
@@ -94,9 +131,9 @@ class TestVllmStrategyBeamSearch:
         return worker
 
     @pytest.fixture
-    def vllm_strategy(self, mock_worker):
+    def vllm_strategy(self, vllm_strategy_module, mock_worker):
         """Create VllmStrategy instance for testing."""
-        strategy = VllmStrategy(mock_worker)
+        strategy = vllm_strategy_module.VllmStrategy(mock_worker)
 
         # Mock the model and tokenizer
         strategy.model = Mock()
@@ -146,47 +183,40 @@ class TestVllmStrategyBeamSearch:
     def test_generate_with_beam_search_success(self, vllm_strategy, sample_batch):
         """Test successful beam search generation."""
         generation_config = {"num_beams": 3, "max_new_tokens": 50}
-
-        # Create mock beam search outputs
         beam_width = 3
         batch_size = 2
 
-        beam_search_outputs = []
-        for batch_idx in range(batch_size):
-            sequences = []
+        # Mock beam_search as an async generator that yields RequestOutput-like objects
+        # _generate_with_beam_search accesses .outputs[].token_ids, not .sequences[]
+        async def mock_beam_search(prompt, request_id, params):
+            output = MagicMock()
+            output.outputs = []
             for beam_idx in range(beam_width):
-                # Include prompt + generated tokens
-                prompt_length = 10
-                generated_tokens = [100 + beam_idx, 200 + beam_idx, 300 + beam_idx]
-                full_tokens = list(range(prompt_length)) + generated_tokens
+                completion = MagicMock()
+                completion.token_ids = [100 + beam_idx, 200 + beam_idx, 300 + beam_idx]
+                output.outputs.append(completion)
+            yield output
 
-                sequence = MockBeamSearchSequence(
-                    tokens=full_tokens,
-                    logprobs=[],
-                    cum_logprob=-1.0 * beam_idx
-                )
-                sequences.append(sequence)
-
-            output = MockBeamSearchOutput(sequences=sequences)
-            beam_search_outputs.append(output)
-
-        # Mock the beam_search method
-        vllm_strategy.model.beam_search = Mock(return_value=beam_search_outputs)
+        vllm_strategy.model.beam_search = Mock(side_effect=mock_beam_search)
 
         # Mock breakpoint to avoid actual debugging
         with patch('builtins.breakpoint'):
-            result = vllm_strategy.generate(sample_batch, generation_config)
+            result = asyncio.run(
+                vllm_strategy.generate(sample_batch, generation_config)
+            )
 
-        # Verify beam_search was called
-        vllm_strategy.model.beam_search.assert_called_once()
+        # beam_search is called once per prompt via asyncio.gather
+        assert vllm_strategy.model.beam_search.call_count == batch_size
 
-        # Check result shape
+        # Check result shape: (batch_size * beam_width, prompt_len + max_output_len)
         assert result.shape[0] == batch_size * beam_width  # 2 * 3 = 6
-        assert result.shape[1] >= 13  # prompt_length + generated_tokens
+        assert result.shape[1] >= 13  # prompt_length (10) + generated_tokens (3)
 
     def test_generate_with_beam_search_multimodal(self, vllm_strategy):
         """Test beam search generation with multimodal data."""
         generation_config = {"num_beams": 2, "max_new_tokens": 30}
+        beam_width = 2
+        batch_size = 2
 
         # Create multimodal batch
         multimodal_data = [
@@ -207,36 +237,32 @@ class TestVllmStrategyBeamSearch:
         })
         batch.non_tensor_batch["multi_modal_data"] = multimodal_data
 
-        # Create mock beam search outputs
-        beam_search_outputs = []
-        for batch_idx in range(2):
-            sequences = []
-            for beam_idx in range(2):
-                prompt_length = 5
-                generated_tokens = [100 + beam_idx, 200 + beam_idx]
-                full_tokens = multimodal_data[batch_idx]["prompt_token_ids"] + generated_tokens
+        # Mock beam_search as an async generator that yields RequestOutput-like objects
+        async def mock_beam_search(prompt, request_id, params):
+            output = MagicMock()
+            output.outputs = []
+            for beam_idx in range(beam_width):
+                completion = MagicMock()
+                completion.token_ids = [100 + beam_idx, 200 + beam_idx]
+                output.outputs.append(completion)
+            yield output
 
-                sequence = MockBeamSearchSequence(
-                    tokens=full_tokens,
-                    logprobs=[],
-                    cum_logprob=-1.0 * beam_idx
-                )
-                sequences.append(sequence)
-
-            output = MockBeamSearchOutput(sequences=sequences)
-            beam_search_outputs.append(output)
-
-        # Mock the beam_search method
-        vllm_strategy.model.beam_search = Mock(return_value=beam_search_outputs)
+        vllm_strategy.model.beam_search = Mock(side_effect=mock_beam_search)
 
         # Mock breakpoint to avoid actual debugging
         with patch('builtins.breakpoint'):
-            result = vllm_strategy.generate(batch, generation_config)
+            result = asyncio.run(
+                vllm_strategy.generate(batch, generation_config)
+            )
 
-        # Verify beam_search was called with correct prompts
-        vllm_strategy.model.beam_search.assert_called_once()
-        call_args = vllm_strategy.model.beam_search.call_args
-        assert call_args[1]['prompts'] == multimodal_data
+        # beam_search is called once per prompt via asyncio.gather
+        assert vllm_strategy.model.beam_search.call_count == batch_size
 
-        # Check result shape
-        assert result.shape[0] == 4  # batch_size * beam_width
+        # Verify each multimodal prompt was passed to beam_search
+        calls = vllm_strategy.model.beam_search.call_args_list
+        actual_prompts = [call[1]['prompt'] for call in calls]
+        for prompt in multimodal_data:
+            assert prompt in actual_prompts
+
+        # Check result shape: (batch_size * beam_width, ...)
+        assert result.shape[0] == batch_size * beam_width  # 2 * 2 = 4

--- a/tests/models/load_utils.py
+++ b/tests/models/load_utils.py
@@ -7,6 +7,27 @@ from roll.datasets.loader import get_dataset
 from roll.models.model_providers import default_tokenizer_provider
 
 
+def get_model_input_device(model):
+    if hasattr(model, "get_input_embeddings"):
+        input_embeddings = model.get_input_embeddings()
+        if input_embeddings is not None:
+            return input_embeddings.weight.device
+    return next(model.parameters()).device
+
+
+def get_generation_eos_token_ids(tokenizer):
+    additional_token_ids = getattr(tokenizer, "additional_special_tokens_ids", None)
+    if additional_token_ids is None:
+        additional_tokens = getattr(tokenizer, "additional_special_tokens", [])
+        additional_token_ids = tokenizer.convert_tokens_to_ids(additional_tokens)
+    if isinstance(additional_token_ids, int):
+        additional_token_ids = [additional_token_ids]
+
+    token_ids = [tokenizer.eos_token_id]
+    token_ids.extend(token_id for token_id in additional_token_ids if token_id is not None)
+    return token_ids
+
+
 def get_mock_dataloader(model_args: ModelArguments, data_args: DataArguments, batch_size: int = 4):
 
     tokenizer = default_tokenizer_provider(model_args=model_args)
@@ -14,6 +35,9 @@ def get_mock_dataloader(model_args: ModelArguments, data_args: DataArguments, ba
     dataset = get_dataset(
         tokenizer=tokenizer,
         data_args=data_args,
+    )
+    dataset = dataset.remove_columns(
+        [col for col in dataset.column_names if col not in ("input_ids", "attention_mask")]
     )
     collate_fn = DataCollatorWithPadding(tokenizer=tokenizer)
     sampler = DistributedSampler(

--- a/tests/models/test_hf_multi_gpus.py
+++ b/tests/models/test_hf_multi_gpus.py
@@ -1,11 +1,13 @@
 import json
 import os
 
+import pytest
 from accelerate import cpu_offload_with_hook
 
 from roll.configs import ModelArguments, DataArguments, TrainingArguments
+from roll.platforms import current_platform
 from roll.utils.offload_states import offload_hf_model, load_hf_model
-from tests.models.load_utils import get_mock_dataloader
+from tests.models.load_utils import get_generation_eos_token_ids, get_mock_dataloader, get_model_input_device
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
 
@@ -16,14 +18,20 @@ from roll.models.model_providers import default_actor_model_provider
 model_name = "Qwen/Qwen2.5-0.5B-Instruct"
 data_filename = "data/comparison_gpt4_data_zh.json"
 
-model_args: ModelArguments = ModelArguments(model_name_or_path=model_name, attn_implementation="fa2", dtype="bf16")
+attn_implementation = "sdpa" if current_platform.is_npu() else "fa2"
+model_args: ModelArguments = ModelArguments(
+    model_name_or_path=model_name,
+    attn_implementation=attn_implementation,
+    dtype="bf16",
+)
 data_args: DataArguments = DataArguments(
     template="qwen2_5",
     file_name=data_filename,
     prompt="instruction",
 )
 
-
+# This generate/offload smoke test takes too long in NPU CI.
+@pytest.mark.skip_on_npu
 def test_hf_multi_gpus_cpu_offload_with_hook():
     dataloader, tokenizer = get_mock_dataloader(model_args=model_args, data_args=data_args, batch_size=4)
     model = default_actor_model_provider(tokenizer, model_args, TrainingArguments(),  False)
@@ -32,29 +40,33 @@ def test_hf_multi_gpus_cpu_offload_with_hook():
     for i, batch in tqdm(enumerate(dataloader)):
         print(f"step: {i}")
 
-        input_ids = batch["input_ids"].to("cuda")
-        attention_mask = batch["attention_mask"].to("cuda")
+        input_device = get_model_input_device(model)
+        input_ids = batch["input_ids"].to(input_device)
+        attention_mask = batch["attention_mask"].to(input_device)
         output = model.generate(
             input_ids,
             attention_mask=attention_mask,
             max_new_tokens=64,
             do_sample=False,
-            eos_token_id=[tokenizer.eos_token_id] + tokenizer.additional_special_tokens_ids,
+            eos_token_id=get_generation_eos_token_ids(tokenizer),
             pad_token_id=tokenizer.pad_token_id,
         )
 
-        print(f"before offload, hf_device_map: {model.hf_device_map}")
+        print(f"before offload, hf_device_map: {getattr(model, 'hf_device_map', None)}")
 
         if not hook:
             model, hook = cpu_offload_with_hook(model)
-        print(f"after offload, hf_device_map: {model.hf_device_map}")
+        print(f"after offload, hf_device_map: {getattr(model, 'hf_device_map', None)}")
         print(f"after offload: {i}")
+        input_device = get_model_input_device(model)
+        input_ids = input_ids.to(input_device)
+        attention_mask = attention_mask.to(input_device)
         output = model.generate(
             input_ids,
             attention_mask=attention_mask,
             max_new_tokens=64,
             do_sample=False,
-            eos_token_id=[tokenizer.eos_token_id] + tokenizer.additional_special_tokens_ids,
+            eos_token_id=get_generation_eos_token_ids(tokenizer),
             pad_token_id=tokenizer.pad_token_id,
         )
 
@@ -62,6 +74,8 @@ def test_hf_multi_gpus_cpu_offload_with_hook():
         print(output_str)
 
 
+# This multi-GPU HF offload smoke test assumes CUDA device maps.
+@pytest.mark.skip_on_npu
 def test_hf_multi_gpus_cpu_offload_hf_device_map():
     dataloader, tokenizer = get_mock_dataloader(model_args=model_args, data_args=data_args, batch_size=4)
     model = default_actor_model_provider(tokenizer, model_args, TrainingArguments(), False)
@@ -70,31 +84,35 @@ def test_hf_multi_gpus_cpu_offload_hf_device_map():
     for i, batch in tqdm(enumerate(dataloader)):
         print(f"step: {i}")
 
-        input_ids = batch["input_ids"].to("cuda")
-        attention_mask = batch["attention_mask"].to("cuda")
+        input_device = get_model_input_device(model)
+        input_ids = batch["input_ids"].to(input_device)
+        attention_mask = batch["attention_mask"].to(input_device)
         output = model.generate(
             input_ids,
             attention_mask=attention_mask,
             max_new_tokens=64,
             do_sample=False,
-            eos_token_id=[tokenizer.eos_token_id] + tokenizer.additional_special_tokens_ids,
+            eos_token_id=get_generation_eos_token_ids(tokenizer),
             pad_token_id=tokenizer.pad_token_id,
         )
 
-        print(f"before offload, hf_device_map: {model.hf_device_map}")
+        print(f"before offload, hf_device_map: {getattr(model, 'hf_device_map', None)}")
 
         offload_hf_model(model=model)
 
-        print(f"after offload, hf_device_map: {model.hf_device_map}")
+        print(f"after offload, hf_device_map: {getattr(model, 'hf_device_map', None)}")
         print(f"after offload: {i}")
         load_hf_model(model=model)
 
+        input_device = get_model_input_device(model)
+        input_ids = input_ids.to(input_device)
+        attention_mask = attention_mask.to(input_device)
         output = model.generate(
             input_ids,
             attention_mask=attention_mask,
             max_new_tokens=64,
             do_sample=False,
-            eos_token_id=[tokenizer.eos_token_id] + tokenizer.additional_special_tokens_ids,
+            eos_token_id=get_generation_eos_token_ids(tokenizer),
             pad_token_id=tokenizer.pad_token_id,
         )
 

--- a/tests/models/test_load_generate.py
+++ b/tests/models/test_load_generate.py
@@ -11,7 +11,8 @@ import torch
 from tqdm import tqdm
 
 from roll.models.model_providers import default_actor_model_provider
-from tests.models.load_utils import get_mock_dataloader
+from roll.platforms import current_platform
+from tests.models.load_utils import get_generation_eos_token_ids, get_mock_dataloader, get_model_input_device
 
 
 def test_load_generate():
@@ -19,13 +20,18 @@ def test_load_generate():
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    device = "cuda"
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
     model_name = "Qwen/Qwen2.5-0.5B-Instruct"
     data_filename = "data/comparison_gpt4_data_zh.json"
 
-    model_args: ModelArguments = ModelArguments(model_name_or_path=model_name, attn_implementation="fa2", dtype="bf16")
+    attn_implementation = "sdpa" if current_platform.is_npu() else "fa2"
+    model_args: ModelArguments = ModelArguments(
+        model_name_or_path=model_name,
+        attn_implementation=attn_implementation,
+        dtype="bf16",
+    )
     data_args: DataArguments = DataArguments(
         template="qwen2_5",
         file_name=data_filename,
@@ -36,16 +42,18 @@ def test_load_generate():
 
     model = default_actor_model_provider(tokenizer, model_args, TrainingArguments(), False)
 
+    max_generate_batches = max(1, int(os.environ.get("ROLL_TEST_LOAD_GENERATE_MAX_BATCHES", "1")))
     results = []
-    for batch in tqdm(dataloader):
-        input_ids = batch["input_ids"].to(device)
-        attention_mask = batch["attention_mask"].to(device)
+    for step, batch in enumerate(tqdm(dataloader, total=max_generate_batches)):
+        input_device = get_model_input_device(model)
+        input_ids = batch["input_ids"].to(input_device)
+        attention_mask = batch["attention_mask"].to(input_device)
         output = model.generate(
             input_ids,
             attention_mask=attention_mask,
             max_new_tokens=64,
             do_sample=False,
-            eos_token_id=[tokenizer.eos_token_id] + tokenizer.additional_special_tokens_ids,
+            eos_token_id=get_generation_eos_token_ids(tokenizer),
             pad_token_id=tokenizer.pad_token_id,
         )
 
@@ -54,6 +62,11 @@ def test_load_generate():
 
         with open("generate_res.json", "w") as f:
             json.dump(results, f, ensure_ascii=False, indent=2)
+
+        if step + 1 >= max_generate_batches:
+            break
+
+    assert results
 
 
 if __name__ == "__main__":

--- a/tests/pipeline/Distill/test_distill_on_prompt.py
+++ b/tests/pipeline/Distill/test_distill_on_prompt.py
@@ -23,17 +23,17 @@ def test_preprocess_dataset_with_real_data():
     # ===== 2. 创建DistillConfig对象 =====
     local_or_mirror_model_path = "Qwen/Qwen2.5-0.5B-Instruct"
 
-    student_cfg = WorkerConfig(data_args=DataArguments(preprocessing_num_workers=16))
+    student_cfg = WorkerConfig(data_args=DataArguments(preprocessing_num_workers=1))
     student_cfg.model_args.model_name_or_path = local_or_mirror_model_path
 
-    teacher_cfg = WorkerConfig(data_args=DataArguments(preprocessing_num_workers=16))
+    teacher_cfg = WorkerConfig(data_args=DataArguments(preprocessing_num_workers=1))
     teacher_cfg.model_args.model_name_or_path = local_or_mirror_model_path
 
     pipeline_config = DistillConfig(
         student=student_cfg,
         teacher=teacher_cfg,
-        query_key="question_zh",
-        response_key="answer_zh",
+        question_key="question_zh",
+        answer_key="answer_zh",
         distill_on_prompt=True,
         sequence_length=256
     )

--- a/tests/pipeline/agentic_pipeline_config.yaml
+++ b/tests/pipeline/agentic_pipeline_config.yaml
@@ -40,24 +40,25 @@ system_envs:
 #    - agentic
 #    - debug
 
-num_gpus_per_node: 8
+num_gpus_per_node: 2
+partial_gpu_mode: false
 
-max_steps: 1024
+max_steps: 1
 save_steps: 10000
 logging_steps: 1
-eval_steps: 10
+eval_steps: 1
 resume_from_checkpoint: false
 
-rollout_batch_size: 32
-val_batch_size: 32
-sequence_length: 8192
+rollout_batch_size: 1
+val_batch_size: 1
+sequence_length: 512
 
 reward_clip: 20
 advantage_clip: 10.0
 ppo_epochs: 1
 adv_estimator: "reinforce"
 init_kl_coef: 0.0
-whiten_advantages: true
+whiten_advantages: false
 entropy_loss_coef: 0
 
 pretrain: Qwen/Qwen2.5-0.5B-Instruct
@@ -65,49 +66,56 @@ reward_pretrain: Qwen/Qwen2.5-0.5B-Instruct
 
 actor_train:
   model_args:
-    attn_implementation: fa2
+    attn_implementation: sdpa
     disable_gradient_checkpointing: false
     dtype: bf16
     model_type: ~
   training_args:
     learning_rate: 1.0e-6
     weight_decay: 0
-    per_device_train_batch_size: 2
-    gradient_accumulation_steps: 2
-    warmup_steps: 10
+    per_device_train_batch_size: 1
+    gradient_accumulation_steps: 1
+    warmup_steps: 0
   data_args:
     template: qwen2_5
   strategy_args:
     strategy_name: deepspeed_train
     strategy_config: ${deepspeed_zero2}
-  device_mapping: list(range(0,8))
+  device_mapping: list(range(0,1))
   infer_batch_size: 1
 
 actor_infer:
   model_args:
     dtype: bf16
   generating_args:
-    max_new_tokens: 128 # single-turn response length
-    top_p: 0.99
-    top_k: 100
+    max_new_tokens: 4 # single-turn response length
+    top_p: 1.0
+    top_k: -1
     num_beams: 1
-    temperature: 0.99
+    temperature: 0.0
     num_return_sequences: 1
   data_args:
     template: qwen2_5
   strategy_args:
     strategy_name: vllm
     strategy_config:
-      gpu_memory_utilization: 0.8
+      gpu_memory_utilization: 0.35
       block_size: 16
       load_format: auto
-      enable_prefix_caching: true
-  device_mapping: list(range(0,8))
+      enable_prefix_caching: false
+      enforce_eager: true
+      max_model_len: 512
+      max_num_batched_tokens: 512
+      max_num_seqs: 1
+      tensor_parallel_size: 1
+      distributed_executor_backend: ray
+      disable_custom_all_reduce: true
+  device_mapping: list(range(1,2))
   infer_batch_size: 1
 
 reference:
   model_args:
-    attn_implementation: fa2
+    attn_implementation: sdpa
     disable_gradient_checkpointing: true
     dtype: bf16
     model_type: ~
@@ -116,7 +124,7 @@ reference:
   strategy_args:
     strategy_name: hf_infer
     strategy_config: ~
-  device_mapping: list(range(0,8))
+  device_mapping: list(range(0,1))
   infer_batch_size: 1
 
 
@@ -124,7 +132,7 @@ enable_response_mask: True
 action_sep: "||"
 use_turn_scores: False # important to GAE when applying token-level rewards to token-level advantages. If False, will take the sum of scores as the reward for the last turn.
 enable_think: False # False -> no think RL
-max_actions_per_traj: 10
+max_actions_per_traj: 1
 reward_normalization:
   grouping: tags # 可以tags(env_type)/traj_group_id(group)/batch(rollout_batch)... group_by计算reward/adv
   method: identity # asym_clip / identity / mean_std
@@ -132,38 +140,52 @@ reward_normalization:
 custom_envs:
   SimpleSokoban:
     env_type: sokoban
-    max_actions_per_traj: ${max_actions_per_traj} # used in environment state manager to control the actual max actions executed per trajectory
-    max_steps_per_traj: ${max_actions_per_traj}
+    max_steps: ${max_actions_per_traj}
+    max_tokens_per_step: 16
+    agent_system_template: ${agent_system_template}
+    agent_template: ${agent_template}
     env_instruction: "You are solving the Sokoban puzzle. You are the player and you need to push all boxes to targets. When you are right next to a box, you can push it by moving in the same direction. You cannot push a box through a wall, and you cannot pull a box. The answer must be one of action in a turn, format is <answer>Right</answer>"
-    max_tokens: 100 # used to curate llm prompt "max words", not used for rollout
     env_config: # keys should be a subset of SokobanConfig
+      action_pattern: ${action_pattern}
       dim_x: 10
       dim_y: 10
       num_boxes: 1
-      max_steps: 100
+      max_steps: 1
   FrozenLake:
     env_type: frozen_lake
-    max_actions_per_traj: ${max_actions_per_traj}
-    max_steps_per_traj: ${max_actions_per_traj}
+    max_steps: ${max_actions_per_traj}
+    max_tokens_per_step: 16
+    agent_system_template: ${agent_system_template}
+    agent_template: ${agent_template}
     env_instruction: "You are solving the FrozenLake puzzle. Forbid the whole and go to the target. You may move to the unintended direction due to the slippery ice. The answer must be one of action in a turn, format is <answer>Right</answer>"
-    max_tokens: 100
     env_config:
+      action_pattern: ${action_pattern}
+      max_steps: ${max_actions_per_traj}
+      format_penalty: -0.001
       size: 4
       is_slippery: false
 
+action_pattern: "<answer>(.*?)</answer>"
+agent_system_template: You're a helpful assistant. You are a good game player.
+agent_template: |
+  Observation:
+  {observation}
+  Use format '<answer>Right</answer>'. You have {actions_left} actions left.
+  Decide the next action:
+
 train_env_manager:
   format_penalty: -0.001
-  num_env_groups: 2
+  num_env_groups: 1
   # under the same group, the env config and env seed are ensured to be equal
   group_size: 1
   max_env_num_per_worker: 1
   tags: [ "FrozenLake" ]
-  num_groups_partition: [ 2 ] # If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
+  num_groups_partition: [ 1 ] # If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
 
 val_env_manager:
-  num_env_groups: 2
+  num_env_groups: 1
   # under the same group, the env config and env seed are ensured to be equal
   group_size: 1
   max_env_num_per_worker: 1
-  tags: [ "SimpleSokoban", "FrozenLake"]
-  num_groups_partition: [ 2, 2 ] # If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation
+  tags: [ "FrozenLake"]
+  num_groups_partition: [ 1 ] # If not set, all env names divide nums equally. Under the same group, the env config and env seed (prompt) are equal in each generation

--- a/tests/pipeline/test_agentic_pipeline.py
+++ b/tests/pipeline/test_agentic_pipeline.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import os
 from dataclasses import asdict
 
 from dacite import from_dict
@@ -10,22 +9,43 @@ from omegaconf import OmegaConf
 from roll.distributed.scheduler.initialize import init
 from roll.pipeline.agentic.agentic_config import AgenticConfig
 
-parser = argparse.ArgumentParser(description="PPO Configuration")
 
-parser.add_argument(
-    "--config_name", type=str, default="agentic_pipeline_config", help="Name of the PPO configuration."
-)
-args = parser.parse_args()
+DEFAULT_CONFIG_NAME = "agentic_pipeline_config"
 
 
-def make_ppo_config():
+def _align_resource_shape_with_config(ppo_config, configured_num_gpus_per_node):
+    total_devices = []
+    for value in vars(ppo_config).values():
+        device_mapping = getattr(value, "device_mapping", None)
+        if device_mapping is not None:
+            total_devices.extend(device_mapping)
+
+    if not total_devices or configured_num_gpus_per_node is None:
+        return
+
+    max_gpu_num = max(total_devices) + 1
+    ppo_config.num_gpus_per_node = max(
+        ppo_config.num_gpus_per_node,
+        configured_num_gpus_per_node,
+    )
+    ppo_config.num_nodes = (max_gpu_num + ppo_config.num_gpus_per_node - 1) // ppo_config.num_gpus_per_node
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="PPO Configuration")
+    parser.add_argument("--config_name", type=str, default=DEFAULT_CONFIG_NAME, help="Name of the PPO configuration.")
+    return parser.parse_args(argv)
+
+
+def make_ppo_config(config_name=DEFAULT_CONFIG_NAME):
     config_path = "."
-    config_name = args.config_name
 
-    initialize(config_path=config_path)
-    cfg = compose(config_name=config_name)
+    with initialize(config_path=config_path, version_base=None):
+        cfg = compose(config_name=config_name)
     print(cfg)
-    ppo_config = from_dict(data_class=AgenticConfig, data=OmegaConf.to_container(cfg, resolve=True))
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+    ppo_config = from_dict(data_class=AgenticConfig, data=cfg_dict)
+    _align_resource_shape_with_config(ppo_config, cfg_dict.get("num_gpus_per_node"))
     return ppo_config
 
 
@@ -34,9 +54,10 @@ def test_make_ppo_config():
     print(ppo_config)
 
 
-def test_ppo_pipeline():
+def test_ppo_pipeline(config_name=DEFAULT_CONFIG_NAME):
     from roll.pipeline.agentic.agentic_pipeline import AgenticPipeline
-    ppo_config = make_ppo_config()
+
+    ppo_config = make_ppo_config(config_name)
 
     init()
 
@@ -50,4 +71,5 @@ def test_ppo_pipeline():
 
 
 if __name__ == "__main__":
-    test_ppo_pipeline()
+    cli_args = parse_args()
+    test_ppo_pipeline(cli_args.config_name)

--- a/tests/pipeline/test_rlvr_pipeline.py
+++ b/tests/pipeline/test_rlvr_pipeline.py
@@ -1,27 +1,29 @@
 import argparse
+import os
 
+import pytest
 from dacite import from_dict
-from hydra.experimental import compose, initialize
+from hydra import compose, initialize
 from omegaconf import OmegaConf
 
 from roll.distributed.scheduler.initialize import init
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 
-parser = argparse.ArgumentParser(description="PPO Configuration")
 
-parser.add_argument(
-    "--config_name", type=str, default="rlvr_megatron_config", help="Name of the PPO configuration."
-)
-args = parser.parse_args()
+DEFAULT_CONFIG_NAME = "rlvr_megatron_config"
 
 
-def make_ppo_config():
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="PPO Configuration")
+    parser.add_argument("--config_name", type=str, default=DEFAULT_CONFIG_NAME, help="Name of the PPO configuration.")
+    return parser.parse_args(argv)
 
+
+def make_ppo_config(config_name=DEFAULT_CONFIG_NAME):
     config_path = "."
-    config_name = args.config_name
 
-    initialize(config_path=config_path)
-    cfg = compose(config_name=config_name)
+    with initialize(config_path=config_path, version_base=None):
+        cfg = compose(config_name=config_name)
     ppo_config = from_dict(data_class=RLVRConfig, data=OmegaConf.to_container(cfg, resolve=True))
 
     return ppo_config
@@ -32,9 +34,13 @@ def test_make_ppo_config():
     print(ppo_config)
 
 
-def test_ppo_pipeline():
+@pytest.mark.skipif(
+    os.environ.get("RUN_PIPELINE_INTEGRATION") != "1",
+    reason="Full pipeline integration run is disabled by default.",
+)
+def test_ppo_pipeline(config_name=DEFAULT_CONFIG_NAME):
 
-    ppo_config = make_ppo_config()
+    ppo_config = make_ppo_config(config_name)
 
     init()
 
@@ -45,4 +51,5 @@ def test_ppo_pipeline():
 
 
 if __name__ == "__main__":
-    test_ppo_pipeline()
+    cli_args = parse_args()
+    test_ppo_pipeline(cli_args.config_name)

--- a/tests/third_party/deepspeed/test_offload_states.py
+++ b/tests/third_party/deepspeed/test_offload_states.py
@@ -295,6 +295,8 @@ def run_model_memory_dump(model, config_dict, hidden_dim, dtype, include, pin_me
     model.destroy()
 
 
+# The full offload state matrix takes too long in NPU CI.
+@pytest.mark.skip_on_npu
 class TestOffloadStates(DistributedTest):
     # Need multiple gpus to test possible hanging
     world_size = 2

--- a/tests/third_party/sglang/conftest.py
+++ b/tests/third_party/sglang/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+
+if os.environ.get("ROLL_NPU_CI") == "1":
+    # Full engine-backed SGLang abort tests can exceed the NPU CI container
+    # memory limit; keep them opt-in while retaining the lightweight abort smoke.
+    collect_ignore = [
+        "test_abort.py",
+        "test_abort_grpc.py",
+        "test_abort_http.py",
+        "test_fp8.py",
+    ]
+    if os.environ.get("ROLL_NPU_SGLANG_ABORT_ENGINE") == "1":
+        collect_ignore.remove("test_abort.py")

--- a/tests/third_party/sglang/test_abort.py
+++ b/tests/third_party/sglang/test_abort.py
@@ -1,19 +1,27 @@
 import asyncio
+import gc
+import inspect
+import os
 import uuid
 
+import pytest
 from transformers import AutoTokenizer
 
-from sglang.srt.managers.io_struct import GenerateReqInput
-from sglang import __version__ as version
-
-from roll.third_party.sglang import patch as sglang_patch
+from roll.platforms import current_platform
 from roll.utils.checkpoint_manager import download_model
+
+
+ABORT_MAX_NEW_TOKENS = int(os.environ.get("ROLL_NPU_SGLANG_ABORT_MAX_NEW_TOKENS", "512"))
+ABORT_SLEEP_SECONDS = float(os.environ.get("ROLL_NPU_SGLANG_ABORT_SLEEP_SECONDS", "0.2"))
+SMOKE_MODEL = os.environ.get("ROLL_NPU_SGLANG_ABORT_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+
 
 def chat_format(prompt):
     system = "Please reason step by step, and put your final answer within \\boxed{}."
     return f"<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
 
-async def generate(model, obj):
+
+async def _generate(model, obj):
     generator = model.tokenizer_manager.generate_request(obj, None)
     chunks = None
     async for chunks in generator:
@@ -21,97 +29,153 @@ async def generate(model, obj):
     chunks = chunks if isinstance(chunks, list) else [chunks]
     return chunks
 
-async def test_sampling_n(model, input_ids):
+
+async def _wait_for_active_request(model, request_ids):
+    request_ids = set(request_ids)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10
+    while loop.time() < deadline:
+        active_request_ids = set(model.tokenizer_manager.rid_to_state)
+        if request_ids <= active_request_ids:
+            return
+        await asyncio.sleep(0.05)
+
+
+async def _check_sampling_n(model, input_ids, generate_req_cls):
     sampling_params = {
-        'temperature': 0.8,
-        'min_new_tokens': 128,
-        'max_new_tokens': 128,
-        'n': 3,
+        "temperature": 0.8,
+        "min_new_tokens": 32,
+        "max_new_tokens": 32,
+        "n": 3,
     }
-    obj = GenerateReqInput(
+    obj = generate_req_cls(
         input_ids=input_ids[0],
         sampling_params=sampling_params,
         rid=None,
         return_logprob=True,
     )
-    chunks = await generate(model, obj)
+    chunks = await _generate(model, obj)
     assert all(chunk is not None for chunk in chunks)
     assert all(chunk["meta_info"]["finish_reason"]["type"] == "length" for chunk in chunks)
 
-async def test_abort_all(model, input_ids):
+
+async def _check_abort_all(model, input_ids, generate_req_cls):
     sampling_params = {
-        'temperature': 0.8,
-        'min_new_tokens': 8192,
-        'max_new_tokens': 8192,
-        'n': 3,
+        "temperature": 0.8,
+        "min_new_tokens": ABORT_MAX_NEW_TOKENS,
+        "max_new_tokens": ABORT_MAX_NEW_TOKENS,
+        "n": 1,
     }
-    obj1 = GenerateReqInput(
-        rid=None if version < '0.5' and sampling_params["n"] > 1 else str(uuid.uuid4().hex),
+    obj1 = generate_req_cls(
+        rid=str(uuid.uuid4().hex),
         input_ids=input_ids[0],
         sampling_params=sampling_params,
         return_logprob=True,
     )
-    obj2 = GenerateReqInput(
-        rid=None if version < '0.5' and sampling_params["n"] > 1 else str(uuid.uuid4().hex),
+    obj2 = generate_req_cls(
+        rid=str(uuid.uuid4().hex),
         input_ids=input_ids[0],
         sampling_params=sampling_params,
         return_logprob=True,
     )
-    tasks = [asyncio.create_task(generate(model, obj1)), asyncio.create_task(generate(model, obj2))]
-    await asyncio.sleep(1)
-    for rid in model.tokenizer_manager.rid_to_state:
+    tasks = [asyncio.create_task(_generate(model, obj1)), asyncio.create_task(_generate(model, obj2))]
+    await _wait_for_active_request(model, [obj1.rid, obj2.rid])
+    await asyncio.sleep(ABORT_SLEEP_SECONDS)
+    for rid in list(model.tokenizer_manager.rid_to_state):
         model.tokenizer_manager.abort_request(rid)
     responses = await asyncio.gather(*tasks)
-    assert all(isinstance(response, list) and len(response) > 0 for response in responses) # assume at least generate one iter
+    assert all(isinstance(response, list) and len(response) > 0 for response in responses)
     assert all(resp["meta_info"]["finish_reason"]["type"] == "abort" for response in responses for resp in response)
 
-async def test_abort(model, input_ids):
+
+async def _check_abort(model, input_ids, generate_req_cls):
     sampling_params = {
-        'temperature': 0.8,
-        'min_new_tokens': 8192,
-        'max_new_tokens': 8192,
-        'n': 1,
+        "temperature": 0.8,
+        "min_new_tokens": ABORT_MAX_NEW_TOKENS,
+        "max_new_tokens": ABORT_MAX_NEW_TOKENS,
+        "n": 1,
     }
     rid = uuid.uuid4().hex
-    obj = GenerateReqInput(
+    obj = generate_req_cls(
         input_ids=input_ids[0],
         sampling_params=sampling_params,
         rid=rid,
         return_logprob=True,
     )
-    task = asyncio.create_task(generate(model, obj))
-    await asyncio.sleep(1)
+    task = asyncio.create_task(_generate(model, obj))
+    await _wait_for_active_request(model, [rid])
+    await asyncio.sleep(ABORT_SLEEP_SECONDS)
     model.tokenizer_manager.abort_request(rid)
     response = await task
-    assert response is not None and len(response) == 1 # assume at least generate one iter
+    assert response is not None and len(response) == 1
     assert response[0]["meta_info"]["finish_reason"]["type"] == "abort"
 
-async def main():
-    model_path = "Qwen/Qwen2.5-7B-Instruct"
-    model_path = download_model(model_path)
+
+async def _shutdown_sglang_engine(model):
+    for method_name in ("shutdown", "close"):
+        method = getattr(model, method_name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
+
+
+async def _run_sglang_abort_suite():
+    if not current_platform.is_npu():
+        pytest.skip("SGLang abort suite only applies on Ascend NPU.")
+
+    pytest.importorskip("sglang")
+    pytest.importorskip("sgl_kernel_npu")
+
+    from sglang.srt.managers.io_struct import GenerateReqInput
+
+    from roll.third_party.sglang import patch as sglang_patch
+
+    model_path = download_model(SMOKE_MODEL)
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     prompts = [
-        "类型#上衣*材质#牛仔布*颜色#白色*风格#简约*图案#刺绣*衣样式#外套*衣款式#破洞,生成一段文案",
-        "根据关键词描述生成女装/女士精品行业连衣裙品类的发在淘宝的小红书风格的推送配文，包括标题和内容。关键词：pe。要求:1. 推送标题要体现关键词和品类特点，语言通顺，有吸引力，约10个字；2. 推送内容要语言通顺，突出关键词和品类特点，对目标受众有吸引力，长度约30字。标题:",
-        "100.25和90.75谁更大？",
+        "Write one short sentence about testing.",
+        "Which number is larger, 100.25 or 100.75?",
+        "Say hello in one short sentence.",
     ]
     prompts = [chat_format(prompt) for prompt in prompts]
     input_ids = tokenizer(prompts)["input_ids"]
 
-    model = sglang_patch.engine.engine_module.Engine(
-        model_path=model_path,
-        enable_memory_saver= True,
-        skip_tokenizer_init=False, # to use min_new_tokens
-        dtype="bfloat16",
-        tp_size=1,
-        mem_fraction_static= 0.6,
-        disable_custom_all_reduce=True,
-    )
+    model = None
+    try:
+        model = sglang_patch.engine.engine_module.Engine(
+            model_path=model_path,
+            enable_memory_saver=False,  # CI skips torch-memory-saver; abort behavior does not need it.
+            skip_tokenizer_init=False,  # to use min_new_tokens
+            dtype="bfloat16",
+            tp_size=1,
+            mem_fraction_static=0.3,
+            max_total_tokens=2048,
+            max_running_requests=4,
+            disable_custom_all_reduce=True,
+        )
 
-    await test_sampling_n(model, input_ids)
-    await test_abort_all(model, input_ids)
-    await test_abort(model, input_ids)
+        await _check_sampling_n(model, input_ids, GenerateReqInput)
+        await _check_abort_all(model, input_ids, GenerateReqInput)
+        await _check_abort(model, input_ids, GenerateReqInput)
+    finally:
+        if model is not None:
+            try:
+                await _shutdown_sglang_engine(model)
+            except Exception as e:
+                print(f"Failed to shut down SGLang model cleanly: {e}")
+        gc.collect()
+        empty_cache = getattr(current_platform, "empty_cache", None)
+        if empty_cache is not None:
+            empty_cache()
+
+
+def test_sglang_abort_suite():
+    asyncio.run(_run_sglang_abort_suite())
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    test_sglang_abort_suite()

--- a/tests/third_party/sglang/test_npu_import.py
+++ b/tests/third_party/sglang/test_npu_import.py
@@ -1,0 +1,90 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from roll.platforms import current_platform
+
+
+def _require_module(module_name: str) -> None:
+    try:
+        module_spec = importlib.util.find_spec(module_name)
+    except ValueError:
+        module_spec = None
+
+    available = module_spec is not None or module_name in sys.modules
+    if not available and not current_platform.is_npu():
+        pytest.skip(f"{module_name} is not installed in this environment.")
+    assert available, f"{module_name} must be installed for NPU SGLang tests."
+
+
+class _CapturingScheduler:
+    def __init__(self):
+        self.messages = []
+
+    def send_pyobj(self, obj):
+        self.messages.append(obj)
+
+
+def test_sglang_import_available():
+    _require_module("sglang")
+    import sglang
+
+    assert sglang.__version__
+
+
+def _run_npu_sglang_abort_smoke():
+    _require_module("sglang")
+    _require_module("sgl_kernel_npu")
+
+    from sglang.srt.managers.tokenizer_manager import ReqState, TokenizerManager
+
+    request_id = uuid.uuid4().hex
+    manager = TokenizerManager.__new__(TokenizerManager)
+    manager.rid_to_state = {}
+    manager.send_to_scheduler = _CapturingScheduler()
+    manager.enable_metrics = False
+
+    request = SimpleNamespace(
+        rid=request_id,
+        stream=False,
+        return_logprob=False,
+        top_logprobs_num=0,
+        token_ids_logprob=[],
+        return_text_in_logprobs=False,
+    )
+    state = ReqState([], False, asyncio.Event(), request, created_time=0.0)
+    state.output_ids = [101, 102, 103]
+    state.text = "partial output"
+    manager.rid_to_state[request_id] = state
+
+    manager.abort_request(request_id)
+
+    assert len(manager.send_to_scheduler.messages) == 1
+    abort_req = manager.send_to_scheduler.messages[0]
+    assert abort_req.rid == request_id
+    assert not abort_req.abort_all
+
+    manager._handle_abort_req(abort_req)
+
+    assert state.finished
+    assert state.event.is_set()
+    assert state.out_list
+    output = state.out_list[-1]
+    assert output["text"] == "partial output"
+    assert output["output_ids"] == [101, 102, 103]
+    assert output["meta_info"]["id"] == request_id
+    assert output["meta_info"]["finish_reason"]["type"] == "abort"
+
+
+def test_npu_sglang_abort_smoke():
+    if not current_platform.is_npu():
+        pytest.skip("NPU SGLang abort smoke only applies on Ascend NPU.")
+    if os.environ.get("ROLL_NPU_SGLANG_ABORT_SMOKE", "1") == "0":
+        pytest.skip("ROLL_NPU_SGLANG_ABORT_SMOKE=0")
+
+    _run_npu_sglang_abort_smoke()

--- a/tests/third_party/vllm/conftest.py
+++ b/tests/third_party/vllm/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+
+_THIS_DIR = os.path.dirname(__file__)
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+
+if os.environ.get("ROLL_NPU_CI") == "1":
+    collect_ignore = [
+        "test_add_requests.py",
+        "test_collective_rpc.py",
+        "test_fp8.py",
+        "test_fp8_perf.py",
+        "test_sleep_level.py",
+        "test_vllm_local_actor.py",
+        "test_vllm_local_async.py",
+        "test_vllm_mem_oom.py",
+        "vllm_generate_test.py", # npu server has no MATH_train_reformat_241225.json
+    ]

--- a/tests/third_party/vllm/test_abort.py
+++ b/tests/third_party/vllm/test_abort.py
@@ -1,23 +1,28 @@
-import ray
 import asyncio
-import pytest
-from packaging.version import Version
+import gc
+import inspect
+import os
 
+import pytest
+import ray
 import vllm
+from packaging.version import Version
 from vllm import SamplingParams
 from vllm.sampling_params import RequestOutputKind
 from vllm.utils import random_uuid
 
 from roll.distributed.scheduler.resource_manager import ResourceManager
+from roll.platforms import current_platform
 from roll.third_party.vllm import create_async_llm
-from roll.utils.checkpoint_manager import download_model
-from utils import chat_prompts, print_request_output
+from roll.utils import checkpoint_manager
+from utils import chat_prompts
 
 
 # vLLM 0.8.4 has bug when using n_sample with output_kind other than RequestOutputKind.FINAL_ONLY
 # https://github.com/vllm-project/vllm/pull/16863
 
-async def test_vllm_sampling_n(model):
+
+async def _check_vllm_sampling_n(model):
     print(">>>>>>>>>>>>>>> test_vllm_sampling_n")
     sampling_params = SamplingParams(
         temperature=0.1,
@@ -42,13 +47,14 @@ async def test_vllm_sampling_n(model):
     assert len(output.outputs) == 3
     # print_request_output(output)
 
-# The semantics of AsyncLLMEngine.abort for v1 and v0 are not aligned (see 
+
+# The semantics of AsyncLLMEngine.abort for v1 and v0 are not aligned (see
 # https://github.com/vllm-project/vllm/blob/main/tests/async_engine/test_async_llm_engine.py#L350 and
 # https://github.com/vllm-project/vllm/blob/main/tests/v1/engine/test_async_llm.py#L185 for difference).
 #
 # What we want is the semantic of v0 that raise asyncio.CancelledError in
 # AsyncLLMEngine.generate when request is aborted rather than rely on cancel of async task to abort request.
-async def test_vllm_abort(model):
+async def _check_vllm_abort(model):
     print(">>>>>>>>>>>>>>> test_vllm_abort")
     sampling_params = SamplingParams(
         temperature=0.1,
@@ -59,13 +65,14 @@ async def test_vllm_abort(model):
     )
 
     request_id = random_uuid()
+
     async def generate():
         output = None
         if Version(vllm.__version__) >= Version("0.10.2"):
             async for request_output in model.generate(chat_prompts[0], sampling_params, request_id=request_id):
                 output = request_output
         else:
-            with pytest.raises(asyncio.CancelledError): # we patch older version vllm
+            with pytest.raises(asyncio.CancelledError):  # we patch older version vllm
                 async for request_output in model.generate(chat_prompts[0], sampling_params, request_id=request_id):
                     output = request_output
         return output
@@ -82,24 +89,26 @@ async def test_vllm_abort(model):
     else:
         assert output is None
 
-async def test_vllm_abort_cumulative(model):
+
+async def _check_vllm_abort_cumulative(model):
     print(">>>>>>>>>>>>>>> test_vllm_abort_cumulative")
     sampling_params = SamplingParams(
         temperature=0.1,
         min_tokens=8192,
         max_tokens=8192,
-        n=3, # the behaviour of n sample before 0.10.2 is the same as sglang, we must store output by index
+        n=3,  # the behaviour of n sample before 0.10.2 is the same as sglang, we must store output by index
         output_kind=RequestOutputKind.CUMULATIVE,
     )
 
     request_id = random_uuid()
+
     async def generate():
         output = None
         if Version(vllm.__version__) >= Version("0.10.2"):
             async for request_output in model.generate(chat_prompts[0], sampling_params, request_id=request_id):
                 output = request_output
         else:
-            with pytest.raises(asyncio.CancelledError): # we patch older version vllm
+            with pytest.raises(asyncio.CancelledError):  # we patch older version vllm
                 async for request_output in model.generate(chat_prompts[0], sampling_params, request_id=request_id):
                     output = request_output
         return output
@@ -115,32 +124,82 @@ async def test_vllm_abort_cumulative(model):
         assert all(out.finish_reason == "abort" for out in output.outputs)
     else:
         assert output is not None and not output.finished
-        assert len(output.outputs) == 1 # does match sampling_params.n
+        assert len(output.outputs) == 1  # does match sampling_params.n
 
-async def main():
-    model_path = "Qwen/Qwen2.5-7B-Instruct"
-    model_path = download_model(model_path)
 
-    resource_manager = ResourceManager(2, 1)
-    placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0, 1])
-    sampling_params = SamplingParams(temperature=0.0, top_p=0.99, top_k=100, max_tokens=512)
+async def _shutdown_async_llm(model):
+    for method_name in ("shutdown", "close"):
+        method = getattr(model, method_name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
 
-    model = await create_async_llm(
-        resource_placement_groups=placement_groups[0],
-        model=model_path,
-        block_size=16,
-        dtype="bfloat16",
-        gpu_memory_utilization=0.8,
-        tensor_parallel_size=2,
-        distributed_executor_backend="ray",
-        disable_custom_all_reduce=True,
-        enable_sleep_mode=True,
-        enforce_eager=False,
-    )
 
-    await test_vllm_sampling_n(model)
-    await test_vllm_abort(model)
-    await test_vllm_abort_cumulative(model)
+async def _run_vllm_abort_suite():
+    old_task_queue_enable = os.environ.get("TASK_QUEUE_ENABLE")
+    old_vllm_ascend_enable_nz = os.environ.get("VLLM_ASCEND_ENABLE_NZ")
+    if current_platform.is_npu():
+        os.environ["TASK_QUEUE_ENABLE"] = "1"
+        os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
+
+    model = None
+    resource_manager = None
+    try:
+        ray.init(ignore_reinit_error=True)
+        model_path = checkpoint_manager.download_model("Qwen/Qwen2.5-7B-Instruct")
+
+        resource_manager = ResourceManager(2, 1)
+        placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0, 1])
+
+        model = await create_async_llm(
+            resource_placement_groups=placement_groups[0],
+            model=model_path,
+            block_size=16,
+            dtype="bfloat16",
+            gpu_memory_utilization=0.8,
+            tensor_parallel_size=2,
+            distributed_executor_backend="ray",
+            disable_custom_all_reduce=True,
+            enable_sleep_mode=True,
+            enforce_eager=current_platform.is_npu(),
+        )
+
+        await _check_vllm_sampling_n(model)
+        await _check_vllm_abort(model)
+        await _check_vllm_abort_cumulative(model)
+    finally:
+        if model is not None:
+            try:
+                await _shutdown_async_llm(model)
+            except Exception as e:
+                print(f"Failed to shut down vLLM model cleanly: {e}")
+        if resource_manager is not None:
+            resource_manager.destroy_placement_group()
+        if ray.is_initialized():
+            ray.shutdown()
+        checkpoint_manager.shared_storage = None
+        gc.collect()
+        empty_cache = getattr(current_platform, "empty_cache", None)
+        if empty_cache is not None:
+            empty_cache()
+        if old_task_queue_enable is None:
+            os.environ.pop("TASK_QUEUE_ENABLE", None)
+        else:
+            os.environ["TASK_QUEUE_ENABLE"] = old_task_queue_enable
+        if old_vllm_ascend_enable_nz is None:
+            os.environ.pop("VLLM_ASCEND_ENABLE_NZ", None)
+        else:
+            os.environ["VLLM_ASCEND_ENABLE_NZ"] = old_vllm_ascend_enable_nz
+
+
+# Takes about 7 minutes in NPU CI, so skip this full vLLM abort suite there.
+@pytest.mark.skip_on_npu
+def test_vllm_abort_suite():
+    asyncio.run(_run_vllm_abort_suite())
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    test_vllm_abort_suite()

--- a/tests/third_party/vllm/test_model_update.py
+++ b/tests/third_party/vllm/test_model_update.py
@@ -1,15 +1,21 @@
 import os
 import ray
+import inspect
 import asyncio
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM
 from vllm import SamplingParams
 
 from roll.distributed.scheduler.resource_manager import ResourceManager
+from roll.platforms import current_platform
 from roll.third_party.vllm import create_async_llm
 from roll.third_party.vllm.worker import WorkerV1
+from roll.utils import checkpoint_manager
 from roll.utils.checkpoint_manager import download_model
-from utils import generate_batch, chat_prompts, print_request_output
+try:
+    from .utils import generate_batch, chat_prompts, print_request_output
+except ImportError:
+    from utils import generate_batch, chat_prompts, print_request_output
 
 class ModelUpdateWorker(WorkerV1):
     def __init__(self, *args, **kwargs):
@@ -19,59 +25,104 @@ class ModelUpdateWorker(WorkerV1):
         train_model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype="auto")
         for param_name, param in tqdm(iterable=train_model.named_parameters(), total=len(list(train_model.named_parameters()))):
             if zero:
-                param = param.data.clone().cuda().zero_()
+                param = param.data.clone().to(self.device).zero_()
             else:
-                param = param.data.clone().cuda()
+                param = param.data.clone().to(self.device)
             self.load_weights([(param_name, param)])
 
-async def test_vllm_offload():
+
+async def _shutdown_async_llm(model):
+    for method_name in ("shutdown", "close"):
+        method = getattr(model, method_name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
+
+
+async def _run_vllm_offload():
     os.environ["VLLM_USE_V1"] = "1"
-    ray.init()
-    resource_manager = ResourceManager(2, 1)
-    placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0,1])
+    old_task_queue_enable = os.environ.get("TASK_QUEUE_ENABLE")
+    old_vllm_ascend_enable_nz = os.environ.get("VLLM_ASCEND_ENABLE_NZ")
+    if current_platform.is_npu():
+        os.environ["TASK_QUEUE_ENABLE"] = "1"
+        os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
+    model = None
+    resource_manager = None
+    try:
+        ray.init(ignore_reinit_error=True)
+        resource_manager = ResourceManager(2, 1)
+        placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0, 1])
 
-    model_path = "Qwen/Qwen2.5-7B-Instruct"
-    model_path = download_model(model_path)
-    model = await create_async_llm(
-        resource_placement_groups=placement_groups[0],
-        model=model_path,
-        load_format="auto",
-        block_size=16,
-        dtype="bfloat16",
-        gpu_memory_utilization=0.8,
-        tensor_parallel_size=2,
-        disable_custom_all_reduce=True,
-        enable_sleep_mode=True,
-        enforce_eager=False,
-        worker_extension_cls="tests.third_party.vllm.test_model_update.ModelUpdateWorker",
-    )
+        model_path = "Qwen/Qwen2.5-7B-Instruct"
+        model_path = download_model(model_path)
+        model = await create_async_llm(
+            resource_placement_groups=placement_groups[0],
+            model=model_path,
+            load_format="auto",
+            block_size=16,
+            dtype="bfloat16",
+            gpu_memory_utilization=0.8,
+            tensor_parallel_size=2,
+            distributed_executor_backend="ray",
+            disable_custom_all_reduce=True,
+            enable_sleep_mode=True,
+            enforce_eager=current_platform.is_npu(),
+            worker_extension_cls="tests.third_party.vllm.test_model_update.ModelUpdateWorker",
+        )
 
-    # test offload/onload and sleep_level
-    sampling_params = SamplingParams(temperature=0.0, top_p=0.99, top_k=100, max_tokens=512)
+        # test offload/onload and sleep_level
+        sampling_params = SamplingParams(temperature=0.0, top_p=0.99, top_k=100, max_tokens=512)
 
-    print(">>>>>>>>>>>>>>> test_vllm_load_offload: base")
-    vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
-    assert len(vllm_outputs) == len(chat_prompts)
-    print_request_output(vllm_outputs)
+        print(">>>>>>>>>>>>>>> test_vllm_load_offload: base")
+        vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
+        assert len(vllm_outputs) == len(chat_prompts)
+        print_request_output(vllm_outputs)
 
-    print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_1")
-    await model.offload_states(1)
-    await model.load_states()
-    vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
-    print_request_output(vllm_outputs)
+        print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_1")
+        await model.offload_states(1)
+        await model.load_states()
+        vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
+        print_request_output(vllm_outputs)
 
-    print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_2")
-    await model.offload_states(2)
-    await model.load_states()
-    vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
-    print_request_output(vllm_outputs)
+        print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_2")
+        await model.offload_states(2)
+        await model.load_states()
+        vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
+        print_request_output(vllm_outputs)
 
-    print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_2 + reload")
-    await model.offload_states(2)
-    await model.engine_core.collective_rpc_async("load_full_model", args=(model_path,))
-    await model.load_states()
-    vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
-    print_request_output(vllm_outputs)
+        print(">>>>>>>>>>>>>>> test_vllm_load_offload: offload states sleep_level_2 + reload")
+        await model.offload_states(2)
+        await model.engine_core.collective_rpc_async("load_full_model", args=(model_path,))
+        await model.load_states()
+        vllm_outputs = await generate_batch(model=model, prompts=chat_prompts, sampling_params=sampling_params)
+        print_request_output(vllm_outputs)
+    finally:
+        if model is not None:
+            try:
+                await _shutdown_async_llm(model)
+            except Exception as e:
+                print(f"Failed to shut down vLLM model cleanly: {e}")
+        if resource_manager is not None:
+            resource_manager.destroy_placement_group()
+        if ray.is_initialized():
+            ray.shutdown()
+        checkpoint_manager.shared_storage = None
+        if old_task_queue_enable is None:
+            os.environ.pop("TASK_QUEUE_ENABLE", None)
+        else:
+            os.environ["TASK_QUEUE_ENABLE"] = old_task_queue_enable
+        if old_vllm_ascend_enable_nz is None:
+            os.environ.pop("VLLM_ASCEND_ENABLE_NZ", None)
+        else:
+            os.environ["VLLM_ASCEND_ENABLE_NZ"] = old_vllm_ascend_enable_nz
+
+
+def test_vllm_offload():
+    asyncio.run(_run_vllm_offload())
+
 
 if __name__ == "__main__":
-    asyncio.run(test_vllm_offload())
+    test_vllm_offload()

--- a/tests/third_party/vllm/test_npu_import.py
+++ b/tests/third_party/vllm/test_npu_import.py
@@ -1,0 +1,215 @@
+import asyncio
+import gc
+import importlib.util
+import inspect
+import os
+import sys
+
+# The single-device smoke uses TP=1; force this before vLLM-Ascend imports
+# can cache FlashComm settings from the environment.
+os.environ["VLLM_ASCEND_ENABLE_FLASHCOMM"] = "0"
+
+import pytest
+
+from roll.platforms import current_platform
+
+
+def _require_module(module_name: str) -> bool:
+    """Check that *module_name* is importable.
+
+    On CPU environments the test is skipped when the module is missing.
+    On NPU environments the module is expected to be present.
+    """
+    try:
+        module_spec = importlib.util.find_spec(module_name)
+    except ValueError:
+        # Python 3.11+ raises ValueError when a module that is already imported
+        # has ``__spec__`` set to ``None`` (an edge case in certain packaging).
+        # Check ``sys.modules`` as a fallback.
+        module_spec = None
+
+    available = module_spec is not None or module_name in sys.modules
+    if not available and not current_platform.is_npu():
+        pytest.skip(f"{module_name} is not installed in this environment.")
+    assert available, f"{module_name} must be installed for NPU vLLM tests."
+    return available
+
+
+def test_vllm_imports_available():
+    _require_module("vllm")
+    if current_platform.is_npu():
+        _require_module("vllm_ascend")
+
+
+def test_vllm_npu_worker_class_resolves():
+    if not current_platform.is_npu():
+        pytest.skip("NPU worker resolution only applies on Ascend NPU.")
+
+    worker_cls = current_platform.get_vllm_worker_class()
+    assert worker_cls is not None
+    assert worker_cls.__name__.endswith("Worker")
+
+
+def test_roll_vllm_ray_executor_resolves():
+    if not current_platform.is_npu():
+        pytest.skip("ROLL vLLM Ray executor resolution only applies on Ascend NPU.")
+
+    import roll.third_party.vllm as roll_vllm
+    import vllm
+
+    assert roll_vllm.ray_executor_class_v1 is not None, (
+        f"ROLL must resolve a vLLM V1 Ray executor for NPU CI; vllm={vllm.__version__}"
+    )
+
+
+async def _shutdown_async_llm(model):
+    for method_name in ("shutdown", "close"):
+        method = getattr(model, method_name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
+
+
+async def _run_with_npu_vllm_smoke_model(callback, **model_kwargs):
+    import ray
+
+    from roll.distributed.scheduler.initialize import init
+    from roll.distributed.scheduler.resource_manager import ResourceManager
+    from roll.third_party.vllm import create_async_llm
+    from roll.utils import checkpoint_manager
+
+    init()
+
+    model = None
+    resource_manager = None
+    try:
+        model_name_or_path = os.environ.get("ROLL_NPU_VLLM_SMOKE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+        model_path = checkpoint_manager.download_model(model_name_or_path)
+
+        resource_manager = ResourceManager(num_gpus_per_node=1, num_nodes=1)
+        placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0])
+
+        kwargs = dict(
+            dtype="bfloat16",
+            gpu_memory_utilization=0.35,
+            max_model_len=512,
+            max_num_batched_tokens=512,
+            max_num_seqs=1,
+            tensor_parallel_size=1,
+            distributed_executor_backend="ray",
+            disable_custom_all_reduce=True,
+            enforce_eager=True,
+            trust_remote_code=True,
+        )
+        kwargs.update(model_kwargs)
+
+        model = await create_async_llm(
+            resource_placement_groups=placement_groups[0],
+            model=model_path,
+            **kwargs,
+        )
+
+        return await callback(model)
+    finally:
+        if model is not None:
+            try:
+                await _shutdown_async_llm(model)
+            except Exception as e:
+                print(f"Failed to shut down vLLM smoke model cleanly: {e}")
+        if resource_manager is not None:
+            resource_manager.destroy_placement_group()
+        if ray.is_initialized():
+            ray.shutdown()
+        checkpoint_manager.shared_storage = None
+        gc.collect()
+        empty_cache = getattr(current_platform, "empty_cache", None)
+        if empty_cache is not None:
+            empty_cache()
+
+
+async def _run_npu_vllm_generate_smoke():
+    from vllm import SamplingParams
+    from vllm.utils import random_uuid
+
+    async def generate(model):
+        sampling_params = SamplingParams(temperature=0.0, max_tokens=4, min_tokens=1)
+        result_generator = model.generate(
+            prompt="Write one short greeting.",
+            sampling_params=sampling_params,
+            request_id=random_uuid(),
+        )
+
+        output = None
+        async for request_output in result_generator:
+            output = request_output
+
+        assert output is not None
+        assert output.finished
+        assert len(output.outputs) == 1
+        assert output.outputs[0].token_ids
+
+    await _run_with_npu_vllm_smoke_model(generate)
+
+
+async def _run_npu_vllm_abort_smoke():
+    from vllm import SamplingParams
+    from vllm.sampling_params import RequestOutputKind
+    from vllm.utils import random_uuid
+
+    async def abort(model):
+        request_id = random_uuid()
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            min_tokens=512,
+            max_tokens=512,
+            output_kind=RequestOutputKind.FINAL_ONLY,
+        )
+
+        async def collect_output():
+            output = None
+            async for request_output in model.generate(
+                prompt="Count upward and keep going.",
+                sampling_params=sampling_params,
+                request_id=request_id,
+            ):
+                output = request_output
+            return output
+
+        task = asyncio.create_task(collect_output())
+        await asyncio.sleep(float(os.environ.get("ROLL_NPU_VLLM_ABORT_DELAY", "0.2")))
+        result = model.abort(request_id)
+        if inspect.isawaitable(result):
+            await result
+
+        output = await asyncio.wait_for(task, timeout=120)
+        assert output is not None
+        assert output.finished
+        assert output.outputs
+        assert all(completion.finish_reason == "abort" for completion in output.outputs)
+
+    await _run_with_npu_vllm_smoke_model(
+        abort,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+    )
+
+
+def test_npu_vllm_generate_smoke():
+    if not current_platform.is_npu():
+        pytest.skip("NPU vLLM generate smoke only applies on Ascend NPU.")
+    if os.environ.get("ROLL_NPU_VLLM_GENERATE_SMOKE", "1") == "0":
+        pytest.skip("ROLL_NPU_VLLM_GENERATE_SMOKE=0")
+
+    asyncio.run(_run_npu_vllm_generate_smoke())
+
+
+def test_npu_vllm_abort_smoke():
+    if not current_platform.is_npu():
+        pytest.skip("NPU vLLM abort smoke only applies on Ascend NPU.")
+    if os.environ.get("ROLL_NPU_VLLM_ABORT_SMOKE", "1") == "0":
+        pytest.skip("ROLL_NPU_VLLM_ABORT_SMOKE=0")
+
+    asyncio.run(_run_npu_vllm_abort_smoke())

--- a/tests/third_party/vllm/test_vllm_local.py
+++ b/tests/third_party/vllm/test_vllm_local.py
@@ -1,73 +1,189 @@
+import asyncio
+import gc
+import inspect
+import os
+from contextlib import contextmanager
+
 import ray
-import torch
 from vllm import SamplingParams
+from vllm.utils import random_uuid
+from vllm.utils.mem_constants import GiB_bytes
 
 from roll.distributed.scheduler.resource_manager import ResourceManager
-from roll.third_party.vllm import LLM
+from roll.platforms import current_platform
+from roll.third_party.vllm import create_async_llm
+from roll.utils import checkpoint_manager
 from roll.utils.checkpoint_manager import download_model
+from utils import (
+    chat_prompts,
+    generate_batch,
+    print_request_output,
+)
 
 
-def chat_format(prompt):
-    system = "Please reason step by step, and put your final answer within \\boxed{}."
-    return f"<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+def _platform_memory_history_supported():
+    memory = getattr(current_platform, "memory", None)
+    return (
+        memory is not None
+        and hasattr(memory, "_record_memory_history")
+        and hasattr(memory, "_dump_snapshot")
+    )
+
+
+@contextmanager
+def _platform_mem_usage(mem_profile=False):
+    current_platform.empty_cache()
+    gc.collect()
+    free_bytes, total = current_platform.mem_get_info()
+    used_bytes_before = total - free_bytes
+    enable_memory_history = mem_profile and _platform_memory_history_supported()
+    if mem_profile and not enable_memory_history:
+        print(
+            f"[mem_usage] memory history is not supported on "
+            f"{current_platform.device_type}, skip snapshot"
+        )
+    if enable_memory_history:
+        current_platform.memory._record_memory_history(
+            max_entries=100000,
+            stacks="python",
+        )
+    try:
+        yield
+    finally:
+        current_platform.empty_cache()
+        gc.collect()
+        dump_file = ""
+        if enable_memory_history:
+            dump_file = f"/tmp/{random_uuid()}.pickle"
+            os.makedirs(os.path.dirname(dump_file), exist_ok=True)
+            current_platform.memory._dump_snapshot(dump_file)
+            current_platform.memory._record_memory_history(enabled=None)
+        free_bytes, total = current_platform.mem_get_info()
+        used_bytes_after = total - free_bytes
+        print(
+            f"[mem_usage] before {used_bytes_before / GiB_bytes} "
+            f"after {used_bytes_after / GiB_bytes}, dump to file {dump_file}"
+        )
+
+
+async def _shutdown_async_llm(model):
+    for method_name in ("shutdown", "close"):
+        method = getattr(model, method_name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
+
+
+async def _run_vllm_with_load_offload():
+    os.environ["VLLM_USE_V1"] = "1"
+    old_task_queue_enable = os.environ.get("TASK_QUEUE_ENABLE")
+    old_vllm_ascend_enable_nz = os.environ.get("VLLM_ASCEND_ENABLE_NZ")
+    if current_platform.is_npu():
+        os.environ["TASK_QUEUE_ENABLE"] = "1"
+        os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
+
+    tensor_parallel_size = int(
+        os.environ.get(
+            "ROLL_VLLM_LOCAL_TP_SIZE",
+            "2" if current_platform.is_npu() else "4",
+        )
+    )
+    model_name = os.environ.get(
+        "ROLL_VLLM_LOCAL_MODEL",
+        "Qwen/Qwen2.5-7B-Instruct",
+    )
+
+    model = None
+    resource_manager = None
+    try:
+        ray.init(ignore_reinit_error=True)
+        resource_manager = ResourceManager(tensor_parallel_size, 1)
+        placement_groups = resource_manager.allocate_placement_group(
+            world_size=1,
+            device_mapping=list(range(tensor_parallel_size)),
+        )
+
+        mem_profile = os.environ.get("ROLL_VLLM_LOCAL_MEM_PROFILE") == "1"
+        with _platform_mem_usage(mem_profile=mem_profile):
+            model_path = download_model(model_name)
+            model = await create_async_llm(
+                resource_placement_groups=placement_groups[0],
+                model=model_path,
+                load_format="auto",
+                block_size=16,
+                dtype="bfloat16",
+                gpu_memory_utilization=0.8,
+                tensor_parallel_size=tensor_parallel_size,
+                trust_remote_code=True,
+                distributed_executor_backend="ray",
+                disable_custom_all_reduce=True,
+                enable_sleep_mode=True,
+                enforce_eager=current_platform.is_npu(),
+            )
+
+            sampling_params = SamplingParams(
+                temperature=0.0,
+                top_p=0.99,
+                top_k=100,
+                max_tokens=64,
+            )
+
+            print(">>>>>>>>>>>>>>> test_vllm_local: base")
+            vllm_outputs = await generate_batch(
+                model=model,
+                prompts=chat_prompts,
+                sampling_params=sampling_params,
+            )
+            assert len(vllm_outputs) == len(chat_prompts)
+            print_request_output(vllm_outputs)
+
+            print(">>>>>>>>>>>>>>> test_vllm_local: offload states sleep_level_1")
+            await model.offload_states(1)
+            await model.load_states()
+            vllm_outputs = await generate_batch(
+                model=model,
+                prompts=chat_prompts,
+                sampling_params=sampling_params,
+            )
+            assert len(vllm_outputs) == len(chat_prompts)
+            print_request_output(vllm_outputs)
+
+            print(">>>>>>>>>>>>>>> test_vllm_local: offload states sleep_level_2")
+            await model.offload_states(2)
+            await model.load_states()
+            vllm_outputs = await generate_batch(
+                model=model,
+                prompts=chat_prompts,
+                sampling_params=sampling_params,
+            )
+            assert len(vllm_outputs) == len(chat_prompts)
+            print_request_output(vllm_outputs)
+    finally:
+        if model is not None:
+            try:
+                await _shutdown_async_llm(model)
+            except Exception as e:
+                print(f"Failed to shut down vLLM model cleanly: {e}")
+        if resource_manager is not None:
+            resource_manager.destroy_placement_group()
+        if ray.is_initialized():
+            ray.shutdown()
+        checkpoint_manager.shared_storage = None
+        if old_task_queue_enable is None:
+            os.environ.pop("TASK_QUEUE_ENABLE", None)
+        else:
+            os.environ["TASK_QUEUE_ENABLE"] = old_task_queue_enable
+        if old_vllm_ascend_enable_nz is None:
+            os.environ.pop("VLLM_ASCEND_ENABLE_NZ", None)
+        else:
+            os.environ["VLLM_ASCEND_ENABLE_NZ"] = old_vllm_ascend_enable_nz
 
 
 def test_vllm_with_load_offload():
-    model_path = "Qwen/Qwen2.5-7B-Instruct"
-    model_path = download_model(model_path)
-
-    prompts = [
-        "类型#上衣*材质#牛仔布*颜色#白色*风格#简约*图案#刺绣*衣样式#外套*衣款式#破洞,生成一段文案",
-        "根据关键词描述生成女装/女士精品行业连衣裙品类的发在淘宝的小红书风格的推送配文，包括标题和内容。关键词：pe。要求:1. 推送标题要体现关键词和品类特点，语言通顺，有吸引力，约10个字；2. 推送内容要语言通顺，突出关键词和品类特点，对目标受众有吸引力，长度约30字。标题:",
-        "100.25和90.75谁更大？",
-    ]
-
-    chat_prompts = []
-    for prompt in prompts:
-        chat_prompts.append(chat_format(prompt))
-
-    ray.init()
-    resource_manager = ResourceManager(8, 1)
-    placement_groups = resource_manager.allocate_placement_group(world_size=1, device_mapping=[0, 1, 2, 3])
-    sampling_params = SamplingParams(temperature=0.0, top_p=0.99, top_k=100, max_tokens=512)
-
-    MAX_NUM_OF_MEM_EVENTS_PER_SNAPSHOT: int = 100000
-    torch.cuda.memory._record_memory_history(max_entries=MAX_NUM_OF_MEM_EVENTS_PER_SNAPSHOT, stacks="python")
-
-    model = LLM(
-        resource_placement_groups=placement_groups[0],
-        model=model_path,
-        block_size=16,
-        dtype="bfloat16",
-        gpu_memory_utilization=0.8,
-        tensor_parallel_size=4,
-        trust_remote_code=True,
-        distributed_executor_backend="ray",
-        disable_custom_all_reduce=True,
-        enable_sleep_mode=True,
-    )
-
-    vllm_outputs = model.generate(
-        sampling_params=sampling_params,
-        prompts=chat_prompts,
-    )
-    print(vllm_outputs)
-
-    model.offload_states(1)
-    model.load_states()
-    vllm_outputs = model.generate(
-        sampling_params=sampling_params,
-        prompts=chat_prompts,
-    )
-    print(vllm_outputs)
-
-    model.offload_states(2)
-    model.load_states()
-    vllm_outputs = model.generate(
-        sampling_params=sampling_params,
-        prompts=chat_prompts,
-    )
-    print(vllm_outputs)
+    asyncio.run(_run_vllm_with_load_offload())
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_sequence_packing.py
+++ b/tests/utils/test_sequence_packing.py
@@ -15,7 +15,8 @@ def test_load_balance_packer():
     # 创建配置
     config = SequencePackingConfig(
         algorithm="load_balance",
-        max_packed_sequence_length=4096
+        max_packed_sequence_length_forward=4096,
+        max_packed_sequence_length_train=4096,
     )
 
     # 创建 packer
@@ -31,7 +32,7 @@ def test_load_balance_packer():
     print(f"原始数据:")
     print(f"{'=' * 80}")
     print(f"总样本数: {batch_size}")
-    print(f"最大序列长度配置: {config.max_packed_sequence_length}")
+    print(f"最大序列长度配置: {config.max_packed_sequence_length_forward}")
     print(f"\n各样本的序列长度:")
     for idx, length in enumerate(sequence_lengths):
         print(f"  样本 {idx}: {length} tokens")

--- a/tests/utils/test_taskgroups.py
+++ b/tests/utils/test_taskgroups.py
@@ -3,6 +3,9 @@ import pytest
 
 from roll.utils.taskgroups import TaskGroup
 
+pytestmark = pytest.mark.asyncio
+
+
 async def test_base():
     async def foo(result, index):
         result[index] = 2333


### PR DESCRIPTION
**Overview**

Adds Ascend NPU CI support and updates tests/runtime compatibility for NPU execution. It is opened from `UsernameFull:npu_ci` into `alibaba:main`

**Modification Notes**

This PR adds a new GitHub Actions workflow, `.github/workflows/ci-npu-test.yml`, which defines both CPU unit tests and Ascend NPU integration tests. The NPU job runs on `linux-aarch64-a3-8`, uses the `quay.io/ascend/vllm-ascend:v0.18.0-a3` container, configures the Ascend/CANN runtime, installs ROLL, vLLM-Ascend, SGLang NPU kernels, and runs NPU-compatible test suites.

It improves NPU compatibility in the runtime layer. `roll/platforms/npu.py` now resolves the vLLM Ascend `NPUWorker` dynamically across different module paths and sets NPU-specific environment variables. `roll/third_party/vllm` adds compatibility for newer vLLM versions, adjusts Ray executor resource handling for NPU, and disables sleep mode by default on NPU to avoid vLLM-Ascend KV cache issues. SGLang patch selection is also extended to support `sglang==0.5.6.post2`.

The PR updates many tests so they can run reliably in CPU and NPU CI environments. It adds NPU import/smoke tests for both vLLM and SGLang, skips heavyweight or unsupported cases under NPU CI, reduces CUDA-specific assumptions, improves Ray lifecycle cleanup, and adds better mocks/resource checks for distributed, FSDP, model loading, pipeline, dataset, and agentic tests.

It also includes small fixes: `fsdp_utils.py` now filters invalid `None` entries from FSDP wrap class configuration, and README typos/links are corrected, including `DeepSeed` to `DeepSpeed`, `StartPO` to `StarPO`, and URL-encoding a docs link.

**Result**
CI verified https://github.com/UsernameFull/ROLL/actions/runs/26950162753

<img width="1232" height="649" alt="image" src="https://github.com/user-attachments/assets/ddbcf220-3b9b-407b-b495-397160381e12" />


