### PR TITLE
feat(mcore-adapter): support rope_parameters for Transformers v5+ compatibility

### DIFF
--- a/mcore_adapter/src/mcore_adapter/models/converter/template.py
+++ b/mcore_adapter/src/mcore_adapter/models/converter/template.py
@@ -607,6 +607,22 @@ class Template:
         return [mca_prefix + name for name in op.mca_names]
 
 
+@dataclass
+class VisionTemplate(Template):
+    def adjust_config_hf_to_mca(self):
+        non_text_config_keys = set(
+            list(filter(lambda k: k.endswith("_token_id"), self.config_hf_to_mca.keys()))
+            + ["vision_config", "tie_word_embeddings"]
+        )
+        new_config_hf_to_mca = {}
+        for hf_key, mca_key in self.config_hf_to_mca.items():
+            new_hf_key = hf_key
+            if hf_key not in non_text_config_keys:
+                new_hf_key = "text_config." + new_hf_key
+            new_config_hf_to_mca[new_hf_key] = mca_key
+        return new_config_hf_to_mca
+
+
 templates: Dict[str, Template] = {}
 
 

--- a/mcore_adapter/src/mcore_adapter/models/deepseek_v3/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/deepseek_v3/__init__.py
@@ -22,7 +22,7 @@ from .modeling_deepseek_v3 import DeepSeekV3Model
 class DeepSeekV3Template(Template):
     def convert_hf_to_mca_config_kws(self, hf_config, **kw_args):
         # convert mla related parameters
-        rope_scaling = getattr(hf_config, "rope_scaling", None)
+        rope_scaling = getattr(hf_config, "rope_scaling", None) or getattr(hf_config, "rope_parameters", None)
         if rope_scaling:
             if rope_scaling.get("original_max_position_embeddings", None):
                 kw_args["max_position_embeddings"] = rope_scaling["original_max_position_embeddings"]
@@ -185,6 +185,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         "v_head_dim": "v_head_dim",
         "qk_nope_head_dim": "qk_head_dim",

--- a/mcore_adapter/src/mcore_adapter/models/glm4_moe/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/glm4_moe/__init__.py
@@ -24,6 +24,10 @@ from ..model_factory import McaGPTModel
 class Glm4MoeTemplate(Template):
     def convert_hf_to_mca_config_kws(self, hf_config, **kw_args):
         partial_rotary_factor = getattr(hf_config, "partial_rotary_factor", None)
+        rope_parameters = getattr(hf_config, "rope_parameters", None)
+        if rope_parameters is not None:
+            partial_rotary_factor = rope_parameters.get("partial_rotary_factor", partial_rotary_factor)
+
         if partial_rotary_factor is not None:
             kw_args["rotary_percent"] = partial_rotary_factor
 
@@ -169,6 +173,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/llama/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/llama/__init__.py
@@ -30,6 +30,7 @@ register_template(
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
         "rope_scaling": "rope_scaling",
+        "rope_parameters": "rope_parameters",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
     },
     hf_invalid_keys=[".self_attn.rotary_emb.inv_freq"],

--- a/mcore_adapter/src/mcore_adapter/models/llama/configuration_llama.py
+++ b/mcore_adapter/src/mcore_adapter/models/llama/configuration_llama.py
@@ -15,4 +15,4 @@ class LlamaConfig(McaModelConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        self.rotary_scaling = self.rope_scaling is not None
+        self.rotary_scaling = self.rope_scaling is not None or self.rope_parameters is not None

--- a/mcore_adapter/src/mcore_adapter/models/mistral/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/mistral/__init__.py
@@ -32,6 +32,7 @@ register_template(
         "attention_bias": "add_qkv_bias",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
     },
     hf_invalid_keys=[".self_attn.rotary_emb.inv_freq"],

--- a/mcore_adapter/src/mcore_adapter/models/mixtral/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/mixtral/__init__.py
@@ -33,6 +33,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/model_config.py
+++ b/mcore_adapter/src/mcore_adapter/models/model_config.py
@@ -43,6 +43,10 @@ class PretrainedConfig:
         default=None,
         metadata={"help": "Corresponding HuggingFace transformers config json."},
     )
