### PR TITLE
Add Mooncake DataProto transfer backend

### DIFF
--- a/docs_roll/docs/User Guides/Advanced Features/remote_batch_transfer.md
+++ b/docs_roll/docs/User Guides/Advanced Features/remote_batch_transfer.md
@@ -1,12 +1,12 @@
 # ROLL RemoteBatch and Transfer Backend
 
-The ROLL framework supports **RemoteBatch**, a lazy data transfer mechanism that decouples data storage from data consumption. By integrating with a pluggable transfer backend (e.g., **TransferQueue**), large data batches can be transferred across Ray workers without serializing the entire payload through Ray's object store. This document provides a detailed guide on how to use this feature.
+The ROLL framework supports **RemoteBatch**, a lazy data transfer mechanism that decouples data storage from data consumption. With a pluggable transfer backend, the cross-node bulk payload is stored and transferred outside Ray while Ray carries a lightweight reference. A node-scoped backend may still use the local Ray object store to hand materialized data from its node actor to a worker process. This document explains how to configure and use the available backends.
 
 ## Introduction
 
 In RL training pipelines (especially VLM and Agentic scenarios), `DataProto` batches may contain large tensors (e.g., images, multi-modal embeddings) and non-tensor data (e.g., conversation histories). Transferring these between the RolloutScheduler and training workers via Ray's default serialization has two major problems:
 
-1. **High memory overhead**: The full data is serialized and deserialized through the Ray object store, doubling peak memory usage.
+1. **High memory overhead**: The full data is serialized and deserialized through the Ray object store, creating extra copies and raising peak memory usage.
 2. **High transfer latency**: Large data batches (e.g., image data in VLM scenarios) must be fully transferred between workers, causing significant data movement overhead.
 
 **RemoteBatch** addresses these issues by storing data in an external key-value store and only passing lightweight metadata (keys/references) through Ray. The actual data is **lazily materialized** on the consumer side only when needed, and only the requested fields are fetched.
@@ -15,7 +15,7 @@ In RL training pipelines (especially VLM and Agentic scenarios), `DataProto` bat
 
 - **RemoteBatch**: An abstract base class representing a batch of data stored remotely. It supports the same slicing, indexing, selection, concatenation, and repeat operations as `TensorDict`, but defers actual data access until `materialize()` is called.
 - **RowRemoteBatch**: A concrete `RemoteBatch` where data is stored with **row IDs** as keys. Each row (sample) has a unique ID, and the transfer backend stores/retrieves data at row granularity. This is used by the **TransferQueue** backend.
-- **ColumnRemoteBatch**: A concrete `RemoteBatch` where data is stored with **column IDs** as keys (one key per field/column). This is used by the **RayMemoryStore** backend.
+- **ColumnRemoteBatch**: A concrete `RemoteBatch` where fields share column-oriented metadata. It is used by the **RayMemoryStore** and **Mooncake** backends.
 - **BatchProxy**: A proxy object that wraps both a local `TensorDict` (or `dict`) and a `RemoteBatch`, supporting transparent fallback lookup. When a key is accessed, it first checks the local batch and then falls back to the remote batch.
 - **Transfer Backend**: A pluggable storage backend responsible for `put`, `get`, and `delete` operations. Currently supported backends:
   - `None` (Dummy): No remote storage; data stays local (default).
@@ -24,8 +24,8 @@ In RL training pipelines (especially VLM and Agentic scenarios), `DataProto` bat
 
 ### How It Works
 
-1. **Upload (`to_remote`)**: The `DataProto.to_remote()` class method converts a local `DataProto` into a remote-backed `DataProto`. It uploads all tensor and non-tensor fields to the transfer backend and returns a new `DataProto` with a `RemoteBatch` reference (no local data).
-2. **Transfer**: The lightweight `DataProto` (containing only `RemoteBatch` metadata) is transferred between workers via Ray. Since the metadata is small, serialization is fast.
+1. **Upload (`to_remote`)**: The `DataProto.to_remote()` class method converts a local `DataProto` into a remote-backed `DataProto`. It uploads all tensor and non-tensor fields and returns a new `DataProto` with a `RemoteBatch` reference. The producing process may retain a local cache; serialized consumers receive the lightweight reference and materialize data on demand.
+2. **Transfer**: Ray carries the `RemoteBatch` reference together with the original lightweight `meta_info`. Bulk `batch` and `non_tensor_batch` fields remain in the transfer backend.
 3. **Materialize (lazy)**: On the consumer side, when specific fields are needed, `RemoteBatch.materialize(fields)` is called to fetch only the requested columns from the backend. The fetched data is cached locally for subsequent accesses.
 4. **Drop**: After the batch is consumed, `RemoteBatch.drop()` can be called to delete the data from the backend store.
 
@@ -42,29 +42,147 @@ transfer_backend:
         num_data_storage_units: 16
 ```
 
-Mooncake can be enabled as an optional backend:
+### Mooncake
+
+#### 1. Install Mooncake
+
+ROLL requires Mooncake's unified DataProto API, schema support, GET-result release, and the typed-ragged ndarray layout. Use a Mooncake main wheel built from commit `86b21ccf` or later. The following commands follow Mooncake's source-build flow:
+
+```bash
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+git checkout 86b21ccf
+git submodule update --init --recursive
+sudo bash dependencies.sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF
+cmake --build build -j
+PYTHON_VERSION="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYTHON_VERSION="${PYTHON_VERSION}" BUILD_DIR=build bash scripts/build_wheel.sh "${PYTHON_VERSION}" dist
+python -m pip install dist/mooncake_transfer_engine-*.whl
+```
+
+#### 2. Start the metadata service
+
+Mooncake metadata infrastructure must be reachable before ROLL starts. ROLL initializes Store clients but does not start or manage `mooncake_master`, etcd, or Redis. For the standalone master configuration, start it on a reachable host:
+
+```bash
+mooncake_master --rpc_address=<master-ip> --rpc_port=<master-port>
+```
+
+Use the deployment instructions from Mooncake when etcd or Redis provides the metadata service.
+
+#### 3. Configure the ROLL cluster
+
+ROLL shares one `backend_config` across the cluster. Keep common settings in YAML:
 
 ```yaml
 transfer_backend:
   backend_name: Mooncake
   backend_config:
     client_scope: node
-    local_hostname: 192.168.0.1
+    metadata_server: P2PHANDSHAKE
+    global_segment_size: 8589934592
+    local_buffer_size: 8589934592
+    protocol: tcp
+    master_server_addr: <master-host:port>
+```
+
+For RDMA, change the shared protocol:
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
     metadata_server: P2PHANDSHAKE
     global_segment_size: 8589934592
     local_buffer_size: 8589934592
     protocol: rdma
-    rdma_devices: erdma_0
-    master_server_addr: 192.168.0.1:50051
+    master_server_addr: <master-host:port>
 ```
+
+Set node-local values in each node's environment. `MOONCAKE_DEVICE` is required only for RDMA:
+
+```bash
+export MOONCAKE_LOCAL_HOSTNAME=<this-node-ip>
+export MOONCAKE_DEVICE=<this-node-rdma-device>
+```
+
+`field_schemas` is optional. ROLL converts each entry to a Mooncake `FieldSchema` and passes the mapping to `put(type="dataproto")`. When it is omitted, Mooncake infers the representation from the field values. Supplying schemas for known object-array fields is recommended because it keeps the selected representation stable across batches, including batches whose sampled values are all null. For example, a workload with an `int64` ragged field can declare:
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    field_schemas:
+      token_rows:
+        codec: typed_ragged
+        nullable: true
+        metadata:
+          section: non_tensor_batch
+          dtype: int64
+```
+
+Replace `token_rows` and its schema with fields from the workload. Multimodal processor outputs can have model-specific keys, so their schema must match the actual ROLL collator output instead of assuming a fixed `image` member.
+
+Mooncake-specific `backend_config` options are:
+
+| Option | Description |
+| --- | --- |
+| `client_scope` | `node` reuses one Mooncake client and BufferPool per Ray node. It is the only supported scope. |
+| `key_prefix` | Prefix used for Mooncake Store keys. The default is `roll`. |
+| `transfer_policy` | Optional arguments for Mooncake `BundleTransferPolicy`, such as `copy_mode`, `put_mode`, and `max_inflight_put`. |
+| `field_schemas` | Optional per-field `codec`, `nullable`, and `metadata` settings. Unknown schema options fail during client initialization. |
+| Store setup fields | `local_hostname`, `metadata_server`, segment sizes, `protocol`, RDMA device, and metadata backend address. |
+
+Store setup can also be supplied through `setup_args` / `setup_kwargs`, or through the standard Mooncake environment variables:
+
+```bash
+export MOONCAKE_MASTER=<master-host:port>
+export MOONCAKE_LOCAL_HOSTNAME=<worker-ip>
+export MOONCAKE_TE_META_DATA_SERVER=P2PHANDSHAKE
+export MOONCAKE_PROTOCOL=rdma  # or tcp
+export MOONCAKE_DEVICE=<rdma-device>
+```
+
+When environment variables provide the node-specific Store settings, the shared ROLL configuration only needs the backend policy:
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
+    key_prefix: roll
+    transfer_policy:
+      copy_mode: auto
+```
+
+Run the existing ROLL training entry point with the directory and basename of the YAML file that contains this configuration:
+
+```bash
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
+python examples/start_rlvr_pipeline.py \
+  --config_path <config-directory> \
+  --config_name <config-filename-without-yaml>
+```
+
+The other ROLL pipeline launchers accept the same configuration fields. A successful startup logs `Initialized Mooncake transfer backend` on the driver and `Initialized transfer client` in each process that first uses RemoteBatch.
+
+#### 4. Data and buffer lifetime
+
+Mooncake stores each uploaded ROLL DataProto fragment as a structured object. A logical DataProto may reference several such objects after union or concatenation. Tensor fields remain in the `batch` section, NumPy fields remain in `non_tensor_batch`, and ROLL's original `meta_info` continues through the existing lightweight control path. `ColumnRemoteBatch.materialize(fields)` requests only the selected fields, while `ColumnRemoteBatch.drop()` removes the referenced remote objects.
+
+The Mooncake GET lease belongs to the node actor. After placing a serializable view in the local Ray object store, the actor releases the BufferPool lease; a failed release is retried by a later Mooncake operation. Selections, slices, unions, and concatenations retain the original row order.
+
+Local aliases share cleanup state, but ROLL does not provide a cross-process reference counter or invalidation broadcast. The framework must designate one cleanup path and call `drop()` only after every consumer has finished. `drop()` removes the physical remote objects; other processes holding old handles are not notified automatically and must not use them afterward.
 
 - `backend_name`: The name of the transfer backend to use.
   - `null` (default): Disables remote transfer; all data stays local. This is the default behavior when `transfer_backend` is not configured.
   - `TransferQueue`: Uses the TransferQueue library for high-performance data transfer.
-  - `Mooncake`: Uses Mooncake structured `DataProto` transfer. This backend supports tensor batch fields, `non_tensor_batch`, and `meta_info`, and is intended for large multi-node rollout payloads.
+  - `Mooncake`: Uses Mooncake structured `DataProto` transfer for tensor batch fields and `non_tensor_batch`. The original `meta_info` remains on ROLL's lightweight control path.
 - `backend_config`: Backend-specific configuration dictionary.
   - For TransferQueue, this corresponds to the TransferQueue initialization config.
-  - For Mooncake, this config can be passed explicitly as shown above, or loaded from Mooncake environment configuration.
+  - For Mooncake, use the explicit configuration or standard environment variables described above.
   - `backend.SimpleStorage.num_data_storage_units`: The number of storage units to shard data across. Can be configured based on the number of CPU cores and cluster nodes. `msgpack` serialization has a maximum 4 GB limit per object, so larger data transfers require more storage units to shard `non_tensor_batch` into smaller pieces.
 
 ### Agentic Pipeline Optimization
@@ -85,7 +203,7 @@ Manually calling `to_remote` inside environment workers is incompatible with fil
 | Backend | Status | Notes |
 |---------|--------|-------|
 | TransferQueue | End-to-end tested | Production-ready. Tested across RLVR, VLM, and Agentic pipelines. |
-| Mooncake | Experimental | Optional structured `DataProto` backend for tensor, non-tensor, metadata, and multimodal rollout payloads. |
+| Mooncake | Experimental | Optional structured `DataProto` backend for tensor, non-tensor, and multimodal rollout payloads. |
 | RayMemoryStore | Illustration only | Not tested. Provided as a reference implementation for the `ColumnRemoteBatch` pattern. |
 
 ### TODO

