### PR TITLE
fix(advantage): skip whitening for short responses

### DIFF
--- a/roll/pipeline/agentic/utils.py
+++ b/roll/pipeline/agentic/utils.py
@@ -468,10 +468,14 @@ def agentic_compute_advantage(
 ):
     if response_mask is None:
         response_mask = data.batch["response_mask"][:, 1:]
-    if response_mask.sum() == 0:
+    valid_token_count = int(response_mask.sum().item())
+    # masked_whiten uses Bessel's correction, so unbiased variance is undefined with fewer than two valid tokens.
+    if valid_token_count <= 1:
         whiten_rewards = False
         whiten_advantages = False
-        logger.info("Warning: domain final_response_mask.sum() == 0! All masked_whiten will be skipped.")
+        logger.warning(
+            f"Only {valid_token_count} valid response token(s) remain; reward and advantage whitening are disabled."
+        )
 
     # Check OPD config
     is_pure_opd = getattr(pipeline_config, "is_pure_opd", False) if pipeline_config else False

--- a/roll/utils/functionals.py
+++ b/roll/utils/functionals.py
@@ -1096,10 +1096,14 @@ def compute_advantage(
 ):
     if response_mask is None:
         response_mask = data.batch["response_mask"][:, 1:]
-    if response_mask.sum() == 0:
+    valid_token_count = int(response_mask.sum().item())
+    # masked_whiten uses Bessel's correction, so unbiased variance is undefined with fewer than two valid tokens.
+    if valid_token_count <= 1:
         whiten_rewards = False
         whiten_advantages = False
-        logger.info("Warning: domain final_response_mask.sum() == 0! All masked_whiten will be skipped.")
+        logger.warning(
+            f"Only {valid_token_count} valid response token(s) remain; reward and advantage whitening are disabled."
+        )
 
     # Check OPD config
     is_pure_opd = getattr(pipeline_config, "is_pure_opd", False) if pipeline_config else False

--- a/tests/utils/test_compute_advantage.py
+++ b/tests/utils/test_compute_advantage.py
@@ -1,0 +1,53 @@
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from roll.distributed.scheduler.protocol import DataProto
+from roll.pipeline.agentic.utils import agentic_compute_advantage
+from roll.utils.functionals import compute_advantage
+
+
+@pytest.mark.parametrize("compute_fn", [compute_advantage, agentic_compute_advantage])
+@pytest.mark.parametrize(
+    ("response_mask", "expected_advantages"),
+    [
+        (
+            torch.tensor([[0, 0, 0]], dtype=torch.long),
+            torch.tensor([[0.0, 0.0, 0.0]]),
+        ),
+        (
+            torch.tensor([[0, 1, 0]], dtype=torch.long),
+            torch.tensor([[0.0, 3.0, 0.0]]),
+        ),
+        (
+            torch.tensor([[1, 1, 0]], dtype=torch.long),
+            torch.tensor([[-0.70710677, 0.70710677, 0.0]]),
+        ),
+    ],
+)
+def test_compute_advantage_handles_short_response_masks(
+    compute_fn: Callable[..., DataProto],
+    response_mask: torch.Tensor,
+    expected_advantages: torch.Tensor,
+) -> None:
+    """Whitening is skipped below two valid tokens and retained otherwise."""
+    data = DataProto.from_dict(
+        tensors={
+            "token_level_rewards": torch.tensor([[1.0, 3.0, 0.0]]),
+        }
+    )
+
+    result = compute_fn(
+        data=data,
+        gamma=0.0,
+        lambd=1.0,
+        adv_estimator="reinforce",
+        whiten_rewards=True,
+        whiten_advantages=True,
+        response_mask=response_mask,
+    )
+
+    assert torch.isfinite(result.batch["token_level_rewards"]).all()
+    assert torch.isfinite(result.batch["advantages"]).all()
+    torch.testing.assert_close(result.batch["advantages"], expected_advantages)


### PR DESCRIPTION
## Overview

Prevent advantage computation from failing when response filtering leaves fewer than two valid response tokens. This change applies the same guard to the RLVR and Agentic paths and adds focused regression coverage.

Fixes #475.

## Design

ROLL uses unbiased variance in `masked_whiten`, which requires at least two valid values. Each advantage entry point now counts valid response tokens once and disables reward and advantage whitening when the count is zero or one. Existing whitening and variance behavior remains unchanged for two or more valid tokens.

The fix is intentionally scoped to the call sites rather than changing `masked_var` or the statistical convention used by other algorithms.

### Why fewer than two valid tokens cannot be whitened

In ROLL's GRPO path, optional reward and advantage whitening eventually calls `masked_whiten`, which computes variance through `masked_var(..., unbiased=True)`. The unbiased estimator applies Bessel's correction:

```text
s^2 = sum((x_i - mean)^2) / (n - 1)
```

For `n = 1`, the denominator is zero and `masked_var` intentionally raises `ValueError`. This happens before `masked_whiten` evaluates `torch.rsqrt(var + 1e-8)`, so the epsilon in that expression cannot prevent the failure. Skipping whitening preserves the only remaining reward or advantage instead of changing the estimator or turning the learning signal into zero.

## Key changes

- Update RLVR `compute_advantage` to skip whitening when fewer than two valid response tokens remain.
- Apply the same behavior to Agentic `agentic_compute_advantage`.
- Emit a warning containing the valid-token count when whitening is disabled.
- Add parameterized regression tests covering zero, one, and two valid tokens for both paths.

## Impact

- Avoids the single-valid-token `ValueError` from unbiased masked variance.
- Preserves existing behavior for normal batches.
- Does not change GRPO reward normalization or variance correction semantics.

## Test results

- `python -m pytest tests/utils/test_compute_advantage.py -q`: **6 passed**
- `ruff check tests/utils/test_compute_advantage.py`: **passed**
- `python -m py_compile roll/utils/functionals.py roll/pipeline/agentic/utils.py tests/utils/test_compute_advantage.py`: **passed**
- `git diff --check`: **passed**

Full-file Ruff checks on the two existing production modules still report pre-existing import-order, unused-import, and E711 findings unrelated to this change; no unrelated cleanup is included.