+    rope_parameters: Optional[dict] = field(
+        default=None,
+        metadata={"help": "Rope parameters."},
+    )
 
     def post_init(self):
         self.__post_init__()
@@ -348,6 +352,9 @@ class McaModelConfig(TransformerConfig, PretrainedConfig):
                 self.yarn_mscale_all_dim = 0
             if not hasattr(self, "yarn_correction_range_round_to_int"):
                 self.yarn_correction_range_round_to_int = True
+
+        if self.rope_parameters is not None:
+            self.rotary_base = self.rope_parameters.get("rope_theta", self.rotary_base)
 
         if (
             self.recompute_granularity == "full"

--- a/mcore_adapter/src/mcore_adapter/models/qwen2/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2/__init__.py
@@ -31,6 +31,7 @@ register_template(
         "intermediate_size": "ffn_hidden_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
     },
     constant_mca_config={

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/__init__.py
@@ -4,6 +4,7 @@ from ..converter.template import (
     QKVConverOp,
     RenameConverOp,
     StackConverOp,
+    VisionTemplate,
     register_template,
 )
 from .config_qwen2_5_vl import Qwen2_5_VLConfig
@@ -23,6 +24,7 @@ register_dist_config(
 register_template(
     "qwen2_5_vl",
     hf_layer_prefix="model.layers.",
+    template_class=VisionTemplate,
     config_hf_to_mca={
         "max_position_embeddings": "max_sequence_length",
         "hidden_size": "hidden_size",
@@ -43,6 +45,7 @@ register_template(
         "video_token_id": "video_token_id",
         "vision_config": "vision_config",
         "rope_scaling": "rope_scaling",
+        "rope_parameters": "rope_parameters",
     },
     constant_mca_config={
         "swiglu": True,

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/config_qwen2_5_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_5_vl/config_qwen2_5_vl.py
@@ -40,5 +40,7 @@ class Qwen2_5_VLConfig(McaModelConfig):
             * vision_config_obj.temporal_patch_size
         )  # 1176
         self.mrope_section = self.rope_scaling.get("mrope_section")
+        if self.mrope_section is None:
+            self.mrope_section = self.rope_parameters.get("mrope_section")
 
         assert self.hidden_dropout == 0.0, "hidden dropout is Not supported for qwen2_5_vl yet."

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_moe/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_moe/__init__.py
@@ -31,6 +31,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "moe_intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_vl/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_vl/__init__.py
@@ -4,6 +4,7 @@ from ..converter.template import (
     QKVConverOp,
     RenameConverOp,
     StackConverOp,
+    VisionTemplate,
     register_template,
 )
 from .config_qwen2_vl import Qwen2VLConfig
@@ -23,6 +24,7 @@ register_dist_config(
 register_template(
     "qwen2_vl",
     hf_layer_prefix="model.layers.",
+    template_class=VisionTemplate,
     config_hf_to_mca={
         "max_position_embeddings": "max_sequence_length",
         "hidden_size": "hidden_size",
@@ -43,6 +45,7 @@ register_template(
         "video_token_id": "video_token_id",
         "vision_config": "vision_config",
         "rope_scaling": "rope_scaling",
+        "rope_parameters": "rope_parameters",
     },
     constant_mca_config={
         "swiglu": True,

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_vl/config_qwen2_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_vl/config_qwen2_vl.py
@@ -39,5 +39,7 @@ class Qwen2VLConfig(McaModelConfig):
             * vision_config_obj.temporal_patch_size
         )  # 1176
         self.mrope_section = self.rope_scaling.get("mrope_section")
+        if self.mrope_section is None:
+            self.mrope_section = self.rope_parameters.get("mrope_section")
 
         assert self.hidden_dropout == 0.0, "hidden dropout is Not supported for qwen2_vl yet."

--- a/mcore_adapter/src/mcore_adapter/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen2_vl/modeling_qwen2_vl.py
@@ -74,7 +74,7 @@ class Qwen2VLModel(McaGPTModel, ModuleUtilsMixin):
             image_input_lengths, pixel_values, grid_thw, None
         )
 
-        vision_model_dtype = self.vision_model.blocks[0].mlp.down_proj.weight.dtype
+        vision_model_dtype = self.vision_model.blocks[0].mlp.fc1.weight.dtype
         pixel_values = pixel_values.type(vision_model_dtype)
         image_embeds = self.vision_model(pixel_values, grid_thw=grid_thw)
         if not isinstance(image_embeds, torch.Tensor):

--- a/mcore_adapter/src/mcore_adapter/models/qwen3/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3/__init__.py
@@ -1,3 +1,4 @@
+from ...utils import is_megatron_llama
 from ..auto.config_auto import register_config
 from ..auto.modeling_auto import register_model
 from ..converter.dist_converter import default_dist_config, register_dist_config
@@ -10,7 +11,6 @@ from ..converter.template import (
 )
 from ..model_config import McaModelConfig
 from ..model_factory import McaGPTModel
-from ...utils import is_megatron_llama
 
 
 register_config("qwen3", McaModelConfig)
@@ -34,6 +34,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
     },

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_5/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_5/__init__.py
@@ -27,7 +27,7 @@ from ..converter.template import (
     GDNConv1dConverOp,
     RenameConverOp,
     StackConverOp,
-    Template,
+    VisionTemplate,
     ZeroCenteredRMSNormConverOp,
     register_template,
 )
@@ -87,24 +87,11 @@ register_dist_config(
 
 
 @dataclass
-class Qwen3_5Template(Template):
+class Qwen3_5Template(VisionTemplate):
     def __post_init__(self):
         super().__post_init__()
         self.hf_ln_pattern = re.compile(r"^model\.language_model\.layers\.(\d+)\.input_layernorm\.weight$")
         self.mca_ln_pattern = re.compile(r"^decoder\.layers\.(\d+)\.self_attention\.in_proj\.layer_norm_weight$")
-
-    def adjust_config_hf_to_mca(self):
-        non_text_config_keys = set(
-            list(filter(lambda k: k.endswith("_token_id"), self.config_hf_to_mca.keys()))
-            + ["vision_config", "tie_word_embeddings"]
-        )
-        new_config_hf_to_mca = {}
-        for hf_key, mca_key in self.config_hf_to_mca.items():
-            new_hf_key = hf_key
-            if hf_key not in non_text_config_keys:
-                new_hf_key = "text_config." + new_hf_key
-            new_config_hf_to_mca[new_hf_key] = mca_key
-        return new_config_hf_to_mca
 
     def add_hf_weight(self, name, weight):
         match = re.match(self.hf_ln_pattern, name)
@@ -249,7 +236,7 @@ register_template(
         "image_token_id": "image_token_id",
         "video_token_id": "video_token_id",
         "vision_config": "vision_config",
-        "rope_parameters": "rope_scaling",
+        "rope_parameters": "rope_parameters",
         # Linear attention
         "linear_conv_kernel_dim": "linear_conv_kernel_dim",
         "linear_key_head_dim": "linear_key_head_dim",

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_5/config_qwen3_5.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_5/config_qwen3_5.py
@@ -44,9 +44,12 @@ class Qwen3_5Config(McaModelConfig):
             * vision_config_obj.in_channels
             * vision_config_obj.temporal_patch_size
         )  # 1176
-        self.mrope_section = self.rope_scaling.get("mrope_section")
-        self.rotary_base = self.rope_scaling.get("rope_theta")
-        self.rotary_percent = self.rope_scaling.get("partial_rotary_factor")
+        if self.rope_parameters is None and self.rope_scaling is not None:
+            self.rope_parameters = self.rope_scaling
+
+        self.mrope_section = self.rope_parameters.get("mrope_section")
+        self.rotary_base = self.rope_parameters.get("rope_theta")
+        self.rotary_percent = self.rope_parameters.get("partial_rotary_factor")
 
         assert self.hidden_dropout == 0.0, "hidden dropout is Not supported for qwen3_5 yet."
         if self.layer_types is None:

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_5_moe/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_5_moe/__init__.py
@@ -150,7 +150,7 @@ register_template(
         "image_token_id": "image_token_id",
         "video_token_id": "video_token_id",
         "vision_config": "vision_config",
-        "rope_parameters": "rope_scaling",
+        "rope_parameters": "rope_parameters",
         # Linear attention
         "linear_conv_kernel_dim": "linear_conv_kernel_dim",
         "linear_key_head_dim": "linear_key_head_dim",

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_moe/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_moe/__init__.py
@@ -1,3 +1,4 @@
+from ...utils import is_megatron_llama
 from ..auto.config_auto import register_config
 from ..auto.modeling_auto import register_model
 from ..converter.dist_converter import default_dist_config, register_dist_config, shared_moe_dist_config
@@ -10,7 +11,6 @@ from ..converter.template import (
 )
 from ..model_config import McaModelConfig
 from ..model_factory import McaGPTModel
-from ...utils import is_megatron_llama
 
 
 register_config("qwen3_moe", McaModelConfig)
@@ -34,6 +34,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_next/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_next/__init__.py
@@ -138,6 +138,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_omni/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_omni/__init__.py
@@ -73,6 +73,7 @@ register_template(
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
         "rope_scaling": "rope_scaling",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_omni/config_qwen3_omni.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_omni/config_qwen3_omni.py
@@ -65,5 +65,7 @@ class Qwen3OmniMoeConfig(McaModelConfig):
             * vision_config_obj.in_channels
             * vision_config_obj.temporal_patch_size
         )  # 1536
-        assert "mrope_section" in self.rope_scaling, "mrope_section is required"
+
         self.mrope_section = self.rope_scaling.get("mrope_section")
+        if self.mrope_section is None:
+            self.mrope_section = self.rope_parameters.get("mrope_section")

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_vl/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_vl/__init__.py
@@ -6,7 +6,7 @@ from ..converter.template import (
     QKVConverOp,
     RenameConverOp,
     StackConverOp,
-    Template,
+    VisionTemplate,
     register_template,
 )
 from .config_qwen3_vl import Qwen3VLConfig
@@ -24,33 +24,10 @@ register_dist_config(
 )
 
 
-@dataclass
-class Qwen3VLTemplate(Template):
-    def adjust_config_hf_to_mca(self):
-        # NOTE: for `tie_word_embeddings`,
-        # in qwen3-vl model like Qwen/Qwen3-VL-4B-Instruct, tie_word_embeddings
-        # exists both in inner and outer of text_config, and both are True
-        # in qwen3-vl-moe model like Qwen/Qwen3-VL-30B-A3B-Instruct, tie_word_embeddings
-        # in outer of text_config is False while it uses the default value True in the
-        # inner of text_config
-        # currently, both use tie_word_embeddings in the outter of text_config
-        non_text_config_keys = set(
-            list(filter(lambda k: k.endswith("_token_id"), self.config_hf_to_mca.keys()))
-            + ["vision_config", "tie_word_embeddings"]
-        )
-        new_config_hf_to_mca = {}
-        for hf_key, mca_key in self.config_hf_to_mca.items():
-            new_hf_key = hf_key
-            if hf_key not in non_text_config_keys:
-                new_hf_key = "text_config." + new_hf_key
-            new_config_hf_to_mca[new_hf_key] = mca_key
-        return new_config_hf_to_mca
-
-
 register_template(
     "qwen3_vl",
     hf_layer_prefix="model.language_model.layers.",
-    template_class=Qwen3VLTemplate,
+    template_class=VisionTemplate,
     config_hf_to_mca={
         "max_position_embeddings": "max_sequence_length",
         "hidden_size": "hidden_size",
@@ -74,6 +51,7 @@ register_template(
         "video_token_id": "video_token_id",
         "vision_config": "vision_config",
         "rope_scaling": "rope_scaling",
+        "rope_parameters": "rope_parameters",
     },
     constant_mca_config={
         "swiglu": True,

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_vl/config_qwen3_vl.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_vl/config_qwen3_vl.py
@@ -47,3 +47,5 @@ class Qwen3VLConfig(McaModelConfig):
             * vision_config_obj.temporal_patch_size
         )  # 1176
         self.mrope_section = self.rope_scaling.get("mrope_section")
+        if self.mrope_section is None:
+            self.mrope_section = self.rope_parameters.get("mrope_section")

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_vl_moe/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_vl_moe/__init__.py
@@ -23,9 +23,10 @@ from ..converter.template import (
     QKVConverOp,
     RenameConverOp,
     StackedTensors,
+    VisionTemplate,
     register_template,
 )
-from ..qwen3_vl import Qwen3VLConfig, Qwen3VLModel, Qwen3VLTemplate
+from ..qwen3_vl import Qwen3VLConfig, Qwen3VLModel
 
 
 if TYPE_CHECKING:
@@ -82,7 +83,7 @@ register_dist_config(
 
 
 @dataclass
-class Qwen3VLMoeTemplate(Qwen3VLTemplate):
+class Qwen3VLMoeTemplate(VisionTemplate):
     def add_mca_weight(self, name, weight, **kwargs):
         weight_prefix = get_mca_weight_prefix(name)
         original_name = remove_mca_weight_prefix(name)
@@ -136,6 +137,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         # MoE related

--- a/mcore_adapter/src/mcore_adapter/models/seed_oss/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/seed_oss/__init__.py
@@ -33,6 +33,7 @@ register_template(
         "vocab_size": "padded_vocab_size",
         "attention_dropout": "attention_dropout",
         "rope_theta": "rotary_base",
+        "rope_parameters": "rope_parameters",
         "intermediate_size": "ffn_hidden_size",
         "tie_word_embeddings": "tie_embeddings_and_output_weights",
         "hidden_dropout": "residual_dropout"

--- a/mcore_adapter/src/mcore_adapter/patcher.py
+++ b/mcore_adapter/src/mcore_adapter/patcher.py
@@ -3,7 +3,13 @@ import sys
 from bisect import bisect_right, insort
 from typing import Optional
 
+import megatron.core.transformer.moe.router
 import torch
+from megatron.core.transformer.moe.moe_utils import (
+    get_tokens_per_expert_and_token_count,
+    save_to_aux_losses_tracker,
+    switch_load_balancing_loss_func,
+)
 from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharding_spec._internals import _check_shard_metadata_pair_overlap
 from torch.distributed.checkpoint.default_planner import (
@@ -157,3 +163,134 @@ def patch_torch_validate_global_plan():
         return all_good
 
     torch.distributed.checkpoint.default_planner._validate_global_plan = _validate_global_plan
+
+
+def patch_hybrid_optimizer():
+    def _update_fp32_params_by_new_state(self):
+        if not self.param_update_in_fp32 or not self.param_to_fp32_param:
+            return
+        for param, v in self.state.items():
+            fp32_param = self.param_to_fp32_param[param]
+            fp32_param.data.copy_(v["master_param"])
+
+    from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
+
+    HybridDeviceOptimizer._update_fp32_params_by_new_state = _update_fp32_params_by_new_state
+
+
+def patch_megatron_preload_tensors_non_blocking(non_blocking: bool = False):
+    """
+    Patch FileSystemWriterAsync.get_save_function_and_args to control the
+    non_blocking parameter passed to preload_tensors during async checkpoint D2H.
+
+    On certain GPU+CPU hardware combinations, async D2H (non_blocking=True) in
+    Megatron's checkpoint saving can cause segmentation faults. This patch
+    allows controlling the non_blocking behavior via McoreAdapter's args.
+
+    This patch is compatible with Megatron-Core versions (>=0.13.0),
+    as the get_save_function_and_args API signature is identical across versions.
+
+    Args:
+        non_blocking (bool): Whether to use non_blocking D2H transfer.
+            Default is False (synchronous, safe for all hardware).
+    """
+    if non_blocking:
+        logger.info("Skip patch mcore preload_tensors when non_blocking=True...")
+        return
+
+    try:
+        from megatron.core.dist_checkpointing.strategies.filesystem_async import (
+            FileSystemWriterAsync,
+        )
+    except ImportError:
+        logger.warning("megatron.core.dist_checkpointing not available, skipping preload_tensors patch")
+        return
+
+    import inspect
+    from functools import partial
+
+    _original_get_save_function_and_args = FileSystemWriterAsync.get_save_function_and_args
+
+    def patched_get_save_function_and_args(self):
+        result = _original_get_save_function_and_args(self)
+
+        if len(result) != 3:
+            logger.warning(
+                f"The return vals of get_save_function_and_args is not 3, skipping preload_tensors patch, check the mcore version."
+            )
+            return result
+
+        save_fn, _preload_fn, args = result
+        if _preload_fn is None:
+            return result
+
+        params = list(inspect.signature(_preload_fn.func).parameters.keys())
+        if "non_blocking" not in params:
+            logger.warning("preload_tensors no longer has 'non_blocking' parameter, skipping patch")
+            return result
+
+        # Override preload_fn with configured non_blocking value
+        new_args = list(_preload_fn.args)
+        non_blocking_idx = params.index("non_blocking")
+        new_args[non_blocking_idx] = non_blocking
+        preload_fn = partial(_preload_fn.func, *new_args)
+        return (save_fn, preload_fn, args)
+
+    logger.info(
+        f"Patched FileSystemWriterAsync.get_save_function_and_args with non_blocking={non_blocking} for D2H transfers"
+    )
+    FileSystemWriterAsync.get_save_function_and_args = patched_get_save_function_and_args
+
+
+def patch_apply_aux_loss():
+    def _apply_aux_loss(
+        self,
+        probs: torch.Tensor,
+        scores_for_aux_loss: torch.Tensor,
+        routing_map: torch.Tensor,
+        with_padding_mask: bool = False,
+    ):
+        """Apply the auxiliary loss for the given scores and routing map."""
+        aux_loss_coeff = self.get_aux_loss_coeff("aux_loss")
+        if aux_loss_coeff == 0:
+            return probs
+
+        global_tokens_per_expert, local_num_tokens, total_num_tokens = get_tokens_per_expert_and_token_count(
+            routing_map=routing_map,
+            reduce_group=self.tp_cp_group,
+            topk=self.topk,
+            with_padding_mask=with_padding_mask,
+        )
+        tokens_per_expert_for_statistics = global_tokens_per_expert.detach().clone()
+        num_layers = self.config.num_layers
+        if self.config.mtp_num_layers is not None:
+            num_layers += self.config.mtp_num_layers
+        save_to_aux_losses_tracker(
+            "expert_distributed_std",
+            torch.std(tokens_per_expert_for_statistics.to(torch.float), unbiased=False),
+            self.layer_number,
+            num_layers,
+        )
+        save_to_aux_losses_tracker(
+            "max_token_per_expert", torch.max(tokens_per_expert_for_statistics), self.layer_number, num_layers
+        )
+        aux_loss = switch_load_balancing_loss_func(
+            probs=scores_for_aux_loss,
+            tokens_per_expert=global_tokens_per_expert,
+            total_num_tokens=total_num_tokens,
+            topk=self.topk,
+            num_experts=self.config.num_moe_experts,
+            moe_aux_loss_coeff=aux_loss_coeff,
+            fused=self.config.moe_router_fusion,
+        )
+        probs = self.attach_and_log_load_balancing_loss(
+            probs,
+            aux_loss_coeff,
+            aux_loss,
+            "load_balancing_loss",
+            self.tp_cp_group,
+            valid_token_count=local_num_tokens,
+        )
+        return probs
+
+    megatron.core.transformer.moe.router.TopKRouter._apply_aux_loss = _apply_aux_loss

--- a/mcore_adapter/src/mcore_adapter/trainer/trainer.py
+++ b/mcore_adapter/src/mcore_adapter/trainer/trainer.py
@@ -51,7 +51,13 @@ from transformers.utils import is_peft_available
 from ..checkpointing import get_checkpoint_dir, load_state_dict_from_checkpoint
 from ..constants import ADAPTER_CONFIG_NAME, DIST_OPTIMIZER_DIR, IGNORE_INDEX
 from ..initialize import initialize_megatron
-from ..patcher import patch_torch_find_nd_overlapping_shards, patch_torch_validate_global_plan
+from ..patcher import (
+    patch_apply_aux_loss,
+    patch_hybrid_optimizer,
+    patch_megatron_preload_tensors_non_blocking,
+    patch_torch_find_nd_overlapping_shards,
+    patch_torch_validate_global_plan,
+)
 from ..platforms import current_platform
 from ..training_args import TrainingArguments
 from ..utils import distributed_reduce, get_logger, is_transformers_version_greater_than
@@ -93,6 +99,9 @@ class McaTrainer(Trainer):
             self.processing_class: PreTrainedTokenizer = kwargs.get("tokenizer")
         patch_torch_find_nd_overlapping_shards()
         patch_torch_validate_global_plan()
+        patch_megatron_preload_tensors_non_blocking(non_blocking=args.ckpt_d2h_non_blocking)
+        patch_hybrid_optimizer()
+        patch_apply_aux_loss()
         initialize_megatron(args=args)
         self.args = args
         super().__init__(

--- a/mcore_adapter/src/mcore_adapter/training_args.py
+++ b/mcore_adapter/src/mcore_adapter/training_args.py
@@ -385,6 +385,14 @@ class MegatronArguments(DistributingParallelArguments):
             "`torch_dist` is a megatron built-in distributed checkpointing format"
         },
     )
+    ckpt_d2h_non_blocking: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether set non_blocking=True for GPU-to-CPU (D2H) tensor transfers during async checkpoint saving. "
+            "Default is False (synchronous D2H) to avoid segfaults on certain GPU+CPU hardware combinations. "
+            "Set to True only if your hardware supports reliable async pinned memory transfers."
+        },
+    )
 
     sequence_packing: bool = field(
         default=False,


### PR DESCRIPTION
## What does this PR do?

This PR adds first-class support for `rope_parameters` to ensure MCore Adapter compatibility with Transformers v5+.

In newer Transformers versions, model RoPE configurations may be exposed through `rope_parameters`. MCore Adapter previously relied primarily on `rope_scaling` and `rope_theta`, which could result in missing or incorrectly converted rotary-position settings.

## Key changes

- Add `rope_parameters` to the common MCore Adapter model configuration.
- Propagate `rope_parameters` during HF-to-MCore configuration conversion.
- Read the following settings from `rope_parameters` where applicable:
  - `rope_theta`
  - `partial_rotary_factor`
  - `mrope_section`
- Enable `rope_parameters` support across Llama, Mistral, Mixtral, DeepSeek, GLM, Qwen, and Seed-OSS model families.
- Preserve backward compatibility with models and older Transformers versions that use `rope_scaling` or top-level `rope_theta`.
- Introduce a reusable `VisionTemplate` to correctly map nested `text_config` fields for multimodal models.
- Update Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, and Qwen3.5 configuration conversion accordingly.

## Additional fixes

- Improve asynchronous checkpoint D2H transfer compatibility on affected hardware.
- Restore FP32 parameters correctly when loading hybrid optimizer states.
- Improve MoE auxiliary-loss statistics and MTP layer accounting.
- Fix Qwen2-VL vision input dtype detection.

## Compatibility

This PR targets Transformers v5+ while retaining compatibility with existing configurations based on `rope_scaling`.