### PR TITLE
fix: pin click<8.2 to unbreak ray CLIPatch 1

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,4 +1,6 @@
 ray[default,cgraph]==2.48.0 # vllm required ray[default,cgraph]>=2.48.0
++click<8.2  # ray 2.48.0 CLI breaks on click>=8.2: deepcopy of click's Sentinel enum raises ValueError
+ numpy<2.0a0,>=1.25
 numpy<2.0a0,>=1.25
 tensordict>=0.10.0
 sympy

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,6 +1,5 @@
 ray[default,cgraph]==2.48.0 # vllm required ray[default,cgraph]>=2.48.0
-+click<8.2  # ray 2.48.0 CLI breaks on click>=8.2: deepcopy of click's Sentinel enum raises ValueError
- numpy<2.0a0,>=1.25
+click<8.2  # ray 2.48.0 CLI breaks on click>=8.2: deepcopy of click's Sentinel enum raises ValueError
 numpy<2.0a0,>=1.25
 tensordict>=0.10.0
 sympy


### PR DESCRIPTION
## Problem

A fresh install per `requirements_torch280_vllm.txt` leaves the `ray` CLI completely broken — every `ray` command fails at import time:

```
ValueError: <object object at 0x7fa70eca36e0> is not a valid Sentinel
```

`requirements_common.txt` pins `ray==2.48.0` but leaves `click` unconstrained, so pip resolves click 8.4.x. Ray 2.48's CLI calls `copy.deepcopy()` on click command objects at module import time (`add_command_alias` in `ray/scripts/scripts.py`), which fails on click>=8.2 where `Sentinel` became an enum — `enum.__new__` rejects the dynamically created sentinel object during reconstruction.

## Repro

Fresh conda env (Python 3.10.20), install per `requirements_torch280_vllm.txt`, then run any ray command, e.g. `ray start --head`.

<details>
<summary>Full traceback</summary>

```
Traceback (most recent call last):
  File "/root/.miniconda3/envs/roll/bin/ray", line 3, in <module>
    from ray.scripts.scripts import main
  File "/root/.miniconda3/envs/roll/lib/python3.10/site-packages/ray/scripts/scripts.py", line 2681, in <module>
    add_command_alias(up, name="create_or_update", hidden=True)
  File "/root/.miniconda3/envs/roll/lib/python3.10/site-packages/ray/scripts/scripts.py", line 2671, in add_command_alias
    new_command = copy.deepcopy(command)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 206, in _deepcopy_list
    append(deepcopy(a, memo))
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/root/.miniconda3/envs/roll/lib/python3.10/copy.py", line 265, in _reconstruct
    y = func(*args)
  File "/root/.miniconda3/envs/roll/lib/python3.10/enum.py", line 385, in __call__
    return cls.__new__(cls, value)
  File "/root/.miniconda3/envs/roll/lib/python3.10/enum.py", line 710, in __new__
    raise ve_exc
ValueError: <object object at 0x7fa70eca36e0> is not a valid Sentinel
```

</details>

## Fix

Pin `click<8.2` in `requirements_common.txt`, right below the `ray` pin it belongs to.

Verified with click 8.1.8 on the same env — `ray start --head` and `ray status` both work again.

## Note

This is a workaround for an upstream ray/click incompatibility; the pin can be removed once ray supports click>=8.2. The env dump in #379 shows click 8.2.1, already past the breaking version.