### PR TITLE
fix(scheduler): preserve multi_modal_data when building gen_batch in get_batch_opt_level_0

### DIFF
--- a/roll/distributed/scheduler/generate_scheduler.py
+++ b/roll/distributed/scheduler/generate_scheduler.py
@@ -579,7 +579,16 @@ class DynamicSamplingScheduler(RolloutMockMixin):
             request_data: DataProto = DataProto.from_single_dict(collect_data, meta_info=data.meta_info)
             request_data.batch["prompt_id"] = torch.arange(request_data.batch.batch_size[0], device=request_data.batch.device)
 
-            gen_batch = request_data.pop(batch_keys=["input_ids", "attention_mask", "position_ids"])
+            generate_non_tensor_batch_keys = []
+            if "multi_modal_data" in request_data.non_tensor_batch:
+                generate_non_tensor_batch_keys.append("multi_modal_data")
+
+            gen_batch = request_data.pop(
+                batch_keys=["input_ids", "attention_mask", "position_ids"],
+                non_tensor_batch_keys=generate_non_tensor_batch_keys,
+            )
+            for key in generate_non_tensor_batch_keys:
+                request_data.non_tensor_batch[key] = gen_batch.non_tensor_batch[key]
             gen_batch.meta_info = request_data.meta_info
             num_return_sequences = generation_config["num_return_sequences"]
             request_data = request_data.repeat(repeat_times=num_return_sequences)

--- a/tests/distributed/scheduler/test_multi_modal_data_opt_level_0.py
+++ b/tests/distributed/scheduler/test_multi_modal_data_opt_level_0.py
@@ -1,0 +1,79 @@
+"""Bug: get_batch_opt_level_0() drops multi_modal_data before it reaches generation.
+
+DynamicSamplingScheduler.get_batch_opt_level_0() built gen_batch with
+    request_data.pop(batch_keys=["input_ids", "attention_mask", "position_ids"])
+which never carries non_tensor_batch["multi_modal_data"] into gen_batch. For VLM
+requests, the generation backend (router.py / sglang_strategy.py, which read
+multi_modal_data from batch.non_tensor_batch to build image payloads) then receives
+a text-only prompt that still contains image placeholder tokens, and the model's
+M-RoPE position code indexes an empty image_grid_thw, producing an IndexError.
+
+Fix: forward multi_modal_data into gen_batch via pop()'s non_tensor_batch_keys, same
+as PR #446 (ae4c065), which a later release-publish commit (7f9d4d3) accidentally
+dropped again.
+"""
+
+import asyncio
+
+import numpy as np
+import torch
+
+from roll.distributed.scheduler.generate_scheduler import DynamicSamplingScheduler
+from roll.distributed.scheduler.protocol import DataProto
+
+
+class _RecordingActorCluster:
+    dp_size = 1
+
+    def __init__(self):
+        self.received_keys = None
+
+    def generate(self, gen_batch):
+        # Snapshot immediately: gen_batch may be aliased and mutated by a later union().
+        self.received_keys = set(gen_batch.non_tensor_batch.keys())
+        return gen_batch
+
+
+class _NoOpRewardScheduler:
+    async def compute_rewards(self, data, reward_clusters, pipeline_config):
+        return DataProto(meta_info={"metrics": {}})
+
+
+def _next_vlm_item():
+    return {
+        "prompt": torch.ones((1, 1)),
+        "domain": np.array(["default"], dtype=object),
+        "multi_modal_data": np.array([{"image": ["fake"]}], dtype=object),
+    }
+
+
+def _collect_fn(data_item_list):
+    assert len(data_item_list) == 1
+    return data_item_list[0]
+
+
+def test_get_batch_opt_level_0_forwards_multi_modal_data():
+    async def run():
+        actor_cluster = _RecordingActorCluster()
+
+        class _Scheduler:
+            is_val = True
+            get_next_dataset_item = staticmethod(_next_vlm_item)
+            collect_fn = staticmethod(_collect_fn)
+
+        scheduler = _Scheduler()
+        scheduler.actor_cluster = actor_cluster
+        scheduler.reward_scheduler = _NoOpRewardScheduler()
+        scheduler.reward_clusters = {}
+        scheduler.pipeline_config = object()
+
+        data = DataProto(meta_info={"generation_config": {"num_return_sequences": 1}})
+        await DynamicSamplingScheduler.get_batch_opt_level_0(scheduler, data, batch_size=1)
+
+        assert actor_cluster.received_keys is not None
+        assert "multi_modal_data" in actor_cluster.received_keys, (
+            "multi_modal_data must reach actor_cluster.generate() for VLM requests; "
+            f"got non_tensor_batch keys {actor_cluster.received_keys}"
+        )
+
+    asyncio.run(run())


### PR DESCRIPTION
`get_batch_opt_level_0()` builds `gen_batch` from `request_data.pop(batch_keys=["input_ids", "attention_mask", "position_ids"])`, which only copies tensor keys. For VLM requests, `non_tensor_batch["multi_modal_data"]` never reaches `gen_batch`, so `actor_cluster.generate()` receives a text-only prompt that still contains image placeholder tokens. The generation backend's M-RoPE position code then indexes an empty `image_grid_thw`, raising `IndexError`.

Forward `multi_modal_data` through `pop()`'s `non_tensor_batch_keys` argument (the same mechanism this file already uses for other provider-specific fields), and restore it on `request_data` so downstream reward computation still sees it.

This restores a fix already reviewed and merged once, PR #446 (`ae4c065`). A later 306-file release-publish commit (`7f9d4d3`, "publish v0.3.0") reverted that hunk back to the bare `pop()` with no stated reason, most likely lost during a rebase for the version bump.

- Added `tests/distributed/scheduler/test_multi_modal_data_opt_level_0.py`: fails with `AssertionError` on `main` (`multi_modal_data` is absent from the keys `actor_cluster.generate()` receives), passes with this fix. Ran directly (`pytest tests/distributed/scheduler/test_multi_modal_data_opt_level_0.py`); this directory is not in `Unit Tests (CPU)`'s covered paths, so it does not run in that CI job.
- `Unit Tests (CPU)`'s own suite (`tests/utils tests/datasets tests/agentic tests/test_ref_worker_type_consistency.py`) passes identically before and after this change. Six pre-existing failures in `tests/agentic/env` and `tests/agentic/tools` are network/sandbox timeouts, reproduced unchanged on unmodified `main`, unrelated to this diff.
- Did not verify the GPU/vLLM/SGLang generation path end-to-end; this environment has no GPU, so the fix is checked at the scheduler layer only, the same scope PR #446 was reviewed and merged under.

Fixes #423
