### PR TITLE
fix: is_offload_optimizer_states_in_train_step not passed to batch.meta_info in RLVR and agentic pipelines

### DIFF
--- a/roll/pipeline/agentic/agentic_pipeline.py
+++ b/roll/pipeline/agentic/agentic_pipeline.py
@@ -314,6 +314,7 @@ class AgenticPipeline(BasePipeline):
                     batch.meta_info["global_step"] = global_step
                     batch.meta_info["_broadcast_non_tensor_batch"] = True
                     batch.meta_info["loss_mask_keys"] = ["response_mask"]
+                    batch.meta_info["is_offload_optimizer_states_in_train_step"] = self.pipeline_config.is_offload_optimizer_states_in_train_step
 
                     if val_future is not None:
                         val_metrics = val_future.result()

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -570,6 +570,7 @@ class RLVRPipeline(BasePipeline):
                 batch.meta_info["global_step"] = global_step
                 batch.meta_info["_broadcast_non_tensor_batch"] = True
                 batch.meta_info["loss_mask_keys"] = ['response_mask', 'final_response_mask']
+                batch.meta_info["is_offload_optimizer_states_in_train_step"] = self.pipeline_config.is_offload_optimizer_states_in_train_step
                 batch.non_tensor_batch['sample_uuid'] = np.array([str(uuid.uuid4()) for _ in range(batch.batch.shape[0])], dtype=object)
                 batch.batch["prompt_id"] = torch.arange(batch.batch.batch_size[0], device=batch.batch.device)
 


### PR DESCRIPTION
## Description

`is_offload_optimizer_states_in_train_step` controls whether optimizer states are offloaded to CPU after each train step (saving GPU memory at the cost of CPU-GPU transfer overhead). This field is defined in `base_config.py` with default `False`, and should be passed from each pipeline's config to `batch.meta_info` so that `MegatronTrainStrategy.train_step` can read it.

However, in the RLVR and agentic pipelines, this field was missing from `batch.meta_info` during training. As a result, `MegatronTrainStrategy.train_step` falls back to its hardcoded default `True`, rendering the user's yaml configuration ineffective.

## Changes

- **rlvr_pipeline.py**: Added `is_offload_optimizer_states_in_train_step` to training batch's `meta_info`, reading from `self.pipeline_config`
- **agentic_pipeline.py**: Same fix

## Impact

Users can now control `is_offload_optimizer_states_in_train_step` via yaml configuration in RLVR and agentic training workflows. Previously, the setting was silently ignored.