--- a/docs_roll/docs/User Guides/Advanced Features/remote_batch_transfer.md
+++ b/docs_roll/docs/User Guides/Advanced Features/remote_batch_transfer.md
@@ -20,6 +20,7 @@ In RL training pipelines (especially VLM and Agentic scenarios), `DataProto` bat
 - **Transfer Backend**: A pluggable storage backend responsible for `put`, `get`, and `delete` operations. Currently supported backends:
   - `None` (Dummy): No remote storage; data stays local (default).
   - `TransferQueue`: Uses the [TransferQueue](https://github.com/kvcache-ai/TransferQueue) library for high-performance distributed key-value transfer.
+  - `Mooncake`: Uses Mooncake as an optional structured `DataProto` transfer backend for large tensor, non-tensor, and multimodal rollout payloads.
 
 ### How It Works
 
@@ -41,10 +42,29 @@ transfer_backend:
         num_data_storage_units: 16
 ```
 
+Mooncake can be enabled as an optional backend:
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
+    local_hostname: 192.168.0.1
+    metadata_server: P2PHANDSHAKE
+    global_segment_size: 8589934592
+    local_buffer_size: 8589934592
+    protocol: rdma
+    rdma_devices: erdma_0
+    master_server_addr: 192.168.0.1:50051
+```
+
 - `backend_name`: The name of the transfer backend to use.
   - `null` (default): Disables remote transfer; all data stays local. This is the default behavior when `transfer_backend` is not configured.
   - `TransferQueue`: Uses the TransferQueue library for high-performance data transfer.
-- `backend_config`: Backend-specific configuration dictionary. For TransferQueue, this corresponds to the TransferQueue initialization config.
+  - `Mooncake`: Uses Mooncake structured `DataProto` transfer. This backend supports tensor batch fields, `non_tensor_batch`, and `meta_info`, and is intended for large multi-node rollout payloads.
+- `backend_config`: Backend-specific configuration dictionary.
+  - For TransferQueue, this corresponds to the TransferQueue initialization config.
+  - For Mooncake, this config can be passed explicitly as shown above, or loaded from Mooncake environment configuration.
   - `backend.SimpleStorage.num_data_storage_units`: The number of storage units to shard data across. Can be configured based on the number of CPU cores and cluster nodes. `msgpack` serialization has a maximum 4 GB limit per object, so larger data transfers require more storage units to shard `non_tensor_batch` into smaller pieces.
 
 ### Agentic Pipeline Optimization
@@ -65,6 +85,7 @@ Manually calling `to_remote` inside environment workers is incompatible with fil
 | Backend | Status | Notes |
 |---------|--------|-------|
 | TransferQueue | End-to-end tested | Production-ready. Tested across RLVR, VLM, and Agentic pipelines. |
+| Mooncake | Experimental | Optional structured `DataProto` backend for tensor, non-tensor, metadata, and multimodal rollout payloads. |
 | RayMemoryStore | Illustration only | Not tested. Provided as a reference implementation for the `ColumnRemoteBatch` pattern. |
 
 ### TODO

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/remote_batch_transfer.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/remote_batch_transfer.md
@@ -1,12 +1,12 @@
 # ROLL RemoteBatch 与传输后端
 
-ROLL 框架支持 **RemoteBatch**，一种惰性数据传输机制，将数据存储与数据消费解耦。通过集成可插拔的传输后端（如 **TransferQueue**），大数据批次可以在 Ray Worker 之间传输，而无需通过 Ray 的 Object Store 序列化整个数据负载。本文档详细介绍如何使用这一功能。
+ROLL 框架支持 **RemoteBatch**，一种将数据存储与数据消费解耦的惰性传输机制。使用可插拔传输后端时，跨节点的大数据 payload 由后端存储和传输，Ray 只携带轻量引用。node scope 后端仍可能使用本机 Ray Object Store，在 node actor 和 Worker 进程之间交接物化后的数据。本文档介绍各后端的配置和使用方法。
 
 ## 简介
 
 在 RL 训练流水线中（特别是 VLM 和 Agentic 场景），`DataProto` 批次可能包含大型张量（如图片、多模态 embedding）和非张量数据（如对话历史）。通过 Ray 默认的序列化方式在 RolloutScheduler 和训练 Worker 之间传输这些数据存在以下问题：
 
-1. **内存开销高**：完整数据需要通过 Ray Object Store 进行序列化和反序列化，峰值内存使用量翻倍。
+1. **内存开销高**：完整数据需要通过 Ray Object Store 进行序列化和反序列化，会产生额外副本并抬高峰值内存。
 2. **传输延迟大**：大数据批次（如 VLM 场景中的图片数据）需要在 Worker 之间完整传输，导致数据搬运耗时显著。
 
 **RemoteBatch** 通过将数据存储在外部键值存储中，仅通过 Ray 传递轻量级元数据（键/引用）来解决这些问题。实际数据在消费侧按需**惰性物化（lazily materialized）**，且仅获取请求的字段。
@@ -15,7 +15,7 @@ ROLL 框架支持 **RemoteBatch**，一种惰性数据传输机制，将数据�
 
 - **RemoteBatch**：表示远程存储数据批次的抽象基类。它支持与 `TensorDict` 相同的切片、索引、选择、拼接和重复操作，但将实际数据访问延迟到调用 `materialize()` 时执行。
 - **RowRemoteBatch**：以**行 ID** 为键存储数据的具体 `RemoteBatch` 实现。每行（样本）有一个唯一 ID，传输后端以行粒度存储/检索数据。**TransferQueue** 后端使用此实现。
-- **ColumnRemoteBatch**：以**列 ID** 为键存储数据的具体 `RemoteBatch` 实现（每个字段/列一个键）。**RayMemoryStore** 后端使用此实现。
+- **ColumnRemoteBatch**：使用列式字段元数据的 `RemoteBatch` 实现。**RayMemoryStore** 和 **Mooncake** 后端使用此实现。
 - **BatchProxy**：包装本地 `TensorDict`（或 `dict`）和 `RemoteBatch` 的代理对象，支持透明的回退查找。访问键时，先检查本地 batch，再回退到远程 batch。
 - **传输后端（Transfer Backend）**：负责 `put`、`get` 和 `delete` 操作的可插拔存储后端。目前支持的后端：
   - `None`（Dummy）：无远程存储，数据保留在本地（默认）。
@@ -24,8 +24,8 @@ ROLL 框架支持 **RemoteBatch**，一种惰性数据传输机制，将数据�
 
 ### 工作原理
 
-1. **上传 (`to_remote`)**：`DataProto.to_remote()` 类方法将本地 `DataProto` 转换为远程支持的 `DataProto`。它将所有张量和非张量字段上传到传输后端，并返回一个包含 `RemoteBatch` 引用的新 `DataProto`（无本地数据）。
-2. **传输**：轻量级的 `DataProto`（仅包含 `RemoteBatch` 元数据）通过 Ray 在 Worker 之间传输。由于元数据很小，序列化速度很快。
+1. **上传 (`to_remote`)**：`DataProto.to_remote()` 类方法将本地 `DataProto` 转换为远程支持的 `DataProto`。它将所有张量和非张量字段上传到传输后端，并返回一个包含 `RemoteBatch` 引用的新 `DataProto`。生产进程可以保留本地 cache；序列化后的消费端只收到轻量引用，并按需物化数据。
+2. **传输**：Ray 传递 `RemoteBatch` 引用和原有的轻量 `meta_info`，体积较大的 `batch` 与 `non_tensor_batch` 字段保留在传输后端。
 3. **物化（惰性）**：在消费侧，当需要特定字段时，调用 `RemoteBatch.materialize(fields)` 仅从后端获取请求的列。获取的数据会缓存在本地供后续访问。
 4. **清理（Drop）**：数据消费完成后，可以调用 `RemoteBatch.drop()` 从后端存储中删除数据。
 
@@ -42,29 +42,147 @@ transfer_backend:
         num_data_storage_units: 16
 ```
 
-Mooncake 可以作为可选 backend 启用：
+### Mooncake
+
+#### 1. 安装 Mooncake
+
+ROLL 需要 Mooncake 提供统一 DataProto API、schema 支持、GET 结果显式释放能力和 typed-ragged ndarray layout。请使用基于 `86b21ccf` 或更新 main commit 构建的 Mooncake wheel。下面的命令遵循 Mooncake 的源码构建流程：
+
+```bash
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+git checkout 86b21ccf
+git submodule update --init --recursive
+sudo bash dependencies.sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF
+cmake --build build -j
+PYTHON_VERSION="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYTHON_VERSION="${PYTHON_VERSION}" BUILD_DIR=build bash scripts/build_wheel.sh "${PYTHON_VERSION}" dist
+python -m pip install dist/mooncake_transfer_engine-*.whl
+```
+
+#### 2. 启动 metadata 服务
+
+启动 ROLL 前，需要保证各节点能够访问 Mooncake metadata 服务。ROLL 只负责初始化 Store client，不负责启动或管理 `mooncake_master`、etcd 或 Redis。使用独立 master 时，在一个所有节点可访问的地址启动：
+
+```bash
+mooncake_master --rpc_address=<master-ip> --rpc_port=<master-port>
+```
+
+使用 etcd 或 Redis 时，请按 Mooncake 的部署说明准备 metadata 服务。
+
+#### 3. 配置 ROLL 集群
+
+ROLL 会在集群内共享同一份 `backend_config`，因此 YAML 只放公共配置：
 
 ```yaml
 transfer_backend:
   backend_name: Mooncake
   backend_config:
     client_scope: node
-    local_hostname: 192.168.0.1
+    metadata_server: P2PHANDSHAKE
+    global_segment_size: 8589934592
+    local_buffer_size: 8589934592
+    protocol: tcp
+    master_server_addr: <master-host:port>
+```
+
+使用 RDMA 时，只需修改共享的传输协议：
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
     metadata_server: P2PHANDSHAKE
     global_segment_size: 8589934592
     local_buffer_size: 8589934592
     protocol: rdma
-    rdma_devices: erdma_0
-    master_server_addr: 192.168.0.1:50051
+    master_server_addr: <master-host:port>
 ```
+
+本机地址和 RDMA 设备属于节点本地配置，需要在每个节点分别设置。TCP 不需要 `MOONCAKE_DEVICE`：
+
+```bash
+export MOONCAKE_LOCAL_HOSTNAME=<本机-ip>
+export MOONCAKE_DEVICE=<本机-rdma-device>
+```
+
+`field_schemas` 是可选配置。ROLL 会把每个条目转换成 Mooncake `FieldSchema`，并传给 `put(type="dataproto")`。未配置时，Mooncake 根据字段的实际值推断数据表示。对于结构已知的 object-array 字段，建议由框架提供 schema，这样不同 batch 会稳定使用同一种表示方式，全空采样也不会改变编码路径。例如，一个 `int64` ragged 字段可以这样声明：
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    field_schemas:
+      token_rows:
+        codec: typed_ragged
+        nullable: true
+        metadata:
+          section: non_tensor_batch
+          dtype: int64
+```
+
+实际使用时，需要把 `token_rows` 和 schema 替换成当前 workload 的字段。多模态 processor 输出的 key 由模型决定，因此 schema 必须匹配 ROLL collator 的实际输出，不能假定只有固定的 `image` 成员。
+
+Mooncake 使用的 `backend_config` 选项如下：
+
+| 配置项 | 说明 |
+| --- | --- |
+| `client_scope` | `node` 在每个 Ray 节点复用一个 Mooncake client 和 BufferPool，也是当前唯一支持的 scope。 |
+| `key_prefix` | Mooncake Store key 的前缀，默认为 `roll`。 |
+| `transfer_policy` | 可选的 Mooncake `BundleTransferPolicy` 参数，例如 `copy_mode`、`put_mode` 和 `max_inflight_put`。 |
+| `field_schemas` | 可选的字段级 `codec`、`nullable` 和 `metadata`。无法识别的 schema 参数会在 client 初始化时直接报错。 |
+| Store 初始化参数 | 包括本机地址、metadata server、segment 大小、传输协议、RDMA 设备和 metadata backend 地址。 |
+
+Store 参数也可以通过 `setup_args` / `setup_kwargs` 传入，或者使用 Mooncake 标准环境变量：
+
+```bash
+export MOONCAKE_MASTER=<master-host:port>
+export MOONCAKE_LOCAL_HOSTNAME=<worker-ip>
+export MOONCAKE_TE_META_DATA_SERVER=P2PHANDSHAKE
+export MOONCAKE_PROTOCOL=rdma  # 或 tcp
+export MOONCAKE_DEVICE=<rdma-device>
+```
+
+如果节点相关的 Store 参数由环境变量提供，共享的 ROLL 配置只需要包含 backend policy：
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
+    key_prefix: roll
+    transfer_policy:
+      copy_mode: auto
+```
+
+假设上述配置位于某个 YAML 文件中，可以使用配置目录和不带 `.yaml` 的文件名启动：
+
+```bash
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
+python examples/start_rlvr_pipeline.py \
+  --config_path <config-directory> \
+  --config_name <config-filename-without-yaml>
+```
+
+其他 ROLL pipeline launcher 使用相同的配置字段。初始化成功后，Driver 日志中会出现 `Initialized Mooncake transfer backend`，首次使用 RemoteBatch 的进程会输出 `Initialized transfer client`。
+
+#### 4. 数据和 BufferPool 生命周期
+
+Mooncake 将每次上传的 ROLL DataProto fragment 保存为一个结构化对象；经过 union 或 concat 后，一个逻辑 DataProto 可以引用多个物理对象。tensor 字段保留在 `batch` section，NumPy 字段保留在 `non_tensor_batch`，ROLL 原有的 `meta_info` 继续沿用轻量控制路径传递。`ColumnRemoteBatch.materialize(fields)` 只读取指定字段，`ColumnRemoteBatch.drop()` 负责删除这些远端对象。
+
+Mooncake GET lease 属于 node actor。actor 将可序列化的数据视图写入本机 Ray Object Store 后释放 BufferPool lease；如果释放失败，会在后续 Mooncake 操作中重试。select、slice、union 和 concat 会保留原始 row 顺序。
+
+同一进程中的派生视图共享 cleanup 状态，但 ROLL 不提供跨进程引用计数或失效通知。框架必须指定唯一的清理路径，并在所有 consumer 完成后调用 `drop()`。该调用会删除物理远端对象；其他进程持有的旧 handle 不会自动失效，但之后不能再使用。
 
 - `backend_name`：要使用的传输后端名称。
   - `null`（默认）：禁用远程传输，所有数据保留在本地。未配置 `transfer_backend` 时的默认行为。
   - `TransferQueue`：使用 TransferQueue 库进行高性能数据传输。
-  - `Mooncake`：使用 Mooncake 结构化 `DataProto` 传输，支持 tensor batch、`non_tensor_batch` 和 `meta_info`，适用于大规模多节点 rollout payload。
+  - `Mooncake`：使用 Mooncake 结构化 `DataProto` 传输 tensor batch 和 `non_tensor_batch`；原有 `meta_info` 仍沿用 ROLL 的轻量控制路径。
 - `backend_config`：后端特定的配置字典。
   - 对于 TransferQueue，对应 TransferQueue 的初始化配置。
-  - 对于 Mooncake，可以像上例一样显式配置，也可以从 Mooncake 环境配置中加载。
+  - 对于 Mooncake，使用上面介绍的显式配置或标准环境变量。
   - `backend.SimpleStorage.num_data_storage_units`：数据分片的存储单元数量。可以根据 CPU 核数和集群节点数进行配置。`msgpack` 序列化单个对象有最大 4GB 的限制，因此传输大数据时需要更多的 storage unit 来将 `non_tensor_batch` 分片成更小的块。
 
 ### Agentic Pipeline 优化
@@ -85,7 +203,7 @@ output_queue.put(batch)
 | 后端 | 状态 | 说明 |
 |------|------|------|
 | TransferQueue | 端到端已测试 | 生产可用。已在 RLVR、VLM 和 Agentic Pipeline 中测试通过。 |
-| Mooncake | 实验性 | 可选的结构化 `DataProto` backend，支持 tensor、non-tensor、metadata 和多模态 rollout payload。 |
+| Mooncake | 实验性 | 可选的结构化 `DataProto` backend，支持 tensor、non-tensor 和多模态 rollout payload。 |
 | RayMemoryStore | 仅作示例 | 未经测试。仅作为 `ColumnRemoteBatch` 模式的参考实现提供。 |
 
 ### TODO
@@ -93,4 +211,3 @@ output_queue.put(batch)
 - 避免在 Trainer 侧全量物化：当前 Trainer 会对整个 RemoteBatch 调用 `materialize()`，后续可优化为仅物化实际需要的字段，避免不必要的数据拉取。
 - Driver 侧选择性预取：在 Pipeline Driver 中实现选择性 prefetch，根据后续步骤的需求批量预取所需字段，减少多次小规模拉取的开销。
 - Scheduler 对被 filter 的 RemoteBatch 自动调用 `drop()`，避免远程存储泄漏。
-

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/remote_batch_transfer.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/remote_batch_transfer.md
@@ -20,6 +20,7 @@ ROLL 框架支持 **RemoteBatch**，一种惰性数据传输机制，将数据�
 - **传输后端（Transfer Backend）**：负责 `put`、`get` 和 `delete` 操作的可插拔存储后端。目前支持的后端：
   - `None`（Dummy）：无远程存储，数据保留在本地（默认）。
   - `TransferQueue`：使用 [TransferQueue](https://github.com/kvcache-ai/TransferQueue) 库进行高性能分布式键值传输。
+  - `Mooncake`：作为可选的结构化 `DataProto` 传输后端，用于大规模 tensor、non-tensor 和多模态 rollout payload。
 
 ### 工作原理
 
@@ -41,10 +42,29 @@ transfer_backend:
         num_data_storage_units: 16
 ```
 
+Mooncake 可以作为可选 backend 启用：
+
+```yaml
+transfer_backend:
+  backend_name: Mooncake
+  backend_config:
+    client_scope: node
+    local_hostname: 192.168.0.1
+    metadata_server: P2PHANDSHAKE
+    global_segment_size: 8589934592
+    local_buffer_size: 8589934592
+    protocol: rdma
+    rdma_devices: erdma_0
+    master_server_addr: 192.168.0.1:50051
+```
+
 - `backend_name`：要使用的传输后端名称。
   - `null`（默认）：禁用远程传输，所有数据保留在本地。未配置 `transfer_backend` 时的默认行为。
   - `TransferQueue`：使用 TransferQueue 库进行高性能数据传输。
-- `backend_config`：后端特定的配置字典。对于 TransferQueue，对应 TransferQueue 的初始化配置。
+  - `Mooncake`：使用 Mooncake 结构化 `DataProto` 传输，支持 tensor batch、`non_tensor_batch` 和 `meta_info`，适用于大规模多节点 rollout payload。
+- `backend_config`：后端特定的配置字典。
+  - 对于 TransferQueue，对应 TransferQueue 的初始化配置。
+  - 对于 Mooncake，可以像上例一样显式配置，也可以从 Mooncake 环境配置中加载。
   - `backend.SimpleStorage.num_data_storage_units`：数据分片的存储单元数量。可以根据 CPU 核数和集群节点数进行配置。`msgpack` 序列化单个对象有最大 4GB 的限制，因此传输大数据时需要更多的 storage unit 来将 `non_tensor_batch` 分片成更小的块。
 
 ### Agentic Pipeline 优化
@@ -65,6 +85,7 @@ output_queue.put(batch)
 | 后端 | 状态 | 说明 |
 |------|------|------|
 | TransferQueue | 端到端已测试 | 生产可用。已在 RLVR、VLM 和 Agentic Pipeline 中测试通过。 |
+| Mooncake | 实验性 | 可选的结构化 `DataProto` backend，支持 tensor、non-tensor、metadata 和多模态 rollout payload。 |
 | RayMemoryStore | 仅作示例 | 未经测试。仅作为 `ColumnRemoteBatch` 模式的参考实现提供。 |
 
 ### TODO

--- a/roll/distributed/scheduler/protocol.py
+++ b/roll/distributed/scheduler/protocol.py
@@ -8,20 +8,20 @@ import copy
 import os
 import uuid
 from collections import defaultdict
-from typing import Dict, List, Optional, Union, Set
+from typing import Dict, List, Optional, Set, Union
 
 import numpy as np
 import ray
 import tensordict
 import torch
+from codetiming import Timer
 from tensordict import TensorDict
 from torch.utils.data import DataLoader
-from codetiming import Timer
 
-from roll.distributed.scheduler.remote_protocol import RemoteBatch, BatchProxy
 from roll.distributed.scheduler import transfer_backend
-from roll.utils.functionals import union_two_dict, divide_by_chunk_size
+from roll.distributed.scheduler.remote_protocol import BatchProxy, RemoteBatch
 from roll.platforms import current_platform
+from roll.utils.functionals import divide_by_chunk_size, union_two_dict
 from roll.utils.logging import get_logger
 
 logger = get_logger()
@@ -128,6 +128,7 @@ def collate_fn(x: list["DataProto"]):
     data = DataProto.concat(x)
     data.meta_info = meta_info
     return data
+
 
 def move_tensors_to_device(data, device):
     if isinstance(data, dict):
@@ -351,9 +352,13 @@ class DataProto:
 
         if len(self._non_tensor_batch) != 0:
             # TODO: we can actually lift this restriction if needed
-            assert len(self._batch.batch_size) == 1, "only support num_batch_dims=1 when non_tensor_batch is not empty."
+            assert (
+                len(self._batch.batch_size) == 1
+            ), "only support num_batch_dims=1 when non_tensor_batch is not empty."
 
-            assert existing_keys.isdisjoint(self._non_tensor_batch.keys()), "batch and non_tensor_batch cannot have overlapping keys"
+            assert existing_keys.isdisjoint(
+                self._non_tensor_batch.keys()
+            ), "batch and non_tensor_batch cannot have overlapping keys"
             existing_keys.update(self._non_tensor_batch.keys())
 
             batch_size = self._batch.batch_size[0]
@@ -454,11 +459,12 @@ class DataProto:
         Create a deep copy of this DataProto, including tensors,
         non-tensor data, and meta_info.
 
-        The new DataProto will share no underlying storage with the original.
+        Local batch data is copied. A remote-backed clone keeps the same remote
+        handles and cleanup lifetime as the original.
 
         Returns:
             DataProto: A new DataProto instance with the same content but
-                       independent memory.
+                       independent local memory.
         """
         # Copy batch
         batch_copy = self._batch.clone() if self._batch is not None else None
@@ -473,10 +479,7 @@ class DataProto:
 
         # Return new DataProto instance
         return DataProto(
-            batch=batch_copy,
-            non_tensor_batch=non_tensor_copy,
-            remote_batch=remote_batch_copy,
-            meta_info=meta_copy
+            batch=batch_copy, non_tensor_batch=non_tensor_copy, remote_batch=remote_batch_copy, meta_info=meta_copy
         )
 
     def update(self, other: dict):
@@ -506,7 +509,9 @@ class DataProto:
         Returns:
             DataProto: the DataProto with the selected batch_keys and meta_info_keys
         """
-        assert set(batch_keys).isdisjoint(non_tensor_batch_keys), "batch_keys and non_tensor_batch_keys cannot be overlapping"
+        assert set(batch_keys).isdisjoint(
+            non_tensor_batch_keys
+        ), "batch_keys and non_tensor_batch_keys cannot be overlapping"
 
         if batch_keys is not None:
             batch_keys = tuple(batch_keys)
@@ -516,7 +521,9 @@ class DataProto:
             sub_batch = self._batch
 
         if non_tensor_batch_keys is not None:
-            non_tensor_batch = {key: val for key, val in self._non_tensor_batch.items() if key in non_tensor_batch_keys}
+            non_tensor_batch = {
+                key: val for key, val in self._non_tensor_batch.items() if key in non_tensor_batch_keys
+            }
         else:
             non_tensor_batch_keys = []
             non_tensor_batch = self._non_tensor_batch
@@ -638,7 +645,9 @@ class DataProto:
             remote_batch = None
 
         # Return a new DataProto object
-        return type(self)(batch=sliced_batch, non_tensor_batch=sliced_non_tensor, remote_batch=remote_batch, meta_info=self.meta_info)
+        return type(self)(
+            batch=sliced_batch, non_tensor_batch=sliced_non_tensor, remote_batch=remote_batch, meta_info=self.meta_info
+        )
 
     def pop(self, batch_keys=None, non_tensor_batch_keys=None, meta_info_keys=None) -> "DataProto":
         """Pop a subset of the DataProto via `batch_keys` and `meta_info_keys`
@@ -655,7 +664,9 @@ class DataProto:
             meta_info_keys = []
         if non_tensor_batch_keys is None:
             non_tensor_batch_keys = []
-        assert set(batch_keys).isdisjoint(non_tensor_batch_keys), "batch_keys and non_tensor_batch_keys cannot be overlapping"
+        assert set(batch_keys).isdisjoint(
+            non_tensor_batch_keys
+        ), "batch_keys and non_tensor_batch_keys cannot be overlapping"
         batch_keys = self.validate_input(batch_keys)
         non_tensor_batch_keys = self.validate_input(non_tensor_batch_keys)
         meta_info_keys = self.validate_input(meta_info_keys)
@@ -779,7 +790,9 @@ class DataProto:
         elif self._remote_batch is None:
             self._remote_batch = other._remote_batch
         if self._remote_batch is not None:
-            existing_keys = set(self._batch.keys() if self._batch is not None else []) | set(self._non_tensor_batch.keys())
+            existing_keys = set(self._batch.keys() if self._batch is not None else []) | set(
+                self._non_tensor_batch.keys()
+            )
             for key in existing_keys:
                 # use local batch as golden source when key conflict
                 if key in self._remote_batch:
@@ -804,7 +817,9 @@ class DataProto:
             Iterator: an iterator that yields a mini-batch data at a time. The total number of iteration steps is
             ``self._batch.batch_size * epochs // mini_batch_size``
         """
-        assert self._batch.batch_size[0] % mini_batch_size == 0, f"{self._batch.batch_size[0]} % {mini_batch_size} != 0"
+        assert (
+            self._batch.batch_size[0] % mini_batch_size == 0
+        ), f"{self._batch.batch_size[0]} % {mini_batch_size} != 0"
         # we can directly create a dataloader from TensorDict
         if dataloader_kwargs is None:
             dataloader_kwargs = {}
@@ -883,9 +898,9 @@ class DataProto:
 
     @staticmethod
     def concat(
-            data: List["DataProto"],
-            *,
-            global_keys: Optional[Set[str]] = None,
+        data: List["DataProto"],
+        *,
+        global_keys: Optional[Set[str]] = None,
     ) -> "DataProto":
         """
         Concatenate a list of DataProto objects.
@@ -915,9 +930,7 @@ class DataProto:
         batch_lst = [d._batch for d in data if d._batch is not None]
         new_batch = torch.cat(batch_lst, dim=0) if batch_lst else None
 
-        non_tensor_batch = list_of_dict_to_dict_of_list(
-            [d._non_tensor_batch for d in data]
-        )
+        non_tensor_batch = list_of_dict_to_dict_of_list([d._non_tensor_batch for d in data])
         for k, v in non_tensor_batch.items():
             non_tensor_batch[k] = custom_np_concatenate(v)
 
@@ -1076,9 +1089,9 @@ class DataProto:
 
     @staticmethod
     def materialize_concat(
-            data_refs: Union[List[ray.ObjectRef], ray.ObjectRef, List["ObjectRefWrap"]],
-            *,
-            global_keys: Optional[Set[str]] = None,
+        data_refs: Union[List[ray.ObjectRef], ray.ObjectRef, List["ObjectRefWrap"]],
+        *,
+        global_keys: Optional[Set[str]] = None,
     ) -> "DataProto":
         """
         Fetch a collection of DataProto objects from Ray ObjectRef(s) and concatenate
@@ -1118,36 +1131,52 @@ class DataProto:
         return DataProto.concat(data, global_keys=global_keys)
 
     @classmethod
-    def to_remote(cls, data: "DataProto", partition = "train_eval", *, ref_data = None) -> "DataProto":
+    def to_remote(cls, data: "DataProto", partition="train_eval", *, ref_data=None) -> "DataProto":
         with Timer(name="RemoteBatch to_remote", logger=None) as timer:
             batch_size = len(data)
 
             if ref_data is not None:
                 if len(ref_data) != batch_size:
-                    logger.warning(f"RemoteBatch to_remote ref_data batch size {len(ref_data)} does not match data batch size {batch_size}, {data=}")
+                    logger.warning(
+                        f"RemoteBatch to_remote ref_data batch size {len(ref_data)} does not match data batch size {batch_size}, {data=}"
+                    )
+                    return data
+                if (
+                    data._remote_batch is not None
+                    and ref_data._remote_batch is not None
+                    and data._remote_batch.partition != ref_data._remote_batch.partition
+                ):
+                    logger.warning("RemoteBatch to_remote ref_data and data have different partitions")
                     return data
                 if ref_data._remote_batch is None or ref_data._remote_batch.row_ids() is None:
-                    logger.warning(f"RemoteBatch to_remote ref_data has no row ids")
+                    logger.warning("RemoteBatch to_remote ref_data has no row ids")
                     return data
                 row_ids = ref_data._remote_batch.row_ids()
                 if len(row_ids) != batch_size:
-                    logger.warning(f"RemoteBatch to_remote ref_data row ids batch size {len(row_ids)} does not match data batch size {batch_size}")
+                    logger.warning(
+                        f"RemoteBatch to_remote ref_data row ids batch size {len(row_ids)} does not match data batch size {batch_size}"
+                    )
                     return data
                 if data._remote_batch is not None and data._remote_batch.row_ids() != row_ids:
-                    logger.warning(f"RemoteBatch to_remote ref_data and data have different row ids")
+                    logger.warning("RemoteBatch to_remote ref_data and data have different row ids")
                     return data
                 logger.info(f"RemoteBatch to_remote add to current rows, {partition=} {len(row_ids)=}")
             elif data._remote_batch is not None and data._remote_batch.row_ids() is not None:
                 row_ids = data._remote_batch.row_ids()
             else:
                 row_ids = [str(uuid.uuid4()) for _ in range(batch_size)]
-                logger.info(f"RemoteBatch to_remote add {len(row_ids)} new rows, row ids {partition=} row_ids={row_ids[:10]}...")
+                logger.info(
+                    f"RemoteBatch to_remote add {len(row_ids)} new rows, row ids {partition=} row_ids={row_ids[:10]}..."
+                )
             assert len(row_ids) == batch_size
 
             # Partition is used to group data of a step.
             # Some backend may support drop partition or delete keys using regex.
             assert isinstance(partition, str)
-            partition = data._remote_batch.partition if data._remote_batch is not None else partition
+            if data._remote_batch is not None:
+                partition = data._remote_batch.partition
+            elif ref_data is not None and ref_data._remote_batch is not None:
+                partition = ref_data._remote_batch.partition
 
             data_dict: dict = data._batch.to_dict() if data._batch is not None else {}
             data_dict.update(data._non_tensor_batch)
@@ -1155,13 +1184,22 @@ class DataProto:
             if not data_dict:
                 return data
 
+            if data._remote_batch is not None:
+                data._remote_batch._ensure_active()
             remote_batch = transfer_backend.put(partition, row_ids, data_dict, batch_size)
-            if remote_batch is None: # transfer backend is not available
+            if remote_batch is None:  # transfer backend is not available
                 assert data._remote_batch is None
                 return data
 
             if data._remote_batch is not None:
-                remote_batch = remote_batch.union(data._remote_batch)
+                try:
+                    remote_batch = remote_batch.union(data._remote_batch)
+                except Exception:
+                    try:
+                        remote_batch.drop()
+                    except Exception:
+                        logger.exception("Failed to clean up a newly written RemoteBatch after union failed")
+                    raise
 
         logger.info(f"RemoteBatch to_remote finished in {timer.last}s")
 
@@ -1188,7 +1226,9 @@ class DataProto:
             return
         with Timer(name="RemoteBatch drop", logger=None) as timer:
             partition = data._remote_batch.partition
-            logger.info(f"RemoteBatch drop {partition=} row_ids={data._remote_batch.row_ids()}")
+            row_ids = data._remote_batch.row_ids()
+            row_count = len(row_ids) if row_ids is not None else None
+            logger.info(f"RemoteBatch drop {partition=} {row_count=}")
             data._remote_batch.drop()
         logger.info(f"RemoteBatch drop {partition=} finished in {timer.last}s")
 

--- a/roll/distributed/scheduler/remote_protocol.py
+++ b/roll/distributed/scheduler/remote_protocol.py
@@ -1,12 +1,15 @@
 import threading
+import uuid
+import weakref
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Any, Optional
 
 import numpy as np
 import torch
+from codetiming import Timer
 from tensordict import TensorDict
 from tensordict.utils import LinkedList
-from codetiming import Timer
 
 from roll.distributed.scheduler import transfer_backend
 from roll.utils.logging import get_logger
@@ -67,6 +70,9 @@ class RemoteBatch:
         raise NotImplementedError
 
     def row_ids(self):
+        return None
+
+    def _ensure_active(self) -> None:
         return None
 
     def to(self, device) -> "RemoteBatch":
@@ -356,7 +362,9 @@ class RowRemoteBatch(RemoteBatch):
         fetch_fields = [field for field in fields if field not in existing_fields]
         if len(fetch_fields) > 0:
             with Timer(name="remote_batch_materialize", logger=None) as timer:
-                data: TensorDict = transfer_backend.get(partition=self.partition, keys=self._row_ids, fields=fetch_fields)
+                data: TensorDict = transfer_backend.get(
+                    partition=self.partition, keys=self._row_ids, fields=fetch_fields
+                )
                 assert set(data.keys()) == set(fetch_fields)
 
                 if self.cache is None:
@@ -367,7 +375,9 @@ class RowRemoteBatch(RemoteBatch):
                     self.cache = union_tensor_dict(self.cache, data)
                 if self.device is not None:
                     self.cache.to(self.device)
-            logger.info(f"RemoteBatch materialize cost {timer.last}s, partition={self.partition}, new materialized {sorted(fetch_fields)}, cached fields {sorted(list(existing_fields))}")
+            logger.info(
+                f"RemoteBatch materialize cost {timer.last}s, partition={self.partition}, new materialized {sorted(fetch_fields)}, cached fields {sorted(list(existing_fields))}"
+            )
 
         return self.cache.select(*fields)
 
@@ -499,7 +509,9 @@ class RowRemoteBatch(RemoteBatch):
 
         for field in rhs.fields:
             if field in self.fields:
-                assert set(self._row_ids) == set(rhs._row_ids), f"Row ids must be the same. Got {self._row_ids} and {rhs._row_ids}"
+                assert set(self._row_ids) == set(
+                    rhs._row_ids
+                ), f"Row ids must be the same. Got {self._row_ids} and {rhs._row_ids}"
                 continue
             self.fields.add(field)
 
@@ -636,9 +648,281 @@ class Box:
                 self.value = value
 
 
+class _ColumnRemoteState:
+    """Shared lifetime for one physical column bundle."""
+
+    def __init__(self, partition: str, keys: list[str], fields: list[Any], state_id: str | None = None):
+        self.state_id = state_id or uuid.uuid4().hex
+        self.partition = partition
+        self.keys = tuple(keys)
+        self.fields = tuple(fields)
+        self.active = True
+        self.delete_pending = True
+        self._lock = threading.Lock()
+        self._pickle_snapshot = threading.local()
+
+    def _snapshot(self):
+        return {
+            "state_id": self.state_id,
+            "partition": self.partition,
+            "keys": self.keys,
+            "fields": self.fields,
+            "active": self.active,
+            "delete_pending": self.delete_pending,
+        }
+
+    def __getstate__(self):
+        with self._lock:
+            snapshot = self._snapshot()
+            active, delete_pending = getattr(
+                self._pickle_snapshot,
+                "value",
+                (self.active, self.delete_pending),
+            )
+            if hasattr(self._pickle_snapshot, "value"):
+                del self._pickle_snapshot.value
+            snapshot["active"] = active
+            snapshot["delete_pending"] = delete_pending
+            return snapshot
+
+    def __setstate__(self, snapshot):
+        restored = self._from_snapshot(snapshot)
+        self.__dict__.update(restored.__dict__)
+
+    @classmethod
+    def _from_snapshot(cls, snapshot):
+        state = cls(
+            partition=snapshot["partition"],
+            keys=snapshot["keys"],
+            fields=snapshot["fields"],
+            state_id=snapshot["state_id"],
+        )
+        state.active = snapshot["active"]
+        state.delete_pending = snapshot["delete_pending"]
+        return state
+
+
+class _ColumnRemoteLifetimeDomain:
+    """Connected cleanup states serialized as one atomic snapshot."""
+
+    _merge_lock = threading.Lock()
+
+    def __init__(self, states: list[_ColumnRemoteState]):
+        self._parent = None
+        self._states = {state.state_id: state for state in states}
+        for state in self._states.values():
+            state._domain_ref = weakref.ref(self)
+
+    @classmethod
+    def merge(cls, left, right):
+        return cls.merge_many((left, right))
+
+    @classmethod
+    def merge_many(cls, domains):
+        with cls._merge_lock:
+            return cls._merge_many_unlocked(domains)
+
+    @classmethod
+    def _merge_many_unlocked(cls, domains):
+        roots = []
+        seen = set()
+        for domain in domains:
+            root = domain._root_unlocked()
+            if id(root) in seen:
+                continue
+            seen.add(id(root))
+            roots.append(root)
+        if not roots:
+            raise ValueError("At least one lifetime domain is required")
+        if len(roots) == 1:
+            return roots[0]
+        states = {}
+        for root in roots:
+            for state_id, state in root._states.items():
+                states.setdefault(state_id, state)
+        merged = cls(list(states.values()))
+        for root in roots:
+            root._parent = merged
+        return merged
+
+    def root(self):
+        with self._merge_lock:
+            return self._root_unlocked()
+
+    def states(self, state_ids) -> list[_ColumnRemoteState]:
+        with self._merge_lock:
+            root = self._root_unlocked()
+            missing = [state_id for state_id in state_ids if state_id not in root._states]
+            if missing:
+                raise RuntimeError("ColumnRemoteBatch was structurally modified during serialization")
+            return [root._states[state_id] for state_id in state_ids]
+
+    def __getstate__(self):
+        with self._locked_states(freeze_domain=True) as states:
+            for state in states:
+                snapshot = state._snapshot()
+                state._pickle_snapshot.value = (
+                    snapshot["active"],
+                    snapshot["delete_pending"],
+                )
+            return {"states": states}
+
+    def __setstate__(self, snapshot):
+        states = snapshot["states"]
+        connected_domains = []
+        for state in states:
+            domain_ref = getattr(state, "_domain_ref", None)
+            domain = domain_ref() if domain_ref is not None else None
+            if domain is not None:
+                connected_domains.append(domain)
+        self._parent = None
+        self._states = {state.state_id: state for state in states}
+        with self._merge_lock:
+            root = self._merge_many_unlocked((self, *connected_domains))
+            for state in root._states.values():
+                state._domain_ref = weakref.ref(root)
+
+    def _root_unlocked(self):
+        root = self
+        while root._parent is not None:
+            root = root._parent
+        current = self
+        while current._parent is not None and current._parent is not root:
+            parent = current._parent
+            current._parent = root
+            current = parent
+        return root
+
+    @contextmanager
+    def _locked_states(self, state_ids=None, freeze_domain=False):
+        while True:
+            with self._merge_lock:
+                root = self._root_unlocked()
+                selected_ids = tuple(root._states) if state_ids is None else tuple(state_ids)
+                states = [root._states[state_id] for state_id in selected_ids]
+
+            acquired = []
+            try:
+                for state in sorted(states, key=lambda state: state.state_id):
+                    state._lock.acquire()
+                    acquired.append(state)
+            except BaseException:
+                for state in reversed(acquired):
+                    state._lock.release()
+                raise
+
+            try:
+                self._merge_lock.acquire()
+            except BaseException:
+                for state in reversed(acquired):
+                    state._lock.release()
+                raise
+            current_root = self._root_unlocked()
+            valid = current_root is root
+            if valid:
+                if not freeze_domain:
+                    self._merge_lock.release()
+                break
+            self._merge_lock.release()
+            for state in reversed(acquired):
+                state._lock.release()
+        try:
+            yield states
+        finally:
+            if freeze_domain:
+                self._merge_lock.release()
+            for state in reversed(acquired):
+                state._lock.release()
+
+
+class _ColumnRemoteLifetime:
+    """Cleanup state shared by local aliases."""
+
+    def __init__(self, states: list[_ColumnRemoteState], domain=None, state_ids=None):
+        self._domain = domain or _ColumnRemoteLifetimeDomain(states)
+        self._state_ids = tuple(state_ids or (state.state_id for state in states))
+
+    def __reduce__(self):
+        return (_restore_column_remote_lifetime, (self._domain.root(), self._state_ids))
+
+    @property
+    def states(self):
+        return self._domain.states(self._state_ids)
+
+    def connect_many(self, others):
+        self._domain = _ColumnRemoteLifetimeDomain.merge_many((self._domain, *(other._domain for other in others)))
+
+    def extend(self, other, states):
+        if not states:
+            return self
+        domain = _ColumnRemoteLifetimeDomain.merge(self._domain, other._domain)
+        state_ids = dict.fromkeys((*self._state_ids, *(state.state_id for state in states)))
+        return _ColumnRemoteLifetime([], domain=domain, state_ids=state_ids)
+
+    def ensure_active(self) -> None:
+        with self._locked_states() as states:
+            if any(not state.active for state in states):
+                raise RuntimeError("RemoteBatch has already been dropped")
+
+    def drop(self) -> None:
+        first_error = None
+        with self._locked_states() as states:
+            for state in states:
+                state.active = False
+                if not state.delete_pending:
+                    continue
+                try:
+                    transfer_backend.delete(
+                        partition=state.partition,
+                        keys=list(state.keys),
+                        fields=list(state.fields),
+                    )
+                except Exception as exc:
+                    if first_error is None:
+                        first_error = exc
+                else:
+                    state.delete_pending = False
+        if first_error is not None:
+            raise first_error.with_traceback(first_error.__traceback__)
+
+    @contextmanager
+    def _locked_states(self):
+        with self._domain._locked_states(self._state_ids) as states:
+            yield states
+
+
+def _restore_column_remote_lifetime(domain, state_ids):
+    domain.states(state_ids)
+    return _ColumnRemoteLifetime([], domain=domain, state_ids=state_ids)
+
+
+def _restore_column_remote_batch(
+    partition,
+    device,
+    lifetime,
+    fields,
+    batch_size,
+    row_ids,
+    field_pipelines,
+):
+    return ColumnRemoteBatch(
+        partition=partition,
+        device=device,
+        fields=fields,
+        cache=None,
+        batch_size=batch_size,
+        row_ids=row_ids,
+        field_pipelines=field_pipelines,
+        lifetime=lifetime,
+    )
+
+
 class ColumnRemoteBatch(RemoteBatch):
     """
     A remote batch stored in a key-value store with column id as keys.
+
+    Structural mutations are not safe to run concurrently with serialization
+    or cleanup.
     """
 
     def __init__(
@@ -646,108 +930,149 @@ class ColumnRemoteBatch(RemoteBatch):
         partition: str,
         device,
         fields: dict[str, Any | list["ColumnRemoteBatch"]],
-        is_nested: bool,
-        cache: TensorDict,
+        cache: TensorDict | None,
         batch_size: int,
-        pipeline: tuple[PlanNode] = tuple(),
+        row_ids: list[str] | None = None,
+        field_pipelines: dict[str, tuple[PlanNode, ...]] | None = None,
+        lifetime: _ColumnRemoteLifetime | None = None,
     ):
         """
         fields contains any meta need to be hold and pass to transfer backend during get
-        or a list of ColumnRemoteBatch if is nested.
+        or a list of ColumnRemoteBatch for concatenated fields.
         """
         super().__init__("column", partition, device)
+        self._structure_lock = threading.RLock()
         self.fields = fields
-        self.is_nested = is_nested
         self.cache = cache
         self.batch_size = batch_size
-        self.pipeline = pipeline
+        self._row_ids = list(row_ids) if row_ids is not None else None
+        if self._row_ids is not None:
+            assert len(self._row_ids) == batch_size
+        self._field_pipelines = field_pipelines if field_pipelines is not None else {key: tuple() for key in fields}
+        if lifetime is None:
+            children = self._children_from_fields(fields)
+            lifetime = _ColumnRemoteLifetime(self._states_from_fields(fields, children))
+            lifetime.connect_many(child._lifetime for child in children)
+        self._lifetime = lifetime
 
     def __reduce__(self):
-        return (
-            ColumnRemoteBatch,
-            (self.partition, self.device, self.fields, self.is_nested, None, self.batch_size, self.pipeline),
-        )
+        with self._structure_lock:
+            return (
+                _restore_column_remote_batch,
+                (
+                    self.partition,
+                    self.device,
+                    self._lifetime,
+                    dict(self.fields),
+                    self.batch_size,
+                    list(self._row_ids) if self._row_ids is not None else None,
+                    dict(self._field_pipelines),
+                ),
+            )
+
+    @property
+    def _states(self) -> list[_ColumnRemoteState]:
+        return self._lifetime.states
 
     def __len__(self) -> int:
         return self.batch_size
 
     def __delitem__(self, key: str):
-        self.fields.pop(key)
-        if self.cache is not None and key in self.cache:
-            del self.cache[key]
+        with self._structure_lock:
+            self.fields.pop(key)
+            self._field_pipelines.pop(key)
+            if self.cache is not None and key in self.cache:
+                del self.cache[key]
 
     def __contains__(self, key: str) -> bool:
         return key in self.fields
 
+    def row_ids(self):
+        return self._row_ids
+
     def clone(self, recurse: bool = True):
-        if self.is_nested:
-            cloned_fields = {k: [batch.clone() for batch in v] for k, v in self.fields.items()}
-        else:
-            cloned_fields = self.fields.copy()
+        """Clone local state while retaining the remote object's shared lifetime."""
+        self._ensure_active()
+        cloned_fields = {}
+        cloned_children = {}
+        for key, value in self.fields.items():
+            if not isinstance(value, list):
+                cloned_fields[key] = value
+                continue
+            children = cloned_children.get(id(value))
+            if children is None:
+                children = [batch.clone(recurse=recurse) for batch in value]
+                cloned_children[id(value)] = children
+            cloned_fields[key] = children
         return ColumnRemoteBatch(
             partition=self.partition,
             device=self.device,
             fields=cloned_fields,
-            is_nested=self.is_nested,
             cache=self.cache.clone(recurse=recurse) if self.cache is not None else None,
             batch_size=self.batch_size,
-            pipeline=self.pipeline,
+            row_ids=self._row_ids,
+            field_pipelines={key: self._field_pipelines[key] for key in cloned_fields},
+            # A clone may copy its local cache, but it still references the same
+            # remote object and therefore shares its cleanup boundary.
+            lifetime=self._lifetime,
         )
 
     def keys(self):
         return self.fields.keys()
 
     def to(self, device) -> "ColumnRemoteBatch":
+        self._ensure_active()
         super().to(device)
         if self.cache is not None:
             self.cache = self.cache.to(device)
         return self
 
     def materialize(self, fields: list[str] = None) -> TensorDict:
+        self._ensure_active()
         if fields is None:
-            fields = self.fields.keys()
+            fields = list(self.fields)
         else:
             assert set(fields) <= set(self.fields.keys())
+        if fields == []:
+            return TensorDict({}, batch_size=[self.batch_size], device=self.device)
         existing_fields = set(self.cache.keys()) if self.cache is not None else set()
+        missing_fields = [field for field in fields if field not in existing_fields]
+        groups: dict[tuple, list[str]] = {}
+        for field in missing_fields:
+            source = self.fields[field]
+            pipeline = self._field_pipelines[field]
+            source_key = ("nested", id(source)) if isinstance(source, list) else ("direct",)
+            groups.setdefault(source_key + tuple(id(op) for op in pipeline), []).append(field)
 
-        data = None
-        if self.is_nested:
-            assert len(self.pipeline) == 1 and isinstance(self.pipeline[0], CatPlan)
-            chunks: list["ColumnRemoteBatch"] = next(iter(self.fields.values()))
-            # TODO shigao: use batch get
-            # TODO: parallel gather
-            data: list[TensorDict] = [chunk.materialize(fields) for chunk in chunks]
-        else:
-            # pass column(key) meta back to transfer backend
-            fetch_fields = {field: self.fields[field] for field in fields if field not in existing_fields}
-            if len(fetch_fields) > 0:
-                data: TensorDict = transfer_backend.get(
-                    partition=self.partition, keys=list(fetch_fields.keys()), fields=list(fetch_fields.values())
+        for group_fields in groups.values():
+            source = self.fields[group_fields[0]]
+            pipeline = self._field_pipelines[group_fields[0]]
+            if isinstance(source, list):
+                data = [chunk.materialize(group_fields) for chunk in source]
+            else:
+                data = transfer_backend.get(
+                    partition=self.partition,
+                    keys=group_fields,
+                    fields=[self.fields[field] for field in group_fields],
                 )
 
-        if data is not None:
-            for operator in self.pipeline:
+            for operator in pipeline:
                 data = operator.execute(data)
             assert len(data) == self.batch_size
-
             if self.device is not None:
-                data.to(self.device)
-
-            if self.cache is None:
-                self.cache = data
-            else:
-                from roll.distributed.scheduler.protocol import union_tensor_dict
-
-                self.cache = union_tensor_dict(self.cache, data)
+                data = data.to(self.device)
+            self._cache_data(data)
 
         return self.cache.select(*fields)
 
     def drop(self):
-        transfer_backend.delete(
-            partition=self.partition, keys=list(self.fields.keys()), fields=list(self.fields.values())
-        )
+        try:
+            self._lifetime.drop()
+        finally:
+            self.cache = None
 
     def select(self, fileds: list[str]) -> "ColumnRemoteBatch":
+        self._ensure_active()
         assert all(key in self.fields for key in fileds), f"Keys {fileds} not in {self.fields.keys()}"
         fields = {key: self.fields[key] for key in fileds}
         cache = self.cache
@@ -763,11 +1088,14 @@ class ColumnRemoteBatch(RemoteBatch):
             fields=fields,
             cache=cache,
             batch_size=self.batch_size,
-            is_nested=self.is_nested,
-            pipeline=self.pipeline,
+            row_ids=self._row_ids,
+            field_pipelines={key: self._field_pipelines[key] for key in fields},
+            lifetime=self._lifetime,
         )
 
-    def _selection(self, plan: PlanNode) -> "ColumnRemoteBatch":
+    def _selection(self, plan: PlanNode, *, ensure_active: bool = True) -> "ColumnRemoteBatch":
+        if ensure_active:
+            self._ensure_active()
         batch_size = plan.batch_size
 
         cache = self.cache
@@ -775,24 +1103,15 @@ class ColumnRemoteBatch(RemoteBatch):
             cache = plan.execute(cache)
             assert isinstance(cache, TensorDict)
 
-        if not self.pipeline:
-            pipeline = self.pipeline + (plan,)
-        else:
-            # TODO: heuristic optimization
-            # TODO: predicate pushdown
-            if isinstance(plan, SelectPlan) and isinstance(self.pipeline[-1], SelectPlan):
-                pipeline = self.pipeline + (plan,)
-            else:
-                pipeline = self.pipeline + (plan,)
-
         return ColumnRemoteBatch(
             partition=self.partition,
             device=self.device,
-            fields=self.fields,
+            fields=dict(self.fields),
             cache=cache,
             batch_size=batch_size,
-            is_nested=self.is_nested,
-            pipeline=pipeline,
+            row_ids=self._apply_row_plan(plan),
+            field_pipelines={key: field_pipeline + (plan,) for key, field_pipeline in self._field_pipelines.items()},
+            lifetime=self._lifetime,
         )
 
     def select_idxs(self, index: torch.Tensor | np.ndarray | list) -> "ColumnRemoteBatch":
@@ -803,6 +1122,11 @@ class ColumnRemoteBatch(RemoteBatch):
             index = torch.tensor(index)
             if index.dtype != torch.bool:
                 index = index.type(torch.int32)
+
+        if index.dtype == torch.bool:
+            assert (
+                len(index) == self.batch_size
+            ), f"Boolean index length {len(index)} does not match batch size {self.batch_size}"
 
         plan = SelectPlan(index)
         return self._selection(plan)
@@ -817,18 +1141,20 @@ class ColumnRemoteBatch(RemoteBatch):
         return self._selection(plan)
 
     def pop(self, fileds) -> "ColumnRemoteBatch":
-        assert len(fileds) == len(set(fileds)), "Fields must be unique"
-        assert set(fileds) <= self.fields.keys(), f"Fields {set(fileds) - self.fields.keys()} not in batch"
-        ret = self.select(fileds)
+        with self._structure_lock:
+            assert len(fileds) == len(set(fileds)), "Fields must be unique"
+            assert set(fileds) <= self.fields.keys(), f"Fields {set(fileds) - self.fields.keys()} not in batch"
+            ret = self.select(fileds)
 
-        for key in fileds:
-            del self.fields[key]
-        if self.cache is not None:
-            remaining_keys = [k for k in self.fields.keys() if k in self.cache.keys()]
-            if remaining_keys:
-                self.cache = self.cache.select(*remaining_keys)
-            else:
-                self.cache = None
+            for key in fileds:
+                del self.fields[key]
+                del self._field_pipelines[key]
+            if self.cache is not None:
+                remaining_keys = [k for k in self.fields.keys() if k in self.cache.keys()]
+                if remaining_keys:
+                    self.cache = self.cache.select(*remaining_keys)
+                else:
+                    self.cache = None
 
         return ret
 
@@ -836,10 +1162,16 @@ class ColumnRemoteBatch(RemoteBatch):
         assert sum(chunk_sizes) == len(
             self
         ), f"Sum of chunk_sizes {sum(chunk_sizes)} does not match batch size {len(self)}"
+        self._ensure_active()
         chunks = []
         offset = 0
         for size in chunk_sizes:
-            chunks.append(self.slice(offset, offset + size))
+            chunks.append(
+                self._selection(
+                    SlicePlan(offset, offset + size, None, self.batch_size),
+                    ensure_active=False,
+                )
+            )
             offset += size
         return chunks
 
@@ -848,22 +1180,57 @@ class ColumnRemoteBatch(RemoteBatch):
         return self._selection(plan)
 
     def union(self, rhs: "ColumnRemoteBatch") -> "ColumnRemoteBatch":
-        assert isinstance(rhs, RemoteBatch)
-        assert len(self) == len(rhs), f"Two tensor dict must have identical batch size. Got {len(self)} and {len(rhs)}"
-        if self.cache is not None and rhs.cache is not None:
-            from roll.distributed.scheduler.protocol import union_tensor_dict
+        assert isinstance(rhs, ColumnRemoteBatch)
+        with self._locked_structure(self, rhs):
+            self._ensure_active()
+            rhs._ensure_active()
+            assert len(self) == len(
+                rhs
+            ), f"Two tensor dict must have identical batch size. Got {len(self)} and {len(rhs)}"
+            assert self.partition == rhs.partition, "Two remote batches must have the same partition"
+            assert (self._row_ids is None) == (rhs._row_ids is None), "Both remote batches must provide row ids"
+            if self._row_ids is not None:
+                assert self._row_ids == rhs._row_ids, "Row ids must have the same order"
+            adopted_fields = {field: value for field, value in rhs.fields.items() if field not in self.fields}
+            adopted_cache_keys = [field for field in adopted_fields if rhs.cache is not None and field in rhs.cache]
+            if adopted_cache_keys:
+                adopted_cache = rhs.cache.select(*adopted_cache_keys).clone(recurse=False)
+                if self.cache is None:
+                    self.cache = adopted_cache
+                else:
+                    from roll.distributed.scheduler.protocol import union_tensor_dict
 
-            union_tensor_dict(self.cache, rhs.cache)
-        elif self.cache is None:
-            self.cache = rhs.cache.clone() if rhs.cache is not None else None
+                    self.cache = union_tensor_dict(self.cache, adopted_cache)
 
-        for field, value in rhs.fields.items():
-            if field in self.fields:
-                # assert self.cache[field].equal(rhs.cache[field]), f"{field=}"
-                continue
-            self.fields[field] = value
+            for field, value in adopted_fields.items():
+                self.fields[field] = value
+                self._field_pipelines[field] = rhs._field_pipelines[field]
+
+            self._lifetime = self._lifetime.extend(
+                rhs._lifetime,
+                rhs._states_for_fields(adopted_fields),
+            )
 
         return self
+
+    @staticmethod
+    @contextmanager
+    def _locked_structure(*batches):
+        locks = sorted({id(batch._structure_lock): batch._structure_lock for batch in batches}.values(), key=id)
+        acquired = []
+        try:
+            for lock in locks:
+                lock.acquire()
+                acquired.append(lock)
+        except BaseException:
+            for lock in reversed(acquired):
+                lock.release()
+            raise
+        try:
+            yield
+        finally:
+            for lock in reversed(acquired):
+                lock.release()
 
     @classmethod
     def _cat(cls, data: list["ColumnRemoteBatch"]) -> "ColumnRemoteBatch":
@@ -872,12 +1239,15 @@ class ColumnRemoteBatch(RemoteBatch):
         """
         assert data
         if len(data) == 1:
+            data[0]._ensure_active()
             return data[0]
 
         keys = set(data[0].fields.keys())
         assert all(set(d.fields.keys()) == keys for d in data), "All batches must have the same fields"
         partition = data[0].partition
         assert all(d.partition == partition for d in data), "All batches must have the same partition"
+        have_row_ids = [batch._row_ids is not None for batch in data]
+        assert all(have_row_ids) or not any(have_row_ids), "All batches must either provide row ids or omit them"
         device = data[0].device
 
         batch_size = sum(d.batch_size for d in data)
@@ -893,12 +1263,108 @@ class ColumnRemoteBatch(RemoteBatch):
         else:
             cache = None
 
-        return ColumnRemoteBatch(
+        result = ColumnRemoteBatch(
             partition=partition,
             device=device,
             fields={field: data for field in keys},
-            is_nested=True,
             cache=cache,
             batch_size=batch_size,
-            pipeline=(plan,),
+            row_ids=[row_id for batch in data for row_id in batch._row_ids] if all(have_row_ids) else None,
+            field_pipelines={field: (plan,) for field in keys},
         )
+        result._ensure_active()
+        return result
+
+    def _ensure_active(self) -> None:
+        self._lifetime.ensure_active()
+
+    @staticmethod
+    def _collect_states(batches: list["ColumnRemoteBatch"]) -> list[_ColumnRemoteState]:
+        states_by_domain = {}
+        lifetimes = {id(batch._lifetime): batch._lifetime for batch in batches}
+        for lifetime in lifetimes.values():
+            root = lifetime._domain.root()
+            domain, state_ids = states_by_domain.setdefault(id(root), (root, {}))
+            for state_id in lifetime._state_ids:
+                state_ids.setdefault(state_id, None)
+        return [state for domain, state_ids in states_by_domain.values() for state in domain.states(state_ids)]
+
+    def _states_from_fields(
+        self,
+        fields: dict[str, Any | list["ColumnRemoteBatch"]],
+        children: list["ColumnRemoteBatch"] | None = None,
+    ) -> list[_ColumnRemoteState]:
+        states = []
+        direct_keys = [key for key, value in fields.items() if not isinstance(value, list)]
+        if direct_keys:
+            states.append(
+                _ColumnRemoteState(
+                    self.partition,
+                    direct_keys,
+                    [fields[key] for key in direct_keys],
+                )
+            )
+        if children is None:
+            children = self._children_from_fields(fields)
+        states.extend(self._collect_states(children))
+        return self._unique_states(states)
+
+    @staticmethod
+    def _children_from_fields(fields):
+        children = []
+        seen = set()
+        for value in fields.values():
+            if not isinstance(value, list) or id(value) in seen:
+                continue
+            seen.add(id(value))
+            children.extend(value)
+        return children
+
+    def _states_for_fields(
+        self,
+        fields: dict[str, Any | list["ColumnRemoteBatch"]],
+    ) -> list[_ColumnRemoteState]:
+        direct_values = {id(value) for value in fields.values() if not isinstance(value, list)}
+        states = [state for state in self._states if any(id(value) in direct_values for value in state.fields)]
+        nested_fields = {}
+        for field, value in fields.items():
+            if not isinstance(value, list):
+                continue
+            _, child_fields = nested_fields.setdefault(id(value), (value, []))
+            child_fields.append(field)
+        for children, child_fields in nested_fields.values():
+            for child in children:
+                selected = {field: child.fields[field] for field in child_fields if field in child.fields}
+                states.extend(child._states_for_fields(selected))
+        return self._unique_states(states)
+
+    @staticmethod
+    def _unique_states(states: list[_ColumnRemoteState]) -> list[_ColumnRemoteState]:
+        unique = {}
+        for state in states:
+            unique.setdefault(state.state_id, state)
+        return list(unique.values())
+
+    def _cache_data(self, data: TensorDict) -> None:
+        if self.cache is None:
+            self.cache = data
+            return
+        from roll.distributed.scheduler.protocol import union_tensor_dict
+
+        self.cache = union_tensor_dict(self.cache, data)
+
+    def _apply_row_plan(self, plan: PlanNode) -> list[str] | None:
+        if self._row_ids is None:
+            return None
+        if isinstance(plan, SelectPlan):
+            index = plan.index.tolist()
+            if plan.index.dtype == torch.bool:
+                return [row_id for row_id, selected in zip(self._row_ids, index) if selected]
+            return [self._row_ids[i] for i in index]
+        if isinstance(plan, SlicePlan):
+            return self._row_ids[plan.slice_obj]
+        if isinstance(plan, RepeatPlan):
+            if plan.interleave:
+                return [row_id for row_id in self._row_ids for _ in range(plan.repeat_times)]
+            return self._row_ids * plan.repeat_times
+        raise TypeError(f"Unsupported row plan: {type(plan)}")

--- a/roll/distributed/scheduler/transfer_backend.py
+++ b/roll/distributed/scheduler/transfer_backend.py
@@ -41,8 +41,8 @@ def _check_transfer_queue_available():
 
 def _check_mooncake_available():
     try:
-        import mooncake.dataproto_transfer  # noqa: F401
         import mooncake.store  # noqa: F401
+        import mooncake.structured_object_store  # noqa: F401
     except ImportError as exc:
         raise ImportError("Mooncake transfer backend requires the mooncake Python package.") from exc
 
@@ -155,7 +155,13 @@ def create_tensordict(fields: dict[str, torch.Tensor | np.ndarray]) -> TensorDic
 
 class DummyClient:
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         return None
 
     def get(self, partition, keys: list[str], fields: list[Any]):
@@ -190,7 +196,13 @@ class RayMemoryStoreClient:
             get_if_exists=True,
         ).remote()
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         # TODO move RayMemoryStoreClient to another file
         from roll.distributed.scheduler.remote_protocol import ColumnRemoteBatch
 
@@ -223,7 +235,13 @@ class MooncakeNodeTransferActor:
     def __init__(self, config: dict[str, Any] | None = None):
         self.client = MooncakeClient(config)
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         return self.client.put(partition, row_ids, fields, batch_size)
 
     def get(self, partition, keys: list[str], fields: list[Any]):
@@ -238,7 +256,13 @@ class MooncakeNodeClientProxy:
         self.config = dict(config or {})
         self.actor = self._get_node_actor()
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         return ray.get(self.actor.put.remote(partition, row_ids, fields, batch_size))
 
     def get(self, partition, keys: list[str], fields: list[Any]):
@@ -264,55 +288,49 @@ class MooncakeNodeClientProxy:
 class MooncakeClient:
     def __init__(self, config: dict[str, Any] | None = None):
         _check_mooncake_available()
-        from mooncake.dataproto_transfer import MooncakeDataProtoTransferBackend
         from mooncake.store import MooncakeDistributedStore
-        from roll.distributed.scheduler.protocol import DataProto
+        from mooncake.structured_object_store import BundleTransferPolicy, MooncakeBundleTransfer
 
         config = config or {}
         store = MooncakeDistributedStore()
-        setup_args = config.get("setup_args")
-        setup_kwargs = config.get("setup_kwargs")
-        if setup_args is not None:
-            ret = store.setup(*setup_args)
-        elif setup_kwargs is not None:
-            ret = store.setup(**setup_kwargs)
-        else:
-            ret = self._setup_store_from_env(store)
+        ret = self._setup_store(store, config)
         if ret != 0:
             raise RuntimeError(f"Mooncake store setup failed, return code={ret}")
 
-        self.backend = MooncakeDataProtoTransferBackend(
-            store,
-            key_prefix=config.get("key_prefix", "roll"),
-            data_cls=DataProto,
-        )
-        self.shard_policy = self._create_shard_policy(config.get("shard_policy"))
+        self.backend = MooncakeBundleTransfer(store, key_prefix=config.get("key_prefix", "roll"))
+        policy_config = config.get("transfer_policy")
+        self.transfer_policy = BundleTransferPolicy(**policy_config) if policy_config else None
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         from roll.distributed.scheduler.protocol import DataProto
         from roll.distributed.scheduler.remote_protocol import ColumnRemoteBatch
 
-        tensors = {key: value for key, value in fields.items() if isinstance(value, torch.Tensor)}
-        non_tensors = {key: value for key, value in fields.items() if isinstance(value, np.ndarray)}
-        if len(tensors) + len(non_tensors) != len(fields):
-            unsupported = {
-                key: type(value) for key, value in fields.items() if key not in tensors and key not in non_tensors
-            }
-            raise TypeError(f"Unsupported Mooncake fields: {unsupported}")
-
-        if tensors:
-            data = DataProto.from_dict(tensors=tensors, non_tensors=non_tensors, meta_info={})
+        batch_fields, non_tensor_fields = self._split_fields(fields)
+        meta_info = {"roll_row_ids": row_ids}
+        if batch_fields:
+            data = DataProto.from_dict(tensors=batch_fields, non_tensors=non_tensor_fields, meta_info=meta_info)
         else:
-            data = DataProto(batch=None, non_tensor_batch=non_tensors, meta_info={})
+            data = DataProto(
+                batch=TensorDict({}, batch_size=[batch_size]),
+                non_tensor_batch=non_tensor_fields,
+                meta_info=meta_info,
+            )
         assert len(data) == batch_size
-        ref = self.backend.put_dataproto(data, partition=partition, shard_policy=self.shard_policy)
+
+        ref = self.backend.put_dataproto(data, partition=partition, policy=self.transfer_policy)
         field_refs = {
-            key: {"ref": ref, "kind": "batch" if key in tensors else "non_tensor"}
+            key: {"ref": ref, "kind": "batch" if key in batch_fields else "non_tensor"}
             for key in fields.keys()
         }
         return ColumnRemoteBatch(
             partition=partition,
-            device=data.batch.device if tensors else None,
+            device=data.batch.device if batch_fields else None,
             fields=field_refs,
             is_nested=False,
             cache=create_tensordict(fields),
@@ -322,53 +340,108 @@ class MooncakeClient:
     def get(self, partition, keys: list[str], fields: list[Any]):
         if not fields:
             return TensorDict({}, batch_size=[0])
-        ref = fields[0]["ref"]
-        if any(field["ref"].object_id != ref.object_id for field in fields):
-            raise ValueError("Mooncake backend cannot materialize fields from different refs in one get")
-        batch_fields = [key for key, field in zip(keys, fields) if field["kind"] == "batch"]
-        non_tensor_fields = [key for key, field in zip(keys, fields) if field["kind"] == "non_tensor"]
-        data = self.backend.materialize_dataproto(
-            ref,
-            batch_fields=batch_fields,
-            non_tensor_fields=non_tensor_fields,
-            include_meta_info=False,
-        )
+
+        grouped: dict[str, dict[str, Any]] = {}
+        for key, field in zip(keys, fields):
+            ref = field["ref"]
+            group = grouped.setdefault(self._ref_key(ref), {"ref": ref, "batch": [], "non_tensor": []})
+            group[field["kind"]].append(key)
+
         data_dict = {}
-        if data._batch is not None:
-            data_dict.update(data._batch.to_dict())
-        data_dict.update(data._non_tensor_batch)
+        for group in grouped.values():
+            data = self.backend.get_dataproto(
+                group["ref"],
+                batch_fields=group["batch"],
+                non_tensor_fields=group["non_tensor"],
+            )
+            data_dict.update(data.get("batch", {}))
+            data_dict.update(data.get("non_tensor_batch", {}))
         return create_tensordict({key: data_dict[key] for key in keys})
 
     def delete(self, partition, keys: list[str], fields: list[Any]):
         deleted = set()
         for field in fields:
             ref = field["ref"]
-            if ref.object_id in deleted:
+            ref_key = self._ref_key(ref)
+            if ref_key in deleted:
                 continue
-            self.backend.remove_dataproto(ref)
-            deleted.add(ref.object_id)
+            self.backend.cleanup_dataproto(ref)
+            deleted.add(ref_key)
 
-    def _setup_store_from_env(self, store):
+    def _setup_store(self, store, config: dict[str, Any]) -> int:
+        setup_args = config.get("setup_args")
+        setup_kwargs = config.get("setup_kwargs")
+        if setup_args is not None:
+            return store.setup(*setup_args)
+        if setup_kwargs is not None:
+            return store.setup(**setup_kwargs)
+        if config.get("master_server_addr") or config.get("master_server_address"):
+            return store.setup(
+                self._require_config(config, "local_hostname"),
+                self._require_config(config, "metadata_server"),
+                config.get("global_segment_size", 3355443200),
+                config.get("local_buffer_size", 1073741824),
+                config.get("protocol", "tcp"),
+                config.get("rdma_devices") or config.get("device_name", ""),
+                config.get("master_server_addr") or config.get("master_server_address"),
+            )
+        return self._setup_store_from_env(store, config)
+
+    def _setup_store_from_env(self, store, config: dict[str, Any]) -> int:
         from mooncake.mooncake_config import MooncakeConfig
 
-        config = MooncakeConfig.load_from_env()
+        mooncake_config = MooncakeConfig.load_from_env()
         return store.setup(
-            config.local_hostname,
-            config.metadata_server,
-            config.global_segment_size,
-            config.local_buffer_size,
-            config.protocol,
-            config.device_name or "",
-            config.master_server_address,
+            config.get("local_hostname", mooncake_config.local_hostname),
+            config.get("metadata_server", mooncake_config.metadata_server),
+            config.get("global_segment_size", mooncake_config.global_segment_size),
+            config.get("local_buffer_size", mooncake_config.local_buffer_size),
+            config.get("protocol", mooncake_config.protocol),
+            config.get("rdma_devices") or config.get("device_name", mooncake_config.device_name or ""),
+            config.get("master_server_addr")
+            or config.get("master_server_address", mooncake_config.master_server_address),
         )
 
-    def _create_shard_policy(self, config: dict[str, Any] | None):
-        if not config:
-            return None
-        from mooncake.dataproto_transfer import DataProtoShardPolicy
+    @staticmethod
+    def _split_fields(
+        fields: dict[str, torch.Tensor | np.ndarray],
+    ) -> tuple[dict[str, torch.Tensor], dict[str, np.ndarray]]:
+        tensors = {key: value for key, value in fields.items() if isinstance(value, torch.Tensor)}
+        non_tensors = {key: value for key, value in fields.items() if isinstance(value, np.ndarray)}
+        MooncakeClient._validate_fields(tensors, non_tensors, fields)
+        return tensors, non_tensors
 
-        return DataProtoShardPolicy(**config)
+    @staticmethod
+    def _validate_fields(
+        batch_fields: dict[str, Any],
+        non_tensor_fields: dict[str, Any],
+        all_fields: dict[str, Any] | None = None,
+    ) -> None:
+        unsupported = {}
+        for key, value in batch_fields.items():
+            if not isinstance(value, torch.Tensor):
+                unsupported[key] = type(value)
+        for key, value in non_tensor_fields.items():
+            if not isinstance(value, np.ndarray):
+                unsupported[key] = type(value)
+        if all_fields is not None:
+            known = set(batch_fields) | set(non_tensor_fields)
+            unsupported.update(
+                {key: type(value) for key, value in all_fields.items() if key not in known}
+            )
+        if unsupported:
+            raise TypeError(f"Unsupported Mooncake fields: {unsupported}")
 
+    @staticmethod
+    def _ref_key(ref) -> str:
+        return getattr(ref, "object_id", repr(ref))
+
+    @staticmethod
+    def _require_config(config: dict[str, Any], key: str) -> Any:
+        value = config.get(key)
+        if value is None or value == "":
+            raise ValueError(f"Mooncake backend_config requires {key!r} when master_server_addr is set")
+        return value
 
 def init_transfer_queue_server(config):
     # Must create enough storage units or may encounter:
@@ -383,7 +456,13 @@ class TransferQueueClient:
         _check_transfer_queue_available()
         tq.init()
 
-    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+    def put(
+        self,
+        partition,
+        row_ids: list[str],
+        fields: dict[str, torch.Tensor | np.ndarray],
+        batch_size: int,
+    ):
         # TODO move TransferQueueClient to another file
         from roll.distributed.scheduler.remote_protocol import RowRemoteBatch
 

--- a/roll/distributed/scheduler/transfer_backend.py
+++ b/roll/distributed/scheduler/transfer_backend.py
@@ -1,31 +1,34 @@
 import os
+import sys
 import threading
 import uuid
+from collections.abc import Mapping
 from typing import Any
 
+import numpy as np
 import ray
 import torch
-import numpy as np
-import sys
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if sys.version_info < (3, 13):
     import transfer_queue as tq
 else:
     tq = None
+
 from omegaconf import OmegaConf
 from tensordict import NonTensorStack, TensorDict
+from tensordict.utils import LinkedList
 
 from roll.configs.base_config import TransferBackendArguments
 from roll.distributed.scheduler.storage import SharedStorage
-from roll.utils.constants import STORAGE_NAME, RAY_NAMESPACE
+from roll.utils.constants import RAY_NAMESPACE, STORAGE_NAME
 from roll.utils.logging import get_logger
 
 logger = get_logger()
 
 MOONCAKE_CLIENT_SCOPE_NODE = "node"
-MOONCAKE_CLIENT_SCOPE_PROCESS = "process"
 MOONCAKE_NODE_ACTOR_NAME_PREFIX = "MooncakeNodeTransfer"
+_MOONCAKE_RELEASE_RESULTS_ATTR = "_mooncake_release_results"
 
 # Global reference to keep SharedStorage actor alive
 _shared_storage = None
@@ -48,7 +51,10 @@ def _check_mooncake_available():
 
 
 def _mooncake_client_scope(config: dict[str, Any] | None) -> str:
-    return (config or {}).get("client_scope", MOONCAKE_CLIENT_SCOPE_NODE)
+    scope = (config or {}).get("client_scope", MOONCAKE_CLIENT_SCOPE_NODE)
+    if scope != MOONCAKE_CLIENT_SCOPE_NODE:
+        raise ValueError(f"Mooncake currently supports only client_scope={MOONCAKE_CLIENT_SCOPE_NODE!r}")
+    return scope
 
 
 def _prepare_mooncake_backend_config(config: TransferBackendArguments) -> None:
@@ -56,17 +62,14 @@ def _prepare_mooncake_backend_config(config: TransferBackendArguments) -> None:
         return
     if config.backend_config is None:
         config.backend_config = {}
-    if _mooncake_client_scope(config.backend_config) != MOONCAKE_CLIENT_SCOPE_NODE:
-        return
+    _mooncake_client_scope(config.backend_config)
     config.backend_config.setdefault("node_actor_session_id", uuid.uuid4().hex)
 
 
 def init_transfer_backend(config: TransferBackendArguments | None):
     global _shared_storage
 
-    _shared_storage = SharedStorage.options(
-        name=STORAGE_NAME, get_if_exists=True, namespace=RAY_NAMESPACE
-    ).remote()
+    _shared_storage = SharedStorage.options(name=STORAGE_NAME, get_if_exists=True, namespace=RAY_NAMESPACE).remote()
 
     if config is None:
         config = TransferBackendArguments()
@@ -91,12 +94,15 @@ def init_transfer_backend(config: TransferBackendArguments | None):
 _client = None
 _client_lock = threading.Lock()
 
+
 def reinit_after_fork():
     global _client, _client_lock
     _client_lock = threading.Lock()
     _client = None
 
+
 os.register_at_fork(after_in_child=reinit_after_fork)
+
 
 def init_client():
     global _client
@@ -113,10 +119,8 @@ def init_client():
         elif config.backend_name == "TransferQueue":
             _client = TransferQueueClient()
         elif config.backend_name == "Mooncake":
-            if _mooncake_client_scope(config.backend_config) == MOONCAKE_CLIENT_SCOPE_NODE:
-                _client = MooncakeNodeClientProxy(config.backend_config)
-            else:
-                _client = MooncakeClient(config.backend_config)
+            _mooncake_client_scope(config.backend_config)
+            _client = MooncakeNodeClientProxy(config.backend_config)
         else:
             raise ValueError(f"Unsupported transfer backend: {config.backend_name}")
         logger.info(f"Initialized transfer client: {_client.__class__.__name__}")
@@ -126,9 +130,11 @@ def put(partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarr
     init_client()
     return _client.put(partition, row_ids, fields, batch_size)
 
+
 def get(partition, keys: list[str], fields: list[Any]):
     init_client()
     return _client.get(partition, keys, fields)
+
 
 def delete(partition, keys: list[str], fields: list[Any]):
     init_client()
@@ -153,8 +159,38 @@ def create_tensordict(fields: dict[str, torch.Tensor | np.ndarray]) -> TensorDic
     return TensorDict(td_dict, batch_size=[batch_size])
 
 
-class DummyClient:
+def _detach_mooncake_pool_value(value: Any) -> Any:
+    """Remove process-local pool owners without copying numeric payloads."""
+    if isinstance(value, np.ndarray):
+        array = np.asarray(value)
+        if array.dtype != object:
+            return array
+        detached = np.empty(array.shape, dtype=object)
+        for index in np.ndindex(array.shape):
+            detached[index] = _detach_mooncake_pool_value(array[index])
+        return detached
+    if isinstance(value, list):
+        return [_detach_mooncake_pool_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_detach_mooncake_pool_value(item) for item in value)
+    if isinstance(value, dict):
+        return {key: _detach_mooncake_pool_value(item) for key, item in value.items()}
+    return value
 
+
+def _detach_mooncake_pool_owners(data: TensorDict) -> TensorDict:
+    """Build a Ray-serializable view before returning data from the node actor."""
+    detached = {}
+    for key, value in data.items():
+        if isinstance(value, (NonTensorStack, LinkedList)):
+            items = value.tolist() if isinstance(value, NonTensorStack) else value
+            detached[key] = NonTensorStack(*(_detach_mooncake_pool_value(item) for item in items))
+        else:
+            detached[key] = value
+    return TensorDict(detached, batch_size=data.batch_size, device=data.device)
+
+
+class DummyClient:
     def put(
         self,
         partition,
@@ -216,9 +252,9 @@ class RayMemoryStoreClient:
             partition=partition,
             device=None,
             fields=meta_dict,
-            is_nested=False,
             cache=data,
             batch_size=batch_size,
+            row_ids=row_ids,
         )
 
     def get(self, partition, keys: list[str], fields: list[Any]):
@@ -245,7 +281,24 @@ class MooncakeNodeTransferActor:
         return self.client.put(partition, row_ids, fields, batch_size)
 
     def get(self, partition, keys: list[str], fields: list[Any]):
-        return self.client.get(partition, keys, fields)
+        data = self.client.get(partition, keys, fields)
+        object_ref = None
+        serialization_error = None
+        try:
+            # The pool lease belongs to this actor process. ray.put() finishes
+            # serialization before the lease is returned to the BufferPool.
+            object_ref = ray.put(_detach_mooncake_pool_owners(data))
+        except Exception as exc:
+            serialization_error = exc
+        try:
+            self.client.release(data)
+        except Exception:
+            if serialization_error is None:
+                raise
+            logger.exception("Failed to release a Mooncake GET result after serialization failed")
+        if serialization_error is not None:
+            raise serialization_error.with_traceback(serialization_error.__traceback__)
+        return object_ref
 
     def delete(self, partition, keys: list[str], fields: list[Any]):
         return self.client.delete(partition, keys, fields)
@@ -263,10 +316,12 @@ class MooncakeNodeClientProxy:
         fields: dict[str, torch.Tensor | np.ndarray],
         batch_size: int,
     ):
-        return ray.get(self.actor.put.remote(partition, row_ids, fields, batch_size))
+        remote = ray.get(self.actor.put.remote(partition, row_ids, fields, batch_size))
+        remote.cache = create_tensordict(fields)
+        return remote
 
     def get(self, partition, keys: list[str], fields: list[Any]):
-        return ray.get(self.actor.get.remote(partition, keys, fields))
+        return ray.get(ray.get(self.actor.get.remote(partition, keys, fields)))
 
     def delete(self, partition, keys: list[str], fields: list[Any]):
         return ray.get(self.actor.delete.remote(partition, keys, fields))
@@ -279,6 +334,8 @@ class MooncakeNodeClientProxy:
             name=actor_name,
             get_if_exists=True,
             namespace=RAY_NAMESPACE,
+            # One client owns the node BufferPool and release-retry queue;
+            # serialize operations so materialization cannot race cleanup.
             max_concurrency=1,
             num_cpus=0,
             scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id, soft=False),
@@ -289,7 +346,11 @@ class MooncakeClient:
     def __init__(self, config: dict[str, Any] | None = None):
         _check_mooncake_available()
         from mooncake.store import MooncakeDistributedStore
-        from mooncake.structured_object_store import BundleTransferPolicy, MooncakeBundleTransfer
+        from mooncake.structured_object_store import (
+            BundleTransferPolicy,
+            FieldSchema,
+            MooncakeBundleTransfer,
+        )
 
         config = config or {}
         store = MooncakeDistributedStore()
@@ -300,6 +361,8 @@ class MooncakeClient:
         self.backend = MooncakeBundleTransfer(store, key_prefix=config.get("key_prefix", "roll"))
         policy_config = config.get("transfer_policy")
         self.transfer_policy = BundleTransferPolicy(**policy_config) if policy_config else None
+        self.field_schemas = self._build_field_schemas(config.get("field_schemas"), FieldSchema)
+        self._pending_release_results = []
 
     def put(
         self,
@@ -308,67 +371,113 @@ class MooncakeClient:
         fields: dict[str, torch.Tensor | np.ndarray],
         batch_size: int,
     ):
-        from roll.distributed.scheduler.protocol import DataProto
+        self._retry_pending_release_results()
         from roll.distributed.scheduler.remote_protocol import ColumnRemoteBatch
 
         batch_fields, non_tensor_fields = self._split_fields(fields)
-        meta_info = {"roll_row_ids": row_ids}
-        if batch_fields:
-            data = DataProto.from_dict(tensors=batch_fields, non_tensors=non_tensor_fields, meta_info=meta_info)
-        else:
-            data = DataProto(
-                batch=TensorDict({}, batch_size=[batch_size]),
-                non_tensor_batch=non_tensor_fields,
-                meta_info=meta_info,
-            )
-        assert len(data) == batch_size
+        if len(row_ids) != batch_size:
+            raise ValueError(f"Expected {batch_size} row ids, got {len(row_ids)}")
+        invalid_lengths = {key: len(value) for key, value in fields.items() if len(value) != batch_size}
+        if invalid_lengths:
+            raise ValueError(f"Mooncake field lengths do not match batch_size={batch_size}: {invalid_lengths}")
+        data = {
+            "batch": batch_fields,
+            "non_tensor_batch": non_tensor_fields,
+            "meta_info": {},
+        }
 
-        ref = self.backend.put(data, type="dataproto", partition=partition, policy=self.transfer_policy)
+        put_kwargs = {"type": "dataproto", "partition": partition, "policy": self.transfer_policy}
+        if self.field_schemas:
+            put_kwargs["field_schemas"] = self.field_schemas
+        ref = self.backend.put(data, **put_kwargs)
         field_refs = {
-            key: {"ref": ref, "kind": "batch" if key in batch_fields else "non_tensor"}
-            for key in fields.keys()
+            key: {"ref": ref, "kind": "batch" if key in batch_fields else "non_tensor"} for key in fields.keys()
         }
         return ColumnRemoteBatch(
             partition=partition,
-            device=data.batch.device if batch_fields else None,
+            device=next(iter(batch_fields.values())).device if batch_fields else None,
             fields=field_refs,
-            is_nested=False,
-            cache=create_tensordict(fields),
+            cache=None,
             batch_size=batch_size,
+            row_ids=row_ids,
         )
 
     def get(self, partition, keys: list[str], fields: list[Any]):
+        self._retry_pending_release_results()
         if not fields:
             return TensorDict({}, batch_size=[0])
 
-        grouped: dict[str, dict[str, Any]] = {}
+        grouped: dict[Any, dict[str, Any]] = {}
         for key, field in zip(keys, fields):
             ref = field["ref"]
             group = grouped.setdefault(self._ref_key(ref), {"ref": ref, "batch": [], "non_tensor": []})
             group[field["kind"]].append(key)
 
-        data_dict = {}
-        for group in grouped.values():
-            data = self.backend.get(
-                group["ref"],
-                type="dataproto",
-                batch_fields=group["batch"],
-                non_tensor_fields=group["non_tensor"],
-                data_cls=dict,
-            )
-            data_dict.update(data.get("batch", {}))
-            data_dict.update(data.get("non_tensor_batch", {}))
-        return create_tensordict({key: data_dict[key] for key in keys})
+        raw_results = []
+        try:
+            data_dict = {}
+            for group in grouped.values():
+                data = self.backend.get(
+                    group["ref"],
+                    type="dataproto",
+                    batch_fields=group["batch"],
+                    non_tensor_fields=group["non_tensor"],
+                    meta_info_keys=[],
+                    data_cls=dict,
+                )
+                raw_results.append(data)
+                data_dict.update(data.get("batch", {}))
+                data_dict.update(data.get("non_tensor_batch", {}))
+            result = create_tensordict({key: data_dict[key] for key in keys})
+        except Exception:
+            self._release_raw_results(raw_results, suppress_errors=True)
+            self._pending_release_results.extend(raw_results)
+            raise
+
+        setattr(result, _MOONCAKE_RELEASE_RESULTS_ATTR, raw_results)
+        return result
+
+    def release(self, data: TensorDict):
+        raw_results = getattr(data, _MOONCAKE_RELEASE_RESULTS_ATTR, None)
+        if raw_results is None:
+            self._retry_pending_release_results()
+            return
+        try:
+            self._release_raw_results(raw_results)
+        except Exception:
+            self._pending_release_results.extend(raw_results)
+            raise
+        finally:
+            delattr(data, _MOONCAKE_RELEASE_RESULTS_ATTR)
+        self._retry_pending_release_results()
 
     def delete(self, partition, keys: list[str], fields: list[Any]):
-        deleted = set()
+        refs = []
+        seen = set()
         for field in fields:
+            if not isinstance(field, Mapping) or "ref" not in field:
+                raise TypeError(f"Unsupported Mooncake field reference: {type(field)}")
             ref = field["ref"]
             ref_key = self._ref_key(ref)
-            if ref_key in deleted:
+            if ref_key in seen:
                 continue
-            self.backend.cleanup_dataproto(ref)
-            deleted.add(ref_key)
+            seen.add(ref_key)
+            refs.append(ref)
+
+        try:
+            self._retry_pending_release_results()
+        except Exception:
+            logger.warning("Pending Mooncake GET release still failed; continuing object cleanup", exc_info=True)
+
+        first_error = None
+        for ref in refs:
+            try:
+                self.backend.cleanup_dataproto(ref)
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error.with_traceback(first_error.__traceback__)
 
     def _setup_store(self, store, config: dict[str, Any]) -> int:
         setup_args = config.get("setup_args")
@@ -377,73 +486,84 @@ class MooncakeClient:
             return store.setup(*setup_args)
         if setup_kwargs is not None:
             return store.setup(**setup_kwargs)
-        if config.get("master_server_addr") or config.get("master_server_address"):
-            return store.setup(
-                self._require_config(config, "local_hostname"),
-                self._require_config(config, "metadata_server"),
-                config.get("global_segment_size", 3355443200),
-                config.get("local_buffer_size", 1073741824),
-                config.get("protocol", "tcp"),
-                config.get("rdma_devices") or config.get("device_name", ""),
-                config.get("master_server_addr") or config.get("master_server_address"),
-            )
-        return self._setup_store_from_env(store, config)
+        protocol = config.get("protocol", "tcp")
+        local_hostname = config.get("local_hostname")
+        device_name = config.get("rdma_devices") or config.get("device_name")
+        master_address = config.get("master_server_addr") or config.get("master_server_address")
+        mooncake_config = None
+        if not local_hostname or not master_address or (protocol == "rdma" and not device_name):
+            from mooncake.mooncake_config import MooncakeConfig
 
-    def _setup_store_from_env(self, store, config: dict[str, Any]) -> int:
-        from mooncake.mooncake_config import MooncakeConfig
+            mooncake_config = MooncakeConfig.load_from_env()
 
-        mooncake_config = MooncakeConfig.load_from_env()
+        def configured(name: str, default=None):
+            value = config.get(name)
+            if value is not None:
+                return value
+            return getattr(mooncake_config, name, default) if mooncake_config is not None else default
+
         return store.setup(
-            config.get("local_hostname", mooncake_config.local_hostname),
-            config.get("metadata_server", mooncake_config.metadata_server),
-            config.get("global_segment_size", mooncake_config.global_segment_size),
-            config.get("local_buffer_size", mooncake_config.local_buffer_size),
-            config.get("protocol", mooncake_config.protocol),
-            config.get("rdma_devices") or config.get("device_name", mooncake_config.device_name or ""),
-            config.get("master_server_addr")
-            or config.get("master_server_address", mooncake_config.master_server_address),
+            configured("local_hostname"),
+            configured("metadata_server", "P2PHANDSHAKE"),
+            configured("global_segment_size", 3355443200),
+            configured("local_buffer_size", 1073741824),
+            configured("protocol", "tcp"),
+            config.get("rdma_devices") or configured("device_name", ""),
+            config.get("master_server_addr") or configured("master_server_address"),
         )
 
     @staticmethod
     def _split_fields(
         fields: dict[str, torch.Tensor | np.ndarray],
     ) -> tuple[dict[str, torch.Tensor], dict[str, np.ndarray]]:
+        unsupported = {
+            key: type(value) for key, value in fields.items() if not isinstance(value, (torch.Tensor, np.ndarray))
+        }
+        if unsupported:
+            raise TypeError(f"Unsupported Mooncake fields: {unsupported}")
         tensors = {key: value for key, value in fields.items() if isinstance(value, torch.Tensor)}
         non_tensors = {key: value for key, value in fields.items() if isinstance(value, np.ndarray)}
-        MooncakeClient._validate_fields(tensors, non_tensors, fields)
         return tensors, non_tensors
 
     @staticmethod
-    def _validate_fields(
-        batch_fields: dict[str, Any],
-        non_tensor_fields: dict[str, Any],
-        all_fields: dict[str, Any] | None = None,
-    ) -> None:
-        unsupported = {}
-        for key, value in batch_fields.items():
-            if not isinstance(value, torch.Tensor):
-                unsupported[key] = type(value)
-        for key, value in non_tensor_fields.items():
-            if not isinstance(value, np.ndarray):
-                unsupported[key] = type(value)
-        if all_fields is not None:
-            known = set(batch_fields) | set(non_tensor_fields)
-            unsupported.update(
-                {key: type(value) for key, value in all_fields.items() if key not in known}
-            )
-        if unsupported:
-            raise TypeError(f"Unsupported Mooncake fields: {unsupported}")
+    def _build_field_schemas(schema_config: Mapping[str, Any] | None, field_schema_cls) -> dict[str, Any]:
+        schemas = {}
+        for name, spec in (schema_config or {}).items():
+            if not isinstance(spec, Mapping):
+                raise TypeError(f"Mooncake field schema {name!r} must be a mapping")
+            schemas[name] = field_schema_cls(**dict(spec))
+        return schemas
+
+    def _release_raw_results(self, results: list[Any], suppress_errors: bool = False) -> None:
+        pending = []
+        first_error = None
+        for result in results:
+            try:
+                self.backend.release_result(result)
+            except Exception as exc:
+                pending.append(result)
+                if first_error is None:
+                    first_error = exc
+                if suppress_errors:
+                    logger.exception("Failed to release a Mooncake GET result")
+        results[:] = pending
+        if first_error is not None and not suppress_errors:
+            raise first_error.with_traceback(first_error.__traceback__)
+
+    def _retry_pending_release_results(self) -> None:
+        pending, self._pending_release_results = self._pending_release_results, []
+        try:
+            self._release_raw_results(pending)
+        finally:
+            self._pending_release_results.extend(pending)
 
     @staticmethod
-    def _ref_key(ref) -> str:
+    def _ref_key(ref) -> Any:
+        stage_refs = getattr(ref, "stage_refs", None)
+        if stage_refs is not None:
+            return tuple(sorted((stage, bundle.manifest_key) for stage, bundle in stage_refs.items()))
         return getattr(ref, "object_id", repr(ref))
 
-    @staticmethod
-    def _require_config(config: dict[str, Any], key: str) -> Any:
-        value = config.get(key)
-        if value is None or value == "":
-            raise ValueError(f"Mooncake backend_config requires {key!r} when master_server_addr is set")
-        return value
 
 def init_transfer_queue_server(config):
     # Must create enough storage units or may encounter:

--- a/roll/distributed/scheduler/transfer_backend.py
+++ b/roll/distributed/scheduler/transfer_backend.py
@@ -323,7 +323,7 @@ class MooncakeClient:
             )
         assert len(data) == batch_size
 
-        ref = self.backend.put_dataproto(data, partition=partition, policy=self.transfer_policy)
+        ref = self.backend.put(data, type="dataproto", partition=partition, policy=self.transfer_policy)
         field_refs = {
             key: {"ref": ref, "kind": "batch" if key in batch_fields else "non_tensor"}
             for key in fields.keys()
@@ -349,10 +349,12 @@ class MooncakeClient:
 
         data_dict = {}
         for group in grouped.values():
-            data = self.backend.get_dataproto(
+            data = self.backend.get(
                 group["ref"],
+                type="dataproto",
                 batch_fields=group["batch"],
                 non_tensor_fields=group["non_tensor"],
+                data_cls=dict,
             )
             data_dict.update(data.get("batch", {}))
             data_dict.update(data.get("non_tensor_batch", {}))

--- a/roll/distributed/scheduler/transfer_backend.py
+++ b/roll/distributed/scheduler/transfer_backend.py
@@ -7,6 +7,7 @@ import ray
 import torch
 import numpy as np
 import sys
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if sys.version_info < (3, 13):
     import transfer_queue as tq
@@ -22,6 +23,10 @@ from roll.utils.logging import get_logger
 
 logger = get_logger()
 
+MOONCAKE_CLIENT_SCOPE_NODE = "node"
+MOONCAKE_CLIENT_SCOPE_PROCESS = "process"
+MOONCAKE_NODE_ACTOR_NAME_PREFIX = "MooncakeNodeTransfer"
+
 # Global reference to keep SharedStorage actor alive
 _shared_storage = None
 
@@ -34,6 +39,28 @@ def _check_transfer_queue_available():
         )
 
 
+def _check_mooncake_available():
+    try:
+        import mooncake.dataproto_transfer  # noqa: F401
+        import mooncake.store  # noqa: F401
+    except ImportError as exc:
+        raise ImportError("Mooncake transfer backend requires the mooncake Python package.") from exc
+
+
+def _mooncake_client_scope(config: dict[str, Any] | None) -> str:
+    return (config or {}).get("client_scope", MOONCAKE_CLIENT_SCOPE_NODE)
+
+
+def _prepare_mooncake_backend_config(config: TransferBackendArguments) -> None:
+    if config.backend_name != "Mooncake":
+        return
+    if config.backend_config is None:
+        config.backend_config = {}
+    if _mooncake_client_scope(config.backend_config) != MOONCAKE_CLIENT_SCOPE_NODE:
+        return
+    config.backend_config.setdefault("node_actor_session_id", uuid.uuid4().hex)
+
+
 def init_transfer_backend(config: TransferBackendArguments | None):
     global _shared_storage
 
@@ -43,6 +70,7 @@ def init_transfer_backend(config: TransferBackendArguments | None):
 
     if config is None:
         config = TransferBackendArguments()
+    _prepare_mooncake_backend_config(config)
     ray.get(_shared_storage.put.remote(key="transfer_backend_config", data=config))
 
     backend_name = config.backend_name
@@ -53,6 +81,9 @@ def init_transfer_backend(config: TransferBackendArguments | None):
         _check_transfer_queue_available()
         init_transfer_queue_server(backend_config)
         logger.info(f"Initialized TransferQueue transfer backend: {config}")
+    elif backend_name == "Mooncake":
+        _check_mooncake_available()
+        logger.info(f"Initialized Mooncake transfer backend: {config}")
     else:
         raise ValueError(f"Unsupported transfer backend: {backend_name}")
 
@@ -81,6 +112,11 @@ def init_client():
             _client = DummyClient()
         elif config.backend_name == "TransferQueue":
             _client = TransferQueueClient()
+        elif config.backend_name == "Mooncake":
+            if _mooncake_client_scope(config.backend_config) == MOONCAKE_CLIENT_SCOPE_NODE:
+                _client = MooncakeNodeClientProxy(config.backend_config)
+            else:
+                _client = MooncakeClient(config.backend_config)
         else:
             raise ValueError(f"Unsupported transfer backend: {config.backend_name}")
         logger.info(f"Initialized transfer client: {_client.__class__.__name__}")
@@ -180,6 +216,158 @@ class RayMemoryStoreClient:
 
     def delete(self, partition, keys: list[str], fields: list[Any]):
         pass
+
+
+@ray.remote
+class MooncakeNodeTransferActor:
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.client = MooncakeClient(config)
+
+    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+        return self.client.put(partition, row_ids, fields, batch_size)
+
+    def get(self, partition, keys: list[str], fields: list[Any]):
+        return self.client.get(partition, keys, fields)
+
+    def delete(self, partition, keys: list[str], fields: list[Any]):
+        return self.client.delete(partition, keys, fields)
+
+
+class MooncakeNodeClientProxy:
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = dict(config or {})
+        self.actor = self._get_node_actor()
+
+    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+        return ray.get(self.actor.put.remote(partition, row_ids, fields, batch_size))
+
+    def get(self, partition, keys: list[str], fields: list[Any]):
+        return ray.get(self.actor.get.remote(partition, keys, fields))
+
+    def delete(self, partition, keys: list[str], fields: list[Any]):
+        return ray.get(self.actor.delete.remote(partition, keys, fields))
+
+    def _get_node_actor(self):
+        node_id = ray.get_runtime_context().get_node_id()
+        session_id = self.config.get("node_actor_session_id", "default")
+        actor_name = f"{MOONCAKE_NODE_ACTOR_NAME_PREFIX}-{session_id}-{node_id[:16]}"
+        return MooncakeNodeTransferActor.options(
+            name=actor_name,
+            get_if_exists=True,
+            namespace=RAY_NAMESPACE,
+            max_concurrency=1,
+            num_cpus=0,
+            scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id, soft=False),
+        ).remote(self.config)
+
+
+class MooncakeClient:
+    def __init__(self, config: dict[str, Any] | None = None):
+        _check_mooncake_available()
+        from mooncake.dataproto_transfer import MooncakeDataProtoTransferBackend
+        from mooncake.store import MooncakeDistributedStore
+        from roll.distributed.scheduler.protocol import DataProto
+
+        config = config or {}
+        store = MooncakeDistributedStore()
+        setup_args = config.get("setup_args")
+        setup_kwargs = config.get("setup_kwargs")
+        if setup_args is not None:
+            ret = store.setup(*setup_args)
+        elif setup_kwargs is not None:
+            ret = store.setup(**setup_kwargs)
+        else:
+            ret = self._setup_store_from_env(store)
+        if ret != 0:
+            raise RuntimeError(f"Mooncake store setup failed, return code={ret}")
+
+        self.backend = MooncakeDataProtoTransferBackend(
+            store,
+            key_prefix=config.get("key_prefix", "roll"),
+            data_cls=DataProto,
+        )
+        self.shard_policy = self._create_shard_policy(config.get("shard_policy"))
+
+    def put(self, partition, row_ids: list[str], fields: dict[str, torch.Tensor | np.ndarray], batch_size: int):
+        from roll.distributed.scheduler.protocol import DataProto
+        from roll.distributed.scheduler.remote_protocol import ColumnRemoteBatch
+
+        tensors = {key: value for key, value in fields.items() if isinstance(value, torch.Tensor)}
+        non_tensors = {key: value for key, value in fields.items() if isinstance(value, np.ndarray)}
+        if len(tensors) + len(non_tensors) != len(fields):
+            unsupported = {
+                key: type(value) for key, value in fields.items() if key not in tensors and key not in non_tensors
+            }
+            raise TypeError(f"Unsupported Mooncake fields: {unsupported}")
+
+        if tensors:
+            data = DataProto.from_dict(tensors=tensors, non_tensors=non_tensors, meta_info={})
+        else:
+            data = DataProto(batch=None, non_tensor_batch=non_tensors, meta_info={})
+        assert len(data) == batch_size
+        ref = self.backend.put_dataproto(data, partition=partition, shard_policy=self.shard_policy)
+        field_refs = {
+            key: {"ref": ref, "kind": "batch" if key in tensors else "non_tensor"}
+            for key in fields.keys()
+        }
+        return ColumnRemoteBatch(
+            partition=partition,
+            device=data.batch.device if tensors else None,
+            fields=field_refs,
+            is_nested=False,
+            cache=create_tensordict(fields),
+            batch_size=batch_size,
+        )
+
+    def get(self, partition, keys: list[str], fields: list[Any]):
+        if not fields:
+            return TensorDict({}, batch_size=[0])
+        ref = fields[0]["ref"]
+        if any(field["ref"].object_id != ref.object_id for field in fields):
+            raise ValueError("Mooncake backend cannot materialize fields from different refs in one get")
+        batch_fields = [key for key, field in zip(keys, fields) if field["kind"] == "batch"]
+        non_tensor_fields = [key for key, field in zip(keys, fields) if field["kind"] == "non_tensor"]
+        data = self.backend.materialize_dataproto(
+            ref,
+            batch_fields=batch_fields,
+            non_tensor_fields=non_tensor_fields,
+            include_meta_info=False,
+        )
+        data_dict = {}
+        if data._batch is not None:
+            data_dict.update(data._batch.to_dict())
+        data_dict.update(data._non_tensor_batch)
+        return create_tensordict({key: data_dict[key] for key in keys})
+
+    def delete(self, partition, keys: list[str], fields: list[Any]):
+        deleted = set()
+        for field in fields:
+            ref = field["ref"]
+            if ref.object_id in deleted:
+                continue
+            self.backend.remove_dataproto(ref)
+            deleted.add(ref.object_id)
+
+    def _setup_store_from_env(self, store):
+        from mooncake.mooncake_config import MooncakeConfig
+
+        config = MooncakeConfig.load_from_env()
+        return store.setup(
+            config.local_hostname,
+            config.metadata_server,
+            config.global_segment_size,
+            config.local_buffer_size,
+            config.protocol,
+            config.device_name or "",
+            config.master_server_address,
+        )
+
+    def _create_shard_policy(self, config: dict[str, Any] | None):
+        if not config:
+            return None
+        from mooncake.dataproto_transfer import DataProtoShardPolicy
+
+        return DataProtoShardPolicy(**config)
 
 
 def init_transfer_queue_server(config):

--- a/tests/distributed/scheduler/test_mooncake_transfer_backend.py
+++ b/tests/distributed/scheduler/test_mooncake_transfer_backend.py
@@ -2,7 +2,9 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import time
+import types
 
 import numpy as np
 import pytest
@@ -107,6 +109,81 @@ def test_mooncake_client_splits_roll_fields():
 def test_mooncake_client_rejects_unsupported_fields():
     with pytest.raises(TypeError, match="Unsupported Mooncake fields"):
         MooncakeClient._split_fields({"bad": ["a", "b"]})
+
+
+def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
+    calls = []
+
+    class FakeStore:
+        def setup(self, *args, **kwargs):
+            return 0
+
+    class FakePolicy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeTransfer:
+        def __init__(self, store, key_prefix):
+            self.store = store
+            self.key_prefix = key_prefix
+
+        def put(self, data, **kwargs):
+            calls.append(("put", kwargs, data))
+            return "ref"
+
+        def get(self, ref, **kwargs):
+            calls.append(("get", kwargs, ref))
+            return {
+                "batch": {"tokens": torch.tensor([[1], [2]])},
+                "non_tensor_batch": {"prompt": np.array(["a", "b"], dtype=object)},
+            }
+
+    mooncake_module = types.ModuleType("mooncake")
+    store_module = types.ModuleType("mooncake.store")
+    structured_module = types.ModuleType("mooncake.structured_object_store")
+    store_module.MooncakeDistributedStore = FakeStore
+    structured_module.BundleTransferPolicy = FakePolicy
+    structured_module.MooncakeBundleTransfer = FakeTransfer
+    monkeypatch.setitem(sys.modules, "mooncake", mooncake_module)
+    monkeypatch.setitem(sys.modules, "mooncake.store", store_module)
+    monkeypatch.setitem(sys.modules, "mooncake.structured_object_store", structured_module)
+
+    client = MooncakeClient(
+        {
+            "local_hostname": "127.0.0.1",
+            "metadata_server": "P2PHANDSHAKE",
+            "protocol": "tcp",
+            "master_server_addr": "127.0.0.1:50051",
+        }
+    )
+
+    remote = client.put(
+        "rollout",
+        ["0", "1"],
+        {
+            "tokens": torch.tensor([[1], [2]]),
+            "prompt": np.array(["a", "b"], dtype=object),
+        },
+        batch_size=2,
+    )
+    materialized = client.get("rollout", ["tokens", "prompt"], [remote.fields["tokens"], remote.fields["prompt"]])
+
+    put_name, put_kwargs, put_data = calls[0]
+    get_name, get_kwargs, get_ref = calls[1]
+    assert put_name == "put"
+    assert put_kwargs["type"] == "dataproto"
+    assert put_kwargs["partition"] == "rollout"
+    assert put_data.meta_info["roll_row_ids"] == ["0", "1"]
+    assert get_name == "get"
+    assert get_ref == "ref"
+    assert get_kwargs == {
+        "type": "dataproto",
+        "batch_fields": ["tokens"],
+        "non_tensor_fields": ["prompt"],
+        "data_cls": dict,
+    }
+    assert torch.equal(materialized["tokens"], torch.tensor([[1], [2]]))
+    assert list(materialized["prompt"]) == ["a", "b"]
 
 
 def test_mooncake_client_real_rdma_round_trip(mooncake_master):

--- a/tests/distributed/scheduler/test_mooncake_transfer_backend.py
+++ b/tests/distributed/scheduler/test_mooncake_transfer_backend.py
@@ -1,0 +1,111 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from roll.configs.base_config import TransferBackendArguments
+from roll.distributed.scheduler.protocol import DataProto
+from roll.distributed.scheduler.transfer_backend import (
+    MOONCAKE_CLIENT_SCOPE_NODE,
+    MOONCAKE_CLIENT_SCOPE_PROCESS,
+    MooncakeClient,
+    _mooncake_client_scope,
+    _prepare_mooncake_backend_config,
+)
+
+
+class FakeMooncakeStore:
+    def setup(self, *args, **kwargs):
+        return 0
+
+
+class FakeMooncakeBackend:
+    refs = {}
+    removed = []
+
+    def __init__(self, store, key_prefix="dataproto", data_cls=None):
+        self.data_cls = data_cls
+
+    def put_dataproto(self, data, partition="default", shard_policy=None):
+        object_id = f"{partition}/ref"
+        ref = SimpleNamespace(object_id=object_id, row_count=len(data), manifest_key="manifest", manifest={})
+        self.refs[object_id] = data
+        return ref
+
+    def materialize_dataproto(
+        self,
+        ref,
+        batch_fields=None,
+        non_tensor_fields=None,
+        include_meta_info=True,
+    ):
+        data = self.refs[ref.object_id]
+        tensors = {}
+        if data._batch is not None:
+            selected = set(batch_fields or [])
+            tensors = {key: value for key, value in data._batch.to_dict().items() if key in selected}
+        non_tensors = {
+            key: value for key, value in data._non_tensor_batch.items() if key in set(non_tensor_fields or [])
+        }
+        return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors) if tensors else DataProto(
+            batch=None, non_tensor_batch=non_tensors
+        )
+
+    def remove_dataproto(self, ref):
+        self.removed.append(ref.object_id)
+
+
+class FakeShardPolicy:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_mooncake_client_scope_defaults_to_node():
+    config = TransferBackendArguments(backend_name="Mooncake", backend_config={})
+
+    _prepare_mooncake_backend_config(config)
+
+    assert _mooncake_client_scope(config.backend_config) == MOONCAKE_CLIENT_SCOPE_NODE
+    assert config.backend_config["node_actor_session_id"]
+
+
+def test_mooncake_process_scope_keeps_config_small():
+    config = TransferBackendArguments(
+        backend_name="Mooncake",
+        backend_config={"client_scope": MOONCAKE_CLIENT_SCOPE_PROCESS},
+    )
+
+    _prepare_mooncake_backend_config(config)
+
+    assert "node_actor_session_id" not in config.backend_config
+
+
+def test_mooncake_client_round_trip(monkeypatch):
+    mooncake = types.ModuleType("mooncake")
+    store_mod = types.ModuleType("mooncake.store")
+    transfer_mod = types.ModuleType("mooncake.dataproto_transfer")
+    store_mod.MooncakeDistributedStore = FakeMooncakeStore
+    transfer_mod.MooncakeDataProtoTransferBackend = FakeMooncakeBackend
+    transfer_mod.DataProtoShardPolicy = FakeShardPolicy
+    monkeypatch.setitem(sys.modules, "mooncake", mooncake)
+    monkeypatch.setitem(sys.modules, "mooncake.store", store_mod)
+    monkeypatch.setitem(sys.modules, "mooncake.dataproto_transfer", transfer_mod)
+
+    FakeMooncakeBackend.refs = {}
+    FakeMooncakeBackend.removed = []
+    client = MooncakeClient({"setup_args": [], "shard_policy": {"enabled": True}})
+    fields = {
+        "tokens": torch.tensor([[1, 2], [3, 4]]),
+        "prompt": np.array(["a", "b"], dtype=object),
+    }
+
+    remote = client.put("rollout", ["0", "1"], fields, batch_size=2)
+    materialized = client.get("rollout", ["tokens", "prompt"], [remote.fields["tokens"], remote.fields["prompt"]])
+
+    assert torch.equal(materialized["tokens"], fields["tokens"])
+    assert list(materialized["prompt"]) == ["a", "b"]
+
+    client.delete("rollout", list(remote.fields.keys()), list(remote.fields.values()))
+    assert FakeMooncakeBackend.removed == ["rollout/ref"]

--- a/tests/distributed/scheduler/test_mooncake_transfer_backend.py
+++ b/tests/distributed/scheduler/test_mooncake_transfer_backend.py
@@ -1,20 +1,32 @@
 import os
+import pickle
 import shutil
 import socket
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 import types
+import uuid
+from collections import UserDict
 
 import numpy as np
 import pytest
+import ray
 import torch
+from tensordict import TensorDict
 
 from roll.configs.base_config import TransferBackendArguments
+from roll.distributed.scheduler import transfer_backend
+from roll.distributed.scheduler.protocol import DataProto
+from roll.distributed.scheduler.remote_protocol import ColumnRemoteBatch
 from roll.distributed.scheduler.transfer_backend import (
     MOONCAKE_CLIENT_SCOPE_NODE,
-    MOONCAKE_CLIENT_SCOPE_PROCESS,
     MooncakeClient,
+    MooncakeNodeClientProxy,
+    MooncakeNodeTransferActor,
+    _detach_mooncake_pool_owners,
     _mooncake_client_scope,
     _prepare_mooncake_backend_config,
 )
@@ -42,36 +54,52 @@ def _mooncake_master_endpoint() -> tuple[str, int]:
 @pytest.fixture(scope="module")
 def mooncake_master():
     host, port = _mooncake_master_endpoint()
-    if shutil.which("mooncake_master") is None:
-        pytest.skip("mooncake_master is not available in PATH")
-
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.2)
         if sock.connect_ex((host, port)) == 0:
             yield f"{host}:{port}"
             return
 
-    process = subprocess.Popen(
-        [
-            "mooncake_master",
-            f"--rpc_address={host}",
-            f"--rpc_port={port}",
-            "--logtostderr=true",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    try:
-        _wait_for_port(host, port)
-        yield f"{host}:{port}"
-    finally:
-        process.terminate()
+    if shutil.which("mooncake_master") is None:
+        pytest.skip("mooncake_master is not available in PATH and the configured master is unreachable")
+
+    with tempfile.TemporaryFile(mode="w+") as master_log:
+        process = subprocess.Popen(
+            [
+                "mooncake_master",
+                f"--rpc_address={host}",
+                f"--rpc_port={port}",
+                "--logtostderr=true",
+            ],
+            stdout=master_log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=5)
+            try:
+                _wait_for_port(host, port)
+            except TimeoutError as exc:
+                master_log.seek(0)
+                raise RuntimeError(f"mooncake_master did not start:\n{master_log.read()}") from exc
+            yield f"{host}:{port}"
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
+def _column_remote(fields, batch_size, *, cache=None, row_ids=None, partition="rollout"):
+    return ColumnRemoteBatch(
+        partition=partition,
+        device=None,
+        fields=fields,
+        cache=cache,
+        batch_size=batch_size,
+        row_ids=row_ids,
+    )
 
 
 def test_mooncake_client_scope_defaults_to_node():
@@ -83,15 +111,10 @@ def test_mooncake_client_scope_defaults_to_node():
     assert config.backend_config["node_actor_session_id"]
 
 
-def test_mooncake_process_scope_keeps_config_small():
-    config = TransferBackendArguments(
-        backend_name="Mooncake",
-        backend_config={"client_scope": MOONCAKE_CLIENT_SCOPE_PROCESS},
-    )
-
-    _prepare_mooncake_backend_config(config)
-
-    assert "node_actor_session_id" not in config.backend_config
+@pytest.mark.parametrize("scope", ["process", "per_worker"])
+def test_mooncake_client_scope_rejects_unsupported_values(scope):
+    with pytest.raises(ValueError, match="client_scope"):
+        _mooncake_client_scope({"client_scope": scope})
 
 
 def test_mooncake_client_splits_roll_fields():
@@ -111,6 +134,61 @@ def test_mooncake_client_rejects_unsupported_fields():
         MooncakeClient._split_fields({"bad": ["a", "b"]})
 
 
+def test_mooncake_client_builds_and_validates_field_schemas():
+    class FakeFieldSchema:
+        def __init__(self, codec, nullable=True, metadata=None):
+            self.codec = codec
+            self.nullable = nullable
+            self.metadata = metadata or {}
+
+    schemas = MooncakeClient._build_field_schemas(
+        UserDict(
+            {
+                "tokens": UserDict(
+                    {
+                        "codec": "ragged_tensor",
+                        "nullable": False,
+                        "metadata": {"section": "non_tensor_batch"},
+                    }
+                ),
+            }
+        ),
+        FakeFieldSchema,
+    )
+
+    assert schemas["tokens"].codec == "ragged_tensor"
+    assert schemas["tokens"].nullable is False
+    assert schemas["tokens"].metadata == {"section": "non_tensor_batch"}
+
+    with pytest.raises(TypeError):
+        MooncakeClient._build_field_schemas({"tokens": {}}, FakeFieldSchema)
+    with pytest.raises(TypeError):
+        MooncakeClient._build_field_schemas(
+            {"tokens": {"codec": "ragged_tensor", "unknown": True}},
+            FakeFieldSchema,
+        )
+    with pytest.raises(TypeError, match="must be a mapping"):
+        MooncakeClient._build_field_schemas({"tokens": "ragged_tensor"}, FakeFieldSchema)
+
+
+def test_mooncake_pool_owners_are_detached_without_copying_numeric_payloads():
+    class PoolBackedArray(np.ndarray):
+        pass
+
+    row = np.arange(4, dtype=np.int64).view(PoolBackedArray)
+    row._mooncake_pool_owner = object()
+    rows = np.empty(1, dtype=object)
+    rows[0] = row
+    data = transfer_backend.create_tensordict({"items": torch.tensor([[1]]), "rows": rows})
+
+    detached = _detach_mooncake_pool_owners(data)
+    detached_row = detached["rows"][0]
+
+    assert np.array_equal(detached_row, row)
+    assert np.shares_memory(detached_row, row)
+    assert not hasattr(detached_row, "_mooncake_pool_owner")
+
+
 def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
     calls = []
 
@@ -122,7 +200,17 @@ def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
+    class FakeFieldSchema:
+        def __init__(self, codec, nullable=True, metadata=None):
+            self.codec = codec
+            self.nullable = nullable
+            self.metadata = metadata or {}
+
     class FakeTransfer:
+        cleanup_calls = []
+        fail_release = False
+        release_calls = []
+
         def __init__(self, store, key_prefix):
             self.store = store
             self.key_prefix = key_prefix
@@ -138,11 +226,22 @@ def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
                 "non_tensor_batch": {"prompt": np.array(["a", "b"], dtype=object)},
             }
 
+        def cleanup_dataproto(self, ref):
+            self.cleanup_calls.append(ref)
+            if ref == "bad":
+                raise RuntimeError("cleanup failed")
+
+        def release_result(self, result):
+            self.release_calls.append(result)
+            if self.fail_release or result.get("release_error"):
+                raise RuntimeError("release failed")
+
     mooncake_module = types.ModuleType("mooncake")
     store_module = types.ModuleType("mooncake.store")
     structured_module = types.ModuleType("mooncake.structured_object_store")
     store_module.MooncakeDistributedStore = FakeStore
     structured_module.BundleTransferPolicy = FakePolicy
+    structured_module.FieldSchema = FakeFieldSchema
     structured_module.MooncakeBundleTransfer = FakeTransfer
     monkeypatch.setitem(sys.modules, "mooncake", mooncake_module)
     monkeypatch.setitem(sys.modules, "mooncake.store", store_module)
@@ -154,15 +253,22 @@ def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
             "metadata_server": "P2PHANDSHAKE",
             "protocol": "tcp",
             "master_server_addr": "127.0.0.1:50051",
+            "field_schemas": {
+                "multi_modal_inputs": {
+                    "codec": "ragged_tensor_dict",
+                    "metadata": {"section": "non_tensor_batch", "keys": {"image": None}},
+                }
+            },
         }
     )
 
+    prompt = np.array(["a", "b"], dtype=object)
     remote = client.put(
         "rollout",
         ["0", "1"],
         {
             "tokens": torch.tensor([[1], [2]]),
-            "prompt": np.array(["a", "b"], dtype=object),
+            "prompt": prompt,
         },
         batch_size=2,
     )
@@ -173,50 +279,952 @@ def test_mooncake_client_uses_unified_dataproto_api(monkeypatch):
     assert put_name == "put"
     assert put_kwargs["type"] == "dataproto"
     assert put_kwargs["partition"] == "rollout"
-    assert put_data.meta_info["roll_row_ids"] == ["0", "1"]
+    schema = put_kwargs["field_schemas"]["multi_modal_inputs"]
+    assert schema.codec == "ragged_tensor_dict"
+    assert schema.metadata == {"section": "non_tensor_batch", "keys": {"image": None}}
+    assert put_data["meta_info"] == {}
+    assert set(put_data["batch"]) == {"tokens"}
+    assert set(put_data["non_tensor_batch"]) == {"prompt"}
+    assert put_data["non_tensor_batch"]["prompt"] is prompt
     assert get_name == "get"
     assert get_ref == "ref"
     assert get_kwargs == {
         "type": "dataproto",
         "batch_fields": ["tokens"],
         "non_tensor_fields": ["prompt"],
+        "meta_info_keys": [],
         "data_cls": dict,
     }
     assert torch.equal(materialized["tokens"], torch.tensor([[1], [2]]))
     assert list(materialized["prompt"]) == ["a", "b"]
 
+    client.release(materialized)
+    client.release(materialized)
+    assert len(FakeTransfer.release_calls) == 1
 
-def test_mooncake_client_real_rdma_round_trip(mooncake_master):
+    non_tensor_remote = client.put(
+        "rollout",
+        ["0", "1"],
+        {"prompt": np.array(["a", "b"], dtype=object)},
+        batch_size=2,
+    )
+    assert non_tensor_remote.fields["prompt"]["kind"] == "non_tensor"
+    assert len(calls[-1][2]["non_tensor_batch"]["prompt"]) == 2
+    non_tensor_data = client.get(
+        "rollout",
+        ["prompt"],
+        [non_tensor_remote.fields["prompt"]],
+    )
+    assert list(non_tensor_data["prompt"]) == ["a", "b"]
+    client.release(non_tensor_data)
+
+    with pytest.raises(ValueError, match="Expected 2 row ids"):
+        client.put("rollout", ["0"], {"tokens": torch.tensor([[1], [2]])}, batch_size=2)
+    with pytest.raises(ValueError, match="field lengths"):
+        client.put("rollout", ["0", "1"], {"tokens": torch.tensor([[1]])}, batch_size=2)
+
+    retry_data = client.get("rollout", ["tokens"], [remote.fields["tokens"]])
+    FakeTransfer.fail_release = True
+    with pytest.raises(RuntimeError, match="release failed"):
+        client.release(retry_data)
+    assert len(client._pending_release_results) == 1
+    client.delete(
+        "rollout",
+        ["tokens"],
+        [{"ref": "release-cleanup", "kind": "batch"}],
+    )
+    assert FakeTransfer.cleanup_calls == ["release-cleanup"]
+    FakeTransfer.fail_release = False
+    client.release(retry_data)
+    assert client._pending_release_results == []
+
+    release_count = len(FakeTransfer.release_calls)
+    FakeTransfer.fail_release = True
+    with pytest.raises(KeyError, match="missing"):
+        client.get("rollout", ["missing"], [{"ref": "ref", "kind": "batch"}])
+    assert len(FakeTransfer.release_calls) == release_count + 1
+    assert len(client._pending_release_results) == 1
+    FakeTransfer.fail_release = False
+    client._retry_pending_release_results()
+    assert client._pending_release_results == []
+
+    client.delete("rollout", list(remote.fields), list(remote.fields.values()))
+    assert FakeTransfer.cleanup_calls == ["release-cleanup", "ref"]
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        client.delete(
+            "rollout",
+            ["bad", "other"],
+            [{"ref": "bad", "kind": "batch"}, {"ref": "other", "kind": "batch"}],
+        )
+    assert FakeTransfer.cleanup_calls[-2:] == ["bad", "other"]
+
+    cleanup_count = len(FakeTransfer.cleanup_calls)
+    with pytest.raises(TypeError, match="Unsupported Mooncake field reference"):
+        client.delete(
+            "rollout",
+            ["valid", "invalid"],
+            [{"ref": "valid", "kind": "batch"}, object()],
+        )
+    assert len(FakeTransfer.cleanup_calls) == cleanup_count
+
+
+def test_column_remote_batch_selected_view_shares_cleanup(monkeypatch):
+    values = {
+        "tokens": torch.tensor([[1], [2]]),
+        "rewards": torch.tensor([[0.1], [0.2]]),
+    }
+    delete_calls = []
+    monkeypatch.setattr(
+        transfer_backend,
+        "get",
+        lambda **kwargs: TensorDict(
+            {key: values[key] for key in kwargs["keys"]},
+            batch_size=[2],
+        ),
+    )
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    fields = {key: {"ref": "ref", "kind": "batch"} for key in ("tokens", "rewards")}
+    remote = _column_remote(fields, 2)
+
+    empty_view = remote.select([])
+    for empty in (empty_view.materialize([]), empty_view.materialize()):
+        assert len(empty) == 2
+        assert list(empty.keys()) == []
+    remote.materialize(["tokens"])
+    assert set(remote.cache.keys()) == {"tokens"}
+    remote.materialize(["rewards"])
+    assert set(remote.cache.keys()) == {"tokens", "rewards"}
+    selected = remote.select(list(fields))
+    selected.drop()
+
+    assert len(delete_calls) == 1
+    assert selected.cache is None
+    with pytest.raises(RuntimeError, match="already been dropped"):
+        remote.materialize(["tokens"])
+
+
+def test_nested_column_remote_batch_materializes_and_drops_children(monkeypatch):
+    fetched = {
+        "first": TensorDict(
+            {"tokens": torch.tensor([[1]]), "labels": torch.tensor([[10]])},
+            batch_size=[1],
+        ),
+        "second": TensorDict(
+            {"tokens": torch.tensor([[2]]), "labels": torch.tensor([[20]])},
+            batch_size=[1],
+        ),
+        "combined": TensorDict({"rewards": torch.tensor([[0.1], [0.2]])}, batch_size=[2]),
+    }
+    delete_calls = []
+
+    def get(**kwargs):
+        return fetched[kwargs["fields"][0]["ref"]]
+
+    monkeypatch.setattr(transfer_backend, "get", get)
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    children = [
+        _column_remote(
+            {
+                "tokens": {"ref": ref, "kind": "batch"},
+                "labels": {"ref": ref, "kind": "batch"},
+            },
+            1,
+            row_ids=[str(index)],
+        )
+        for index, ref in enumerate(("first", "second"))
+    ]
+    nested = pickle.loads(pickle.dumps(ColumnRemoteBatch.cat(children)))
+    remote = _column_remote(
+        {"rewards": {"ref": "combined", "kind": "batch"}},
+        2,
+        row_ids=["0", "1"],
+    ).union(nested)
+    cloned = remote.clone()
+    assert cloned.fields["tokens"] is cloned.fields["labels"]
+    selected = cloned.slice(1, 2)
+    token_data = selected.materialize(["tokens"])
+    materialized = selected.materialize(["labels", "rewards"])
+    assert selected.row_ids() == ["1"]
+    assert torch.equal(token_data["tokens"], torch.tensor([[2]]))
+    assert torch.equal(materialized["labels"], torch.tensor([[20]]))
+    assert torch.equal(materialized["rewards"], torch.tensor([[0.2]]))
+    assert set(selected.cache.keys()) == {"tokens", "labels", "rewards"}
+    cloned.drop()
+
+    assert len(delete_calls) == 3
+    assert cloned.cache is None
+    with pytest.raises(RuntimeError, match="already been dropped"):
+        remote.materialize(["tokens"])
+
+
+def test_dp2_nested_union_preserves_order_through_select_repeat(monkeypatch):
+    def get(**kwargs):
+        data = {key: field["data"] for key, field in zip(kwargs["keys"], kwargs["fields"])}
+        return TensorDict(data, batch_size=[len(next(iter(data.values())))])
+
+    def make_data(field, values):
+        return DataProto(
+            batch=None,
+            remote_batch=_column_remote(
+                {field: {"data": torch.tensor(values).view(4, 1)}},
+                4,
+                row_ids=["r0", "r1", "r2", "r3"],
+            ),
+        )
+
+    monkeypatch.setattr(transfer_backend, "get", get)
+    inputs = DataProto.concat(make_data("tokens", [10, 11, 12, 13]).chunk(2))
+    outputs = DataProto.concat(make_data("rewards", [20, 21, 22, 23]).chunk(2))
+
+    result = inputs.union(outputs).select_idxs([3, 0, 2]).repeat(2, interleave=False)
+    materialized = result._remote_batch.materialize(["tokens", "rewards"])
+
+    assert result._remote_batch.row_ids() == ["r3", "r0", "r2", "r3", "r0", "r2"]
+    assert materialized["tokens"].squeeze(-1).tolist() == [13, 10, 12, 13, 10, 12]
+    assert materialized["rewards"].squeeze(-1).tolist() == [23, 20, 22, 23, 20, 22]
+
+
+def test_many_chunk_cat_merges_lifetimes_once(monkeypatch):
+    chunks = [
+        _column_remote(
+            {"tokens": {"ref": f"ref-{index}", "kind": "batch"}},
+            1,
+            row_ids=[str(index)],
+        )
+        for index in range(64)
+    ]
+    domain_type = type(chunks[0]._lifetime._domain)
+    original_merge_many = domain_type.merge_many.__func__
+    merge_sizes = []
+
+    def merge_many(cls, domains):
+        domains = tuple(domains)
+        merge_sizes.append(len(domains))
+        return original_merge_many(cls, domains)
+
+    monkeypatch.setattr(domain_type, "merge_many", classmethod(merge_many))
+    combined = ColumnRemoteBatch.cat(chunks)
+
+    assert merge_sizes == [65]
+    assert len(combined._states) == 64
+    assert combined.row_ids() == [str(index) for index in range(64)]
+
+    state_reads = []
+    original_states = domain_type.states
+
+    def states(self, state_ids):
+        state_ids = tuple(state_ids)
+        state_reads.append(len(state_ids))
+        return original_states(self, state_ids)
+
+    rechunked = combined.chunk([1] * 64)
+    state_id_iterations = []
+
+    class CountingStateIds(tuple):
+        def __iter__(self):
+            state_id_iterations.append(len(self))
+            return super().__iter__()
+
+    combined._lifetime._state_ids = CountingStateIds(combined._lifetime._state_ids)
+    monkeypatch.setattr(domain_type, "states", states)
+    recombined = ColumnRemoteBatch.cat(rechunked)
+
+    assert state_id_iterations == [64]
+    assert state_reads == [64]
+    assert len(recombined._states) == 64
+
+
+def test_column_remote_batch_preserves_row_order_through_transforms():
+    remote = _column_remote(
+        {"tokens": {"ref": "ref", "kind": "batch"}},
+        4,
+        cache=TensorDict({"tokens": torch.arange(4).view(4, 1)}, batch_size=[4]),
+        row_ids=["0", "1", "2", "3"],
+    )
+
+    restored = pickle.loads(pickle.dumps(remote))
+    assert restored.row_ids() == ["0", "1", "2", "3"]
+    assert restored.select_idxs([3, 1]).row_ids() == ["3", "1"]
+    assert restored.slice(1, 4, 2).row_ids() == ["1", "3"]
+    assert restored.repeat(2, interleave=True).row_ids() == ["0", "0", "1", "1", "2", "2", "3", "3"]
+    assert restored.repeat(2, interleave=False).row_ids() == ["0", "1", "2", "3", "0", "1", "2", "3"]
+    assert ColumnRemoteBatch.cat([remote.slice(0, 2), remote.slice(2, 4)]).row_ids() == ["0", "1", "2", "3"]
+
+    assert len(remote.select_idxs([False, False, False, False])) == 0
+    assert len(remote.select_idxs([])) == 0
+    with pytest.raises(AssertionError, match="Boolean index length"):
+        remote.select_idxs([True])
+
+    view = remote.slice(1, 3)
+    view.union(
+        _column_remote(
+            {"rewards": {"ref": "rewards", "kind": "batch"}},
+            2,
+            row_ids=["1", "2"],
+        )
+    )
+    assert "rewards" in view
+    assert "rewards" not in remote
+    del view["tokens"]
+    assert "tokens" in remote
+    assert torch.equal(remote.materialize(["tokens"])["tokens"], remote.cache["tokens"])
+
+
+def test_union_only_adopts_cleanup_for_new_fields(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(
+        transfer_backend,
+        "get",
+        lambda **kwargs: TensorDict({"tokens": torch.tensor([[1]])}, batch_size=[1]),
+    )
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    left = _column_remote({"tokens": {"ref": "left", "kind": "batch"}}, 1)
+    right = _column_remote(
+        {"tokens": {"ref": "right", "kind": "batch"}},
+        1,
+        cache=TensorDict({"tokens": torch.tensor([[9]])}, batch_size=[1]),
+    )
+
+    left.union(right)
+    assert left.cache is None
+    assert torch.equal(left.materialize(["tokens"])["tokens"], torch.tensor([[1]]))
+    left.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["left"]
+
+    right.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["left", "right"]
+
+
+def test_nested_union_only_adopts_cleanup_for_new_fields(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+
+    def child(index):
+        row_ids = [str(index)]
+        tokens = _column_remote(
+            {"tokens": {"ref": f"tokens-{index}", "kind": "batch"}},
+            1,
+            row_ids=row_ids,
+        )
+        rewards = _column_remote(
+            {"rewards": {"ref": f"rewards-{index}", "kind": "batch"}},
+            1,
+            row_ids=row_ids,
+        )
+        return tokens.union(rewards)
+
+    rhs = pickle.loads(pickle.dumps(ColumnRemoteBatch.cat([child(0), child(1)])))
+    left = _column_remote(
+        {"rewards": {"ref": "left-rewards", "kind": "batch"}},
+        2,
+        row_ids=["0", "1"],
+    )
+
+    left.union(rhs.clone())
+    state_count = len(left._states)
+    left.union(rhs.clone())
+    assert len(left._states) == state_count
+    left.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == [
+        "left-rewards",
+        "tokens-0",
+        "tokens-1",
+    ]
+
+    rhs.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == [
+        "left-rewards",
+        "tokens-0",
+        "tokens-1",
+        "rewards-0",
+        "rewards-1",
+    ]
+
+
+def test_column_remote_batch_union_validates_identity_and_reuses_cache(monkeypatch):
+    monkeypatch.setattr(
+        transfer_backend,
+        "get",
+        lambda **kwargs: pytest.fail(f"unexpected GET for cached fields: {kwargs}"),
+    )
+    left = _column_remote(
+        {"tokens": {"ref": "left", "kind": "batch"}},
+        2,
+        cache=TensorDict({"tokens": torch.tensor([[1], [2]])}, batch_size=[2]),
+        row_ids=["0", "1"],
+    )
+    right = _column_remote(
+        {"rewards": {"ref": "right", "kind": "batch"}},
+        2,
+        cache=TensorDict({"rewards": torch.tensor([[0.1], [0.2]])}, batch_size=[2]),
+        row_ids=["0", "1"],
+    )
+
+    materialized = left.union(right).materialize(["tokens", "rewards"])
+    assert torch.equal(materialized["tokens"], torch.tensor([[1], [2]]))
+    assert torch.equal(materialized["rewards"], torch.tensor([[0.1], [0.2]]))
+
+    cached = right.clone()
+    copied = _column_remote({}, 2, row_ids=["0", "1"]).union(cached)
+    assert copied.cache is not cached.cache
+    assert copied.cache["rewards"].data_ptr() == cached.cache["rewards"].data_ptr()
+    del copied.cache["rewards"]
+    assert "rewards" in cached.cache
+
+    wrong_partition = right.clone()
+    wrong_partition.partition = "other"
+    with pytest.raises(AssertionError, match="same partition"):
+        left.clone().union(wrong_partition)
+
+    missing_row_ids = right.clone()
+    missing_row_ids._row_ids = None
+    with pytest.raises(AssertionError, match="provide row ids"):
+        left.clone().union(missing_row_ids)
+
+    wrong_order = right.clone()
+    wrong_order._row_ids = ["1", "0"]
+    with pytest.raises(AssertionError, match="same order"):
+        left.clone().union(wrong_order)
+
+    without_ids = right.clone()
+    without_ids._row_ids = None
+    with pytest.raises(AssertionError, match="either provide row ids or omit them"):
+        ColumnRemoteBatch.cat([without_ids, right])
+
+
+def test_pickled_views_share_cleanup_state(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    remote = _column_remote({"tokens": {"ref": "ref", "kind": "batch"}}, 1, row_ids=["0"])
+    serialized = pickle.dumps(remote)
+    left = pickle.loads(serialized)
+    right = pickle.loads(serialized)
+    assert len(left.union(right)._states) == 1
+
+    remote, selected = pickle.loads(pickle.dumps((remote, remote.select(["tokens"]))))
+
+    assert remote._states[0] is selected._states[0]
+    remote.drop()
+    selected.drop()
+    assert len(delete_calls) == 1
+
+    left = _column_remote({"tokens": {"ref": "left", "kind": "batch"}}, 1)
+    left_alias = left.clone()
+    left.union(_column_remote({"rewards": {"ref": "right", "kind": "batch"}}, 1))
+    left_alias, left = pickle.loads(pickle.dumps((left_alias, left)))
+    shared_state = {state.state_id: state for state in left._states}
+    assert shared_state[left_alias._states[0].state_id] is left_alias._states[0]
+    left.drop()
+    left_alias.drop()
+    assert len(delete_calls) == 3
+
+
+def test_union_does_not_add_rhs_cleanup_to_existing_aliases(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    left = _column_remote({"tokens": {"ref": "left", "kind": "batch"}}, 1)
+    left_alias = left.clone()
+    right = _column_remote({"rewards": {"ref": "right", "kind": "batch"}}, 1)
+
+    left.union(right)
+    left_alias.drop()
+
+    assert len(left._states) == 2
+    assert len(left_alias._states) == 1
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["left"]
+
+
+def test_union_adopts_an_indivisible_state_for_a_new_field(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    left = _column_remote({"tokens": {"ref": "left", "kind": "batch"}}, 1)
+    right = _column_remote(
+        {
+            "tokens": {"ref": "right", "kind": "batch"},
+            "rewards": {"ref": "right", "kind": "batch"},
+        },
+        1,
+    )
+
+    left.union(right)
+    left.drop()
+    right.drop()
+
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["left", "right"]
+
+
+def test_to_remote_reuses_mooncake_row_ids(monkeypatch):
+    calls = []
+
+    def put(partition, row_ids, fields, batch_size):
+        calls.append((partition, row_ids, list(fields), batch_size))
+        return _column_remote(
+            {key: {"ref": "output", "kind": "batch"} for key in fields},
+            batch_size,
+            row_ids=row_ids,
+            partition=partition,
+        )
+
+    monkeypatch.setattr(transfer_backend, "put", put)
+    input_remote = _column_remote(
+        {"tokens": {"ref": "input", "kind": "batch"}},
+        2,
+        row_ids=["sample-0", "sample-1"],
+    )
+    input_data = DataProto(batch=None, remote_batch=input_remote)
+    output = DataProto.to_remote(
+        DataProto.from_dict(tensors={"rewards": torch.tensor([[1.0], [2.0]])}),
+        ref_data=input_data,
+    )
+
+    assert calls == [("rollout", ["sample-0", "sample-1"], ["rewards"], 2)]
+    assert output._remote_batch.row_ids() == ["sample-0", "sample-1"]
+    assert set(output._remote_batch.fields) == {"rewards"}
+
+    other_partition = input_remote.clone()
+    other_partition.partition = "other"
+    mismatched = DataProto.to_remote(
+        DataProto.from_dict(
+            tensors={"rewards": torch.tensor([[1.0], [2.0]])},
+            meta_info={},
+        ).union(DataProto(batch=None, remote_batch=other_partition)),
+        ref_data=input_data,
+    )
+    assert mismatched._remote_batch.partition == "other"
+    assert len(calls) == 1
+
+
+def test_to_remote_cleans_new_bundle_when_union_fails(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    old_remote = _column_remote({"tokens": {"ref": "old", "kind": "batch"}}, 1, row_ids=["0"])
+    new_remote = _column_remote({"rewards": {"ref": "new", "kind": "batch"}}, 1, row_ids=["0"])
+
+    def fail_union(self, rhs):
+        raise RuntimeError("union failed")
+
+    new_remote.union = types.MethodType(fail_union, new_remote)
+    monkeypatch.setattr(transfer_backend, "put", lambda *args, **kwargs: new_remote)
+    data = DataProto(
+        batch=TensorDict({"rewards": torch.tensor([[1.0]])}, batch_size=[1]),
+        remote_batch=old_remote,
+    )
+
+    with pytest.raises(RuntimeError, match="union failed"):
+        DataProto.to_remote(data)
+
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["new"]
+
+
+def test_to_remote_rejects_dropped_input_before_put(monkeypatch):
+    put_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: None)
+    monkeypatch.setattr(transfer_backend, "put", lambda *args, **kwargs: put_calls.append(args))
+    old_remote = _column_remote({"tokens": {"ref": "old", "kind": "batch"}}, 1, row_ids=["0"])
+    old_remote.drop()
+    data = DataProto(
+        batch=TensorDict({"rewards": torch.tensor([[1.0]])}, batch_size=[1]),
+        remote_batch=old_remote,
+    )
+
+    with pytest.raises(RuntimeError, match="already been dropped"):
+        DataProto.to_remote(data)
+
+    assert put_calls == []
+
+
+def test_cleanup_survives_field_removal_and_pickle(monkeypatch):
+    delete_calls = []
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    remote = _column_remote({"tokens": {"ref": "ref", "kind": "batch"}}, 1, row_ids=["0"])
+    del remote["tokens"]
+
+    pickle.loads(pickle.dumps(remote)).drop()
+
+    assert len(delete_calls) == 1
+    assert delete_calls[0]["fields"] == [{"ref": "ref", "kind": "batch"}]
+
+
+def test_drop_is_idempotent_and_retries_failed_cleanup(monkeypatch):
+    delete_calls = []
+    delete_fails = [True]
+
+    def delete(**kwargs):
+        delete_calls.append(kwargs)
+        if delete_fails[0]:
+            raise RuntimeError("delete failed")
+
+    monkeypatch.setattr(transfer_backend, "delete", delete)
+    remote = _column_remote({"tokens": {"ref": "ref", "kind": "batch"}}, 1)
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        remote.drop()
+    assert len(delete_calls) == 1
+    delete_fails[0] = False
+    remote.drop()
+    remote.drop()
+    assert len(delete_calls) == 2
+
+
+def test_multistate_drop_retries_only_failed_cleanup(monkeypatch):
+    delete_calls = []
+    fail_tokens = [True]
+
+    def delete(**kwargs):
+        ref = kwargs["fields"][0]["ref"]
+        delete_calls.append(ref)
+        if ref == "tokens" and fail_tokens[0]:
+            raise RuntimeError("delete failed")
+
+    monkeypatch.setattr(transfer_backend, "delete", delete)
+    remote = _column_remote({"tokens": {"ref": "tokens", "kind": "batch"}}, 1)
+    remote.union(_column_remote({"rewards": {"ref": "rewards", "kind": "batch"}}, 1))
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        remote.drop()
+    fail_tokens[0] = False
+    remote.drop()
+    remote.drop()
+
+    assert delete_calls == ["tokens", "rewards", "tokens"]
+
+
+def test_concurrent_alias_drop_cleans_up_once(monkeypatch):
+    delete_calls = []
+    delete_started = threading.Event()
+    finish_delete = threading.Event()
+
+    def delete(**kwargs):
+        delete_calls.append(kwargs)
+        delete_started.set()
+        assert finish_delete.wait(timeout=2)
+
+    monkeypatch.setattr(transfer_backend, "delete", delete)
+    remote = _column_remote({"tokens": {"ref": "ref", "kind": "batch"}}, 1)
+    alias = remote.clone()
+    first = threading.Thread(target=remote.drop)
+    second = threading.Thread(target=alias.drop)
+
+    first.start()
+    assert delete_started.wait(timeout=2)
+    second.start()
+    finish_delete.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(delete_calls) == 1
+
+
+def test_pickle_waits_for_inflight_drop(monkeypatch):
+    delete_calls = []
+    delete_started = threading.Event()
+    finish_delete = threading.Event()
+    pickle_started = threading.Event()
+    serialized = []
+
+    def delete(**kwargs):
+        delete_calls.append(kwargs)
+        delete_started.set()
+        assert finish_delete.wait(timeout=2)
+
+    def serialize(remote):
+        pickle_started.set()
+        serialized.append(pickle.dumps(remote))
+
+    monkeypatch.setattr(transfer_backend, "delete", delete)
+    remote = _column_remote({"tokens": {"ref": "ref", "kind": "batch"}}, 1)
+    drop_thread = threading.Thread(target=remote.drop)
+    pickle_thread = threading.Thread(target=serialize, args=(remote,))
+
+    drop_thread.start()
+    assert delete_started.wait(timeout=2)
+    pickle_thread.start()
+    assert pickle_started.wait(timeout=2)
+    finish_delete.set()
+    drop_thread.join(timeout=2)
+    pickle_thread.join(timeout=2)
+
+    assert not drop_thread.is_alive()
+    assert not pickle_thread.is_alive()
+    pickle.loads(serialized[0]).drop()
+    assert len(delete_calls) == 1
+
+
+def test_overlapping_lifetimes_pickle_one_atomic_snapshot(monkeypatch):
+    delete_calls = []
+    first_state_snapshotted = threading.Event()
+    continue_pickle = threading.Event()
+    remote = _column_remote({"tokens": {"ref": "tokens", "kind": "batch"}}, 1)
+    alias = remote.clone()
+    remote.union(_column_remote({"rewards": {"ref": "rewards", "kind": "batch"}}, 1))
+    state_type = type(remote._states[0])
+    first_state_id = remote._states[0].state_id
+    original_snapshot = state_type._snapshot
+
+    def snapshot(state):
+        result = original_snapshot(state)
+        if state.state_id == first_state_id:
+            first_state_snapshotted.set()
+            assert continue_pickle.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    monkeypatch.setattr(state_type, "_snapshot", snapshot)
+    serialized = []
+    pickle_thread = threading.Thread(target=lambda: serialized.append(pickle.dumps((alias, remote))))
+    drop_thread = threading.Thread(target=remote.drop)
+
+    pickle_thread.start()
+    assert first_state_snapshotted.wait(timeout=2)
+    drop_thread.start()
+    assert delete_calls == []
+    continue_pickle.set()
+    pickle_thread.join(timeout=2)
+    drop_thread.join(timeout=2)
+
+    assert not pickle_thread.is_alive()
+    assert not drop_thread.is_alive()
+    restored_alias, restored = pickle.loads(serialized[0])
+    assert all(state.active and state.delete_pending for state in restored._states)
+    assert restored_alias._states[0] is restored._states[0]
+    restored.drop()
+    restored_alias.drop()
+    assert [call["keys"] for call in delete_calls] == [
+        ["tokens"],
+        ["rewards"],
+        ["tokens"],
+        ["rewards"],
+    ]
+
+
+def test_union_after_rhs_alias_snapshot_preserves_cleanup_identity(monkeypatch):
+    delete_calls = []
+    left = _column_remote({"tokens": {"ref": "tokens", "kind": "batch"}}, 1)
+    right = _column_remote({"rewards": {"ref": "rewards", "kind": "batch"}}, 1)
+    right_alias = right.clone()
+    domain_type = type(right._lifetime._domain)
+    original_getstate = domain_type.__getstate__
+    snapshotted = threading.Event()
+    continue_pickle = threading.Event()
+
+    def getstate(domain):
+        result = original_getstate(domain)
+        snapshotted.set()
+        assert continue_pickle.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(domain_type, "__getstate__", getstate)
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    serialized = []
+    pickle_thread = threading.Thread(target=lambda: serialized.append(pickle.dumps((right_alias, left))))
+
+    pickle_thread.start()
+    assert snapshotted.wait(timeout=2)
+    left.union(right)
+    continue_pickle.set()
+    pickle_thread.join(timeout=2)
+
+    assert not pickle_thread.is_alive()
+    restored_alias, restored = pickle.loads(serialized[0])
+    rewards_state = next(state for state in restored._states if state.fields[0]["ref"] == "rewards")
+    assert restored_alias._states[0] is rewards_state
+    assert restored_alias._lifetime._domain.root() is restored._lifetime._domain.root()
+
+    snapshotted = threading.Event()
+    continue_pickle = threading.Event()
+    serialized_again = []
+    pickle_thread = threading.Thread(target=lambda: serialized_again.append(pickle.dumps((restored_alias, restored))))
+
+    pickle_thread.start()
+    assert snapshotted.wait(timeout=2)
+    restored.drop()
+    continue_pickle.set()
+    pickle_thread.join(timeout=2)
+
+    assert not pickle_thread.is_alive()
+    second_alias, second_owner = pickle.loads(serialized_again[0])
+    assert second_alias._lifetime._domain.root() is second_owner._lifetime._domain.root()
+    assert all(state.active and state.delete_pending for state in second_owner._states)
+    second_owner.drop()
+    second_alias.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == [
+        "tokens",
+        "rewards",
+        "tokens",
+        "rewards",
+    ]
+
+
+def test_pickle_waits_for_atomic_union_metadata(monkeypatch):
+    delete_calls = []
+    union_paused = threading.Event()
+    continue_union = threading.Event()
+    pickle_started = threading.Event()
+    pickle_finished = threading.Event()
+    remote = _column_remote({"tokens": {"ref": "tokens", "kind": "batch"}}, 1)
+    rhs = _column_remote({"rewards": {"ref": "rewards", "kind": "batch"}}, 1)
+    original_states_for_fields = rhs._states_for_fields
+
+    def states_for_fields(self, fields):
+        union_paused.set()
+        assert continue_union.wait(timeout=2)
+        return original_states_for_fields(fields)
+
+    def serialize():
+        pickle_started.set()
+        serialized.append(pickle.dumps(remote))
+        pickle_finished.set()
+
+    monkeypatch.setattr(transfer_backend, "delete", lambda **kwargs: delete_calls.append(kwargs))
+    rhs._states_for_fields = types.MethodType(states_for_fields, rhs)
+    serialized = []
+    union_thread = threading.Thread(target=remote.union, args=(rhs,))
+    pickle_thread = threading.Thread(target=serialize)
+
+    union_thread.start()
+    assert union_paused.wait(timeout=2)
+    pickle_thread.start()
+    assert pickle_started.wait(timeout=2)
+    assert not pickle_finished.wait(timeout=0.1)
+    continue_union.set()
+    union_thread.join(timeout=2)
+    pickle_thread.join(timeout=2)
+
+    assert not union_thread.is_alive()
+    assert not pickle_thread.is_alive()
+    restored = pickle.loads(serialized[0])
+    assert set(restored.fields) == {"tokens", "rewards"}
+    restored.drop()
+    assert [call["fields"][0]["ref"] for call in delete_calls] == ["tokens", "rewards"]
+
+
+def test_mooncake_node_actor_serializes_before_release(monkeypatch):
+    actor_cls = MooncakeNodeTransferActor.__ray_metadata__.modified_class
+    actor = actor_cls.__new__(actor_cls)
+    data = TensorDict({"tokens": torch.tensor([[1]])}, batch_size=[1])
+    calls = []
+    failures = {"put": False, "release": False}
+
+    class Client:
+        def get(self, partition, keys, fields):
+            calls.append("get")
+            return data
+
+        def put(self, partition, row_ids, fields, batch_size):
+            calls.append("put")
+            return "remote"
+
+        def release(self, value):
+            calls.append(("release", value))
+            if failures["release"]:
+                raise RuntimeError("release failed")
+
+    def ray_put(value):
+        calls.append(("ray.put", value))
+        if failures["put"]:
+            raise RuntimeError("serialization failed")
+        return "object-ref"
+
+    actor.client = Client()
+    monkeypatch.setattr(transfer_backend.ray, "put", ray_put)
+
+    assert actor.get("rollout", ["tokens"], ["ref"]) == "object-ref"
+    assert [call if isinstance(call, str) else call[0] for call in calls] == ["get", "ray.put", "release"]
+
+    calls.clear()
+    failures["put"] = True
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        actor.get("rollout", ["tokens"], ["ref"])
+    assert [call if isinstance(call, str) else call[0] for call in calls] == ["get", "ray.put", "release"]
+
+    calls.clear()
+    failures.update(put=False, release=True)
+    with pytest.raises(RuntimeError, match="release failed"):
+        actor.get("rollout", ["tokens"], ["ref"])
+    assert [call if isinstance(call, str) else call[0] for call in calls] == ["get", "ray.put", "release"]
+
+    calls.clear()
+    failures["put"] = True
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        actor.get("rollout", ["tokens"], ["ref"])
+    assert [call if isinstance(call, str) else call[0] for call in calls] == ["get", "ray.put", "release"]
+
+
+def test_mooncake_client_real_rdma_local_round_trip(mooncake_master):
     protocol = os.environ.get("MOONCAKE_PROTOCOL", "")
     if protocol != "rdma":
         pytest.skip("Set MOONCAKE_PROTOCOL=rdma to run the Mooncake RDMA backend test")
 
     local_hostname = os.environ.get("MOONCAKE_LOCAL_HOSTNAME", "")
-    rdma_devices = os.environ.get("MOONCAKE_DEVICE_NAME", "")
+    rdma_devices = os.environ.get("MOONCAKE_DEVICE") or os.environ.get("MOONCAKE_DEVICE_NAME", "")
     if not local_hostname or not rdma_devices:
-        pytest.skip("Set MOONCAKE_LOCAL_HOSTNAME and MOONCAKE_DEVICE_NAME for RDMA testing")
+        pytest.skip("Set MOONCAKE_LOCAL_HOSTNAME and MOONCAKE_DEVICE for RDMA testing")
 
-    client = MooncakeClient(
-        {
-            "local_hostname": local_hostname,
-            "metadata_server": os.environ.get("MOONCAKE_METADATA_SERVER", "P2PHANDSHAKE"),
-            "global_segment_size": int(os.environ.get("MOONCAKE_GLOBAL_SEGMENT_SIZE", 1024 * 1024 * 1024)),
-            "local_buffer_size": int(os.environ.get("MOONCAKE_LOCAL_BUFFER_SIZE", 1024 * 1024 * 1024)),
-            "protocol": protocol,
-            "rdma_devices": rdma_devices,
-            "master_server_addr": mooncake_master,
-            "transfer_policy": {"copy_mode": "auto"},
-        }
+    local_buffer_size = min(
+        int(os.environ.get("MOONCAKE_LOCAL_BUFFER_SIZE", 128 * 1024 * 1024)),
+        128 * 1024 * 1024,
     )
+    config = {
+        "local_hostname": local_hostname,
+        "metadata_server": os.environ.get("MOONCAKE_METADATA_SERVER", "P2PHANDSHAKE"),
+        "global_segment_size": int(os.environ.get("MOONCAKE_GLOBAL_SEGMENT_SIZE", 1024 * 1024 * 1024)),
+        "local_buffer_size": local_buffer_size,
+        "protocol": protocol,
+        "rdma_devices": rdma_devices,
+        "master_server_addr": mooncake_master,
+        "transfer_policy": {"copy_mode": "auto"},
+        "field_schemas": {
+            "token_rows": {
+                "codec": "typed_ragged",
+                "nullable": False,
+                "metadata": {"section": "non_tensor_batch", "dtype": "int64"},
+            },
+            "nullable_rows": {
+                "codec": "typed_ragged",
+                "nullable": True,
+                "metadata": {"section": "non_tensor_batch", "dtype": "int64"},
+            },
+        },
+    }
+    started_ray = False
+    if not ray.is_initialized():
+        ray.init(include_dashboard=False, num_cpus=2)
+        started_ray = True
+    config["node_actor_session_id"] = uuid.uuid4().hex
+    client = MooncakeNodeClientProxy(config)
+
+    row_length = 1024 * 1024
+    rows = np.empty(2, dtype=object)
+    rows[0] = np.arange(row_length, dtype=np.int64)
+    rows[1] = np.arange(row_length, dtype=np.int64) + row_length
+    nullable_rows = np.array([None, None], dtype=object)
     fields = {
         "tokens": torch.tensor([[1, 2], [3, 4]]),
         "prompt": np.array(["a", "b"], dtype=object),
+        "token_rows": rows,
+        "nullable_rows": nullable_rows,
     }
 
-    remote = client.put("rollout", ["0", "1"], fields, batch_size=2)
-    materialized = client.get("rollout", ["tokens", "prompt"], [remote.fields["tokens"], remote.fields["prompt"]])
-
-    assert torch.equal(materialized["tokens"], fields["tokens"])
-    assert list(materialized["prompt"]) == ["a", "b"]
-
-    client.delete("rollout", list(remote.fields.keys()), list(remote.fields.values()))
+    original_client = transfer_backend._client
+    held_results = []
+    try:
+        transfer_backend._client = client
+        for _ in range(10):
+            remote = client.put("rollout", ["0", "1"], fields, batch_size=2)
+            remote.cache = None
+            materialized = remote.materialize(list(fields))
+            assert torch.equal(materialized["tokens"], fields["tokens"])
+            assert list(materialized["prompt"]) == ["a", "b"]
+            assert materialized["token_rows"][0].shape == (row_length,)
+            assert materialized["token_rows"][1][-1] == 2 * row_length - 1
+            assert list(materialized["nullable_rows"]) == [None, None]
+            held_results.append(materialized)
+            remote.drop()
+    finally:
+        transfer_backend._client = original_client
+        ray.kill(client.actor)
+        if started_ray:
+            ray.shutdown()

--- a/tests/distributed/scheduler/test_mooncake_transfer_backend.py
+++ b/tests/distributed/scheduler/test_mooncake_transfer_backend.py
@@ -1,12 +1,14 @@
-import sys
-import types
-from types import SimpleNamespace
+import os
+import shutil
+import socket
+import subprocess
+import time
 
 import numpy as np
+import pytest
 import torch
 
 from roll.configs.base_config import TransferBackendArguments
-from roll.distributed.scheduler.protocol import DataProto
 from roll.distributed.scheduler.transfer_backend import (
     MOONCAKE_CLIENT_SCOPE_NODE,
     MOONCAKE_CLIENT_SCOPE_PROCESS,
@@ -16,50 +18,58 @@ from roll.distributed.scheduler.transfer_backend import (
 )
 
 
-class FakeMooncakeStore:
-    def setup(self, *args, **kwargs):
-        return 0
+def _wait_for_port(host: str, port: int, timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex((host, port)) == 0:
+                return
+        time.sleep(0.1)
+    raise TimeoutError(f"Timed out waiting for {host}:{port}")
 
 
-class FakeMooncakeBackend:
-    refs = {}
-    removed = []
-
-    def __init__(self, store, key_prefix="dataproto", data_cls=None):
-        self.data_cls = data_cls
-
-    def put_dataproto(self, data, partition="default", shard_policy=None):
-        object_id = f"{partition}/ref"
-        ref = SimpleNamespace(object_id=object_id, row_count=len(data), manifest_key="manifest", manifest={})
-        self.refs[object_id] = data
-        return ref
-
-    def materialize_dataproto(
-        self,
-        ref,
-        batch_fields=None,
-        non_tensor_fields=None,
-        include_meta_info=True,
-    ):
-        data = self.refs[ref.object_id]
-        tensors = {}
-        if data._batch is not None:
-            selected = set(batch_fields or [])
-            tensors = {key: value for key, value in data._batch.to_dict().items() if key in selected}
-        non_tensors = {
-            key: value for key, value in data._non_tensor_batch.items() if key in set(non_tensor_fields or [])
-        }
-        return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors) if tensors else DataProto(
-            batch=None, non_tensor_batch=non_tensors
-        )
-
-    def remove_dataproto(self, ref):
-        self.removed.append(ref.object_id)
+def _mooncake_master_endpoint() -> tuple[str, int]:
+    master = os.environ.get("MOONCAKE_MASTER", "")
+    if not master:
+        pytest.skip("Set MOONCAKE_MASTER to run the Mooncake RDMA backend test")
+    host, port = master.rsplit(":", 1)
+    return host, int(port)
 
 
-class FakeShardPolicy:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
+@pytest.fixture(scope="module")
+def mooncake_master():
+    host, port = _mooncake_master_endpoint()
+    if shutil.which("mooncake_master") is None:
+        pytest.skip("mooncake_master is not available in PATH")
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        if sock.connect_ex((host, port)) == 0:
+            yield f"{host}:{port}"
+            return
+
+    process = subprocess.Popen(
+        [
+            "mooncake_master",
+            f"--rpc_address={host}",
+            f"--rpc_port={port}",
+            "--logtostderr=true",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_port(host, port)
+        yield f"{host}:{port}"
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
 
 
 def test_mooncake_client_scope_defaults_to_node():
@@ -82,20 +92,45 @@ def test_mooncake_process_scope_keeps_config_small():
     assert "node_actor_session_id" not in config.backend_config
 
 
-def test_mooncake_client_round_trip(monkeypatch):
-    mooncake = types.ModuleType("mooncake")
-    store_mod = types.ModuleType("mooncake.store")
-    transfer_mod = types.ModuleType("mooncake.dataproto_transfer")
-    store_mod.MooncakeDistributedStore = FakeMooncakeStore
-    transfer_mod.MooncakeDataProtoTransferBackend = FakeMooncakeBackend
-    transfer_mod.DataProtoShardPolicy = FakeShardPolicy
-    monkeypatch.setitem(sys.modules, "mooncake", mooncake)
-    monkeypatch.setitem(sys.modules, "mooncake.store", store_mod)
-    monkeypatch.setitem(sys.modules, "mooncake.dataproto_transfer", transfer_mod)
+def test_mooncake_client_splits_roll_fields():
+    fields = {
+        "tokens": torch.tensor([[1], [2]]),
+        "prompt": np.array(["a", "b"], dtype=object),
+    }
 
-    FakeMooncakeBackend.refs = {}
-    FakeMooncakeBackend.removed = []
-    client = MooncakeClient({"setup_args": [], "shard_policy": {"enabled": True}})
+    tensors, non_tensors = MooncakeClient._split_fields(fields)
+
+    assert tensors == {"tokens": fields["tokens"]}
+    assert non_tensors == {"prompt": fields["prompt"]}
+
+
+def test_mooncake_client_rejects_unsupported_fields():
+    with pytest.raises(TypeError, match="Unsupported Mooncake fields"):
+        MooncakeClient._split_fields({"bad": ["a", "b"]})
+
+
+def test_mooncake_client_real_rdma_round_trip(mooncake_master):
+    protocol = os.environ.get("MOONCAKE_PROTOCOL", "")
+    if protocol != "rdma":
+        pytest.skip("Set MOONCAKE_PROTOCOL=rdma to run the Mooncake RDMA backend test")
+
+    local_hostname = os.environ.get("MOONCAKE_LOCAL_HOSTNAME", "")
+    rdma_devices = os.environ.get("MOONCAKE_DEVICE_NAME", "")
+    if not local_hostname or not rdma_devices:
+        pytest.skip("Set MOONCAKE_LOCAL_HOSTNAME and MOONCAKE_DEVICE_NAME for RDMA testing")
+
+    client = MooncakeClient(
+        {
+            "local_hostname": local_hostname,
+            "metadata_server": os.environ.get("MOONCAKE_METADATA_SERVER", "P2PHANDSHAKE"),
+            "global_segment_size": int(os.environ.get("MOONCAKE_GLOBAL_SEGMENT_SIZE", 1024 * 1024 * 1024)),
+            "local_buffer_size": int(os.environ.get("MOONCAKE_LOCAL_BUFFER_SIZE", 1024 * 1024 * 1024)),
+            "protocol": protocol,
+            "rdma_devices": rdma_devices,
+            "master_server_addr": mooncake_master,
+            "transfer_policy": {"copy_mode": "auto"},
+        }
+    )
     fields = {
         "tokens": torch.tensor([[1, 2], [3, 4]]),
         "prompt": np.array(["a", "b"], dtype=object),
@@ -108,4 +143,3 @@ def test_mooncake_client_round_trip(monkeypatch):
     assert list(materialized["prompt"]) == ["a", "b"]
 
     client.delete("rollout", list(remote.fields.keys()), list(remote.fields.values()))
-    assert FakeMooncakeBackend.removed == ["rollout/ref"]


### PR DESCRIPTION
  ## Summary

  This PR adds Mooncake as an optional ROLL transfer backend for structured `DataProto` transfer.

  The implementation keeps ROLL-side integration aligned with the existing transfer backend boundary:

  - ROLL keeps `transfer_backend.put/get/delete` and `RemoteBatch` semantics.
  - Mooncake owns the structured object transfer implementation.
  - Mooncake is integrated through the standard `mooncake` package APIs.
  - The public `transfer_backend.put(...)` API remains unchanged.

  ## What Changed

  ### Mooncake Backend

  - Added Mooncake backend support using `mooncake.structured_object_store.MooncakeBundleTransfer`.
  - Stores ROLL `DataProto`-style payloads as Mooncake structured objects.
  - Supports:
    - tensor batch fields
    - `non_tensor_batch`
    - mixed tensor/non-tensor payloads
    - lazy field materialization through `ColumnRemoteBatch`
    - cleanup through Mooncake DataProto handle cleanup
  - Keeps Mooncake as an optional backend selected by config.

  ### ROLL Compatibility

  - Preserved the existing four-argument `transfer_backend.put(partition, row_ids, fields, batch_size)` API.
  - Did not add Mooncake-specific kwargs to the shared transfer backend interface.
  - Existing TransferQueue behavior remains unchanged.
  - ROLL continues to own `RemoteBatch` / `ColumnRemoteBatch` semantics.

  ### Node-scoped Client

  - Keeps node-scoped Mooncake client support.
  - This avoids initializing Mooncake resources independently in every worker process when node-level reuse is preferred.

  ### Documentation

  - Updated RemoteBatch transfer documentation.
  - Documented Mooncake as an optional structured `DataProto` backend.
  - Added Mooncake backend configuration example.
  - Updated English and Chinese docs.

  ### Tests

  - Rewrote Mooncake transfer tests without fake/mock Mooncake modules.
  - Added real RDMA-backed Mooncake round-trip coverage.
  - Test uses standard `mooncake` command/package names and standard Mooncake environment variables.
  - No hardcoded local repository paths are included in the test file.

  ## Validation

  ```bash
  PATH=/root/Mooncake-PR2050/build/mooncake-store/src:$PATH \
  PYTHONPATH=/root/Mooncake-PR2050/mooncake-wheel:$PYTHONPATH \
  MOONCAKE_MASTER=192.168.22.70:50051 \
  MOONCAKE_LOCAL_HOSTNAME=192.168.22.70 \
  MOONCAKE_PROTOCOL=rdma \
  MOONCAKE_DEVICE_NAME=erdma_0 \
  /root/roll/.venv/bin/python -m pytest -q \
    tests/distributed/scheduler/test_mooncake_transfer_backend.py

  ```

  Result:

  5 passed

  Additional checks:

  python -m py_compile \
    roll/distributed/scheduler/transfer_backend.py \
    tests/distributed/scheduler/test_mooncake_transfer_backend.py

  git diff --check

