### PR TITLE
[vLLM] Fix vLLM Ray executor env var compatibility

### DIFF
--- a/roll/distributed/strategy/vllm_strategy.py
+++ b/roll/distributed/strategy/vllm_strategy.py
@@ -14,7 +14,7 @@ import vllm
 from vllm import RequestOutput, SamplingParams
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import RequestOutputKind, BeamSearchParams
-from vllm.inputs.data import TokensPrompt
+from vllm.inputs import TokensPrompt
 from vllm.utils import random_uuid
 
 from roll.distributed.executor.worker import Worker

--- a/roll/third_party/vllm/ray_distributed_executor.py
+++ b/roll/third_party/vllm/ray_distributed_executor.py
@@ -7,7 +7,15 @@ from ray.runtime_env import RuntimeEnv
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from vllm.v1.executor.ray_executor import RayDistributedExecutor, RayWorkerMetaData
-from vllm.v1.executor.ray_utils import RayWorkerWrapper
+try:
+    from vllm.v1.executor.ray_utils import (
+        RayWorkerWrapper,
+        WORKER_SPECIFIC_ENV_VARS,
+    )
+except ImportError:
+    from vllm.v1.executor.ray_utils import RayWorkerWrapper
+
+    WORKER_SPECIFIC_ENV_VARS = RayDistributedExecutor.WORKER_SPECIFIC_ENV_VARS
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
@@ -177,7 +185,7 @@ class CustomRayDistributedExecutor(RayDistributedExecutor):
 
         # Environment variables to copy from driver to workers
         env_vars_to_copy = get_env_vars_to_copy(
-            exclude_vars=self.WORKER_SPECIFIC_ENV_VARS,
+            exclude_vars=WORKER_SPECIFIC_ENV_VARS,
             additional_vars=set(current_platform.additional_env_vars),
             destination="workers",
         )


### PR DESCRIPTION
Handle newer vLLM versions where `WORKER_SPECIFIC_ENV_VARS` is exported from `vllm.v1.executor.ray_utils` instead of `RayDistributedExecutor`, while keeping fallback support for older versions.