### PR TITLE
[doc] upgrade NPU A2/A3 Docker images

### DIFF
--- a/docker/Dockerfile.A2
+++ b/docker/Dockerfile.A2
@@ -1,4 +1,4 @@
-FROM quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.11
+FROM quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12-devel
 
 ARG SOC_VERSION="ascend910b1"
 
@@ -27,29 +27,33 @@ RUN pip config set global.index-url https://mirrors.huaweicloud.com/repository/p
 
 WORKDIR /workspace
 
-RUN git clone --depth 1 -b v0.18.0 https://github.com/vllm-project/vllm.git && \
-    git clone --depth 1 -b v0.18.0 https://github.com/vllm-project/vllm-ascend.git
+RUN git clone --depth 1 -b v0.23.0 https://github.com/vllm-project/vllm.git && \
+    git clone --depth 1 -b v0.23.0rc1 https://github.com/vllm-project/vllm-ascend.git
 
 RUN cd vllm && \
-    pip install -r requirements/build.txt && \
     VLLM_TARGET_DEVICE=empty pip install -v -e . && \
     pip uninstall -y triton && \
     pip cache purge && \
     cd ..
 
-RUN pip install torch==2.9.0+cpu torchvision==0.24.0 torchaudio==2.9.0 \
-    --index-url https://download.pytorch.org/whl/cpu
+RUN pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     cd vllm-ascend && \
-    pip install -r requirements.txt && \
-    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://download.pytorch.org/whl/cpu
+    git submodule update --init --recursive && \
+    pip install -r requirements.txt --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+
+RUN python3 -m pip install --index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+        --no-deps torch-npu==2.10.0.post4
 
 WORKDIR /workspace/ROLL
 COPY . .
 
-RUN pip install -r requirements_common.txt
+RUN grep -v '^gem-llm' requirements_common.txt > requirements_npu.txt && \
+    pip install -r requirements_npu.txt && \
+    rm -f requirements_npu.txt
 
 RUN pip install "transformers==4.57.6" "tensorboard==2.20.0"
 

--- a/docker/Dockerfile.A3
+++ b/docker/Dockerfile.A3
@@ -1,4 +1,4 @@
-FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.11
+FROM quay.io/ascend/cann:9.1.0-a3-ubuntu22.04-py3.12-devel
 
 ARG SOC_VERSION="ascend910_9391"
 
@@ -27,29 +27,33 @@ RUN pip config set global.index-url https://mirrors.huaweicloud.com/repository/p
 
 WORKDIR /workspace
 
-RUN git clone --depth 1 -b v0.18.0 https://github.com/vllm-project/vllm.git && \
-    git clone --depth 1 -b v0.18.0 https://github.com/vllm-project/vllm-ascend.git
+RUN git clone --depth 1 -b v0.23.0 https://github.com/vllm-project/vllm.git && \
+    git clone --depth 1 -b v0.23.0rc1 https://github.com/vllm-project/vllm-ascend.git
 
 RUN cd vllm && \
-    pip install -r requirements/build.txt && \
     VLLM_TARGET_DEVICE=empty pip install -v -e . && \
     pip uninstall -y triton && \
     pip cache purge && \
     cd ..
 
-RUN pip install torch==2.9.0+cpu torchvision==0.24.0 torchaudio==2.9.0 \
-    --index-url https://download.pytorch.org/whl/cpu
+RUN pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     cd vllm-ascend && \
-    pip install -r requirements.txt && \
-    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://download.pytorch.org/whl/cpu
+    git submodule update --init --recursive && \
+    pip install -r requirements.txt --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+
+RUN python3 -m pip install --index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+        --no-deps torch-npu==2.10.0.post4
 
 WORKDIR /workspace/ROLL
 COPY . .
 
-RUN pip install -r requirements_common.txt
+RUN grep -v '^gem-llm' requirements_common.txt > requirements_npu.txt && \
+    pip install -r requirements_npu.txt && \
+    rm -f requirements_npu.txt
 
 RUN pip install "transformers==4.57.6" "tensorboard==2.20.0"
 

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_docker_usage.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_docker_usage.md
@@ -1,114 +1,128 @@
-# Running ROLL on Ascend NPU with Docker
+# ROLL on Ascend NPU with Docker
 
-Last updated: 06/23/2026.
+Last updated: 08/18/2026.
 
-This guide explains how to get, build, and run ROLL images on **Huawei Ascend NPU**. Prefer the pre-built image when possible; use `Dockerfile.A2` or `Dockerfile.A3` when you need to customize dependencies. Ascend 950 currently follows the manual installation profile in [ROLL x Ascend](ascend_usage.md).
+## Quick Reference
 
-## Hardware & Software Requirements
+- ROLL repository: [alibaba/ROLL](https://github.com/alibaba/ROLL)
+- Ascend usage guide: [ROLL x Ascend](ascend_usage.md)
+- Ascend NPU examples: [Ascend NPU Examples](ascend_npu_examples.md)
+- Available pre-built images: [ROLL images on Quay](https://quay.io/repository/ascend/roll?tab=tags)
+- Issue tracker: [GitHub Issues](https://github.com/alibaba/ROLL/issues)
 
-| Item | Dockerfile.A2 | Dockerfile.A3 |
-| ---- | ------------- | ------------- |
-| Hardware | Atlas 900 A2 PODc (Ascend 910B1) | Atlas 900 A3 PODc (Ascend 910_9391) |
-| Host OS | Ubuntu 22.04 | Ubuntu 22.04 |
-| CANN | 9.0.0 | 9.0.0 |
-| Python | 3.11 | 3.11 |
-| Docker | >= 20.10 | >= 20.10 |
-| Ascend NPU Driver | Installed on host | Installed on host |
+---
 
-This Docker guide covers the A2/A3 Dockerfiles. For Ascend 950, use the manual installation profile: torch 2.10, vLLM v0.20.2, vLLM-Ascend `main`, and `COMPILE_CUSTOM_KERNELS=1` when building vLLM-Ascend.
+## ROLL NPU Image
 
-## Key Components
+The ROLL Ascend NPU images provide the runtime and Python dependencies required to run ROLL on Huawei Ascend training-series NPUs. Use a pre-built image when possible. Build from `Dockerfile.A2` or `Dockerfile.A3` when you need to customize the image or rebuild it locally.
 
-Both Dockerfiles install the same versions of core dependencies:
+The Dockerfiles currently cover Atlas 900 A2 and A3 training-series devices.
+
+---
+
+## Supported Tags and Dockerfile Links
+
+| Hardware | Local tag | Pre-built image | Dockerfile | Base image |
+|---|---|---|---|---|
+| Atlas 900 A2 PODc / Ascend 910B1 | `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` | `quay.io/ascend/roll:main-a2` | [`docker/Dockerfile.A2`](https://github.com/alibaba/ROLL/blob/main/docker/Dockerfile.A2) | `quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12-devel` |
+| Atlas 900 A3 PODc / Ascend 910_9391 | `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` | `quay.io/ascend/roll:main-a3` | [`docker/Dockerfile.A3`](https://github.com/alibaba/ROLL/blob/main/docker/Dockerfile.A3) | `quay.io/ascend/cann:9.1.0-a3-ubuntu22.04-py3.12-devel` |
+
+---
+
+## Image Contents
 
 | Component | Version |
-| --------- | ------- |
-| PyTorch | 2.9.0+cpu |
-| vLLM | 0.18.0 |
-| vLLM-Ascend | 0.18 |
+|---|---|
+| CANN | 9.1.0 |
+| Python | 3.12 |
+| PyTorch | 2.10.0 |
+| torch-npu | 2.10.0.post4 |
+| vLLM | 0.23.0 |
+| vLLM-Ascend | 0.23.0rc1 |
 | Transformers | 4.57.6 |
 | triton-ascend | 3.2.1 |
 
-Ascend 950 uses a newer manual installation stack:
+---
 
-| Component | Ascend 950 Version / Setting |
-| --------- | -------------------------- |
-| PyTorch | 2.10 |
-| vLLM | v0.20.2 |
-| vLLM-Ascend | `main` branch |
-| Required build variable | `COMPILE_CUSTOM_KERNELS=1` |
+## Supported Hardware
 
-The primary difference is the base image and SOC version:
+| Hardware | SOC_VERSION | Docker support |
+|---|---|---|
+| Atlas 900 A2 PODc / Ascend 910B1 | `ascend910b1` | Supported by `Dockerfile.A2` and `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` |
+| Atlas 900 A3 PODc / Ascend 910_9391 | `ascend910_9391` | Supported by `Dockerfile.A3` and `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` |
 
-| Item | Dockerfile.A2 | Dockerfile.A3 |
-| ---- | ------------- | ------------- |
-| Base Image | `quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.11` | `quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.11` |
-| SOC_VERSION | `ascend910b1` | `ascend910_9391` |
+Host requirements for the A2/A3 Docker images:
 
-## Get the Docker Image
+| Item | Requirement |
+|---|---|
+| Host OS | Ubuntu 22.04 |
+| Docker | >= 20.10 |
+| Ascend NPU driver | Installed on the host |
 
-### Option A: Use the Pre-built Image (Recommended)
+---
 
-Pull the image that matches your hardware, then tag it with the local name used by the commands below:
+## Quick Start
 
-**For Atlas 900 A2 PODc (Ascend 910B1):**
+### Get the Image
+
+Pull the image that matches the target hardware and apply the local tag used by the commands below:
+
+For Atlas 900 A2 PODc:
 
 ```bash
 docker pull quay.io/ascend/roll:main-a2
-docker tag quay.io/ascend/roll:main-a2 roll:ascend-a2
+docker tag quay.io/ascend/roll:main-a2 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12
 ```
 
-**For Atlas 900 A3 PODc (Ascend 910_9391):**
+For Atlas 900 A3 PODc:
 
 ```bash
 docker pull quay.io/ascend/roll:main-a3
-docker tag quay.io/ascend/roll:main-a3 roll:ascend-a3
+docker tag quay.io/ascend/roll:main-a3 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12
 ```
 
-Check https://quay.io/repository/ascend/roll?tab=tags for available image tags. If you use a pre-built image, continue with [Run the Container](#run-the-container).
+### Build the Image
 
-### Option B: Build from Dockerfile
-
-### 1. Clone the ROLL Repository
+Clone the repository before building from a Dockerfile:
 
 ```bash
 git clone https://github.com/alibaba/ROLL.git
 cd ROLL
 ```
 
-### 2. Build the Image
-
-Choose the Dockerfile that matches your hardware:
-
-**For Atlas 900 A2 PODc (Ascend 910B1):**
+Build for Atlas 900 A2 PODc:
 
 ```bash
-docker build -f docker/Dockerfile.A2 -t roll:ascend-a2 .
+docker build -f docker/Dockerfile.A2 -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 .
 ```
 
-**For Atlas 900 A3 PODc (Ascend 910_9391):**
+Build for Atlas 900 A3 PODc:
 
 ```bash
-docker build -f docker/Dockerfile.A3 -t roll:ascend-a3 .
+docker build -f docker/Dockerfile.A3 -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 .
 ```
 
-> **Note:** The build process compiles vLLM and vLLM-Ascend from source, which may take a considerable amount of time. Please ensure sufficient disk space (at least 50GB) and network access.
+The build compiles vLLM and vLLM-Ascend from source. Reserve at least 50 GB of disk space and ensure that the build host has network access to the required package and source repositories.
 
-You can also customize the SOC version at build time:
+To override the SOC version explicitly:
 
 ```bash
-# A2 with custom SOC version
-docker build -f docker/Dockerfile.A2 --build-arg SOC_VERSION=ascend910b1 -t roll:ascend-a2 .
+# A2
+docker build -f docker/Dockerfile.A2 \
+    --build-arg SOC_VERSION=ascend910b1 \
+    -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 .
 
-# A3 with custom SOC version
-docker build -f docker/Dockerfile.A3 --build-arg SOC_VERSION=ascend910_9391 -t roll:ascend-a3 .
+# A3
+docker build -f docker/Dockerfile.A3 \
+    --build-arg SOC_VERSION=ascend910_9391 \
+    -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 .
 ```
 
-## Run the Container
+---
 
-### Basic Startup
+## Run Container
 
-**For A2:**
+The host must expose the Ascend device files and driver directories to the container. The following example starts an A2 container with eight NPUs:
 
 ```bash
 docker run -dit \
@@ -131,13 +145,15 @@ docker run -dit \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /home/$USER:/home/$USER \
+    -v /path/to/models:/path/to/models \
+    -v /path/to/data:/path/to/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a2 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
-**For A3:**
+For A3, use `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12`, change the container name, and add the available device files. A full 16-NPU A3 node also requires `/dev/davinci8` through `/dev/davinci15`:
 
 ```bash
 docker run -dit \
@@ -168,118 +184,81 @@ docker run -dit \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /home/$USER:/home/$USER \
-    --ipc=host \
-    --net=host \
-    roll:ascend-a3 \
-    /bin/bash
-```
-
-### Multi-NPU Startup (Recommended for Training)
-
-For multi-NPU training, mount all available NPU devices. Adjust the number of `--device /dev/davinciX` entries according to the NPU count on your node:
-
-```bash
-docker run -dit \
-    --name roll_ascend \
-    --ulimit nofile=65536:65536 \
-    --device /dev/davinci0 \
-    --device /dev/davinci1 \
-    --device /dev/davinci2 \
-    --device /dev/davinci3 \
-    --device /dev/davinci4 \
-    --device /dev/davinci5 \
-    --device /dev/davinci6 \
-    --device /dev/davinci7 \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
-    -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
-    -v /home/$USER:/home/$USER \
     -v /path/to/models:/path/to/models \
     -v /path/to/data:/path/to/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
-> **Note:**
-> - `--device /dev/davinciX`: Mounts NPU devices. Add or remove entries based on available NPU count.
-> - `--device /dev/davinci_manager`, `--device /dev/devmm_svm`, `--device /dev/hisi_hdc`: Required management devices for Ascend NPU.
-> - `-v /usr/local/Ascend/driver`: Mounts the host Ascend driver.
-> - `-v /path/to/models` and `-v /path/to/data`: Mount model weights and training data directories as needed.
+Adjust the `/dev/davinciX` entries to the number of NPUs available on the host. For multi-NPU training, mount every device required by the training topology.
 
-### Enter the Container
+Enter a running container:
 
 ```bash
-# For A2
+# A2
 docker exec -it roll_a2 /bin/bash
 
-# For A3
+# A3
 docker exec -it roll_a3 /bin/bash
 ```
 
-## Verify the Environment
+---
 
-After entering the container, verify that the Ascend environment is properly configured:
+## Verify Environment
+
+Run these checks inside the container:
 
 ```bash
-# Verify NPU visibility
+# NPU visibility
 npu-smi info
 
-# Verify CANN environment is loaded
+# CANN environment variables
 env | grep -E "ASCEND|LD_LIBRARY_PATH|PATH"
 
-# Verify Python packages
+# Python packages and NPU availability
 python -c "import torch; import torch_npu; print(torch.npu.is_available())"
 python -c "import vllm; print(f'vllm: {vllm.__version__}')"
-python -c "import vllm_ascend; print(f'vllm_ascend available')"
+python -c "import vllm_ascend; print('vllm_ascend available')"
 ```
 
-## Run ROLL Pipelines
+---
 
-### Important Configuration Notes
+## Run ROLL Pipeline on Ascend NPU
 
-Since Megatron-LM is not supported on Ascend NPU, you need to use **FSDP2** as the training backend. Make sure your configuration files use the following settings:
+ROLL's Ascend NPU examples use **FSDP2** as the training backend. Megatron-LM is not supported by the current Ascend setup. Before launching a pipeline, update the model paths and set `device_mapping` according to the NPU topology.
 
-1. Set `strategy_args` to use FSDP2
-
-### Example: RLVR Pipeline
+Example RLVR pipeline:
 
 ```bash
-# After modifying model paths and adjusting device_mapping
 python examples/start_rlvr_pipeline.py \
-    --config_path ascend_examples \
-    --config_name qwen3_30b_rlvr_fsdp2
+    --config_path examples/ascend_examples \
+    --config_name qwen3_8b_rlvr_fsdp2
 ```
 
-> **Note:** The `qwen3_30b_rlvr_fsdp2` configuration is specifically designed for Ascend NPU with FSDP2 as the training backend. Adjust `device_mapping` in the configuration file according to your NPU topology.
+The repository also includes `qwen3_30b_rlvr_fsdp2.yaml` and `run_rlvr_pipeline.sh` under `examples/ascend_examples`. Use a configuration that matches the available NPU memory and topology.
 
-## Troubleshooting
+---
 
-### NPU Not Visible Inside Container
+## Notes
 
-Ensure all required devices and driver paths are mounted correctly. Check with `npu-smi info` inside the container.
+- Install a compatible Ascend NPU driver on the host before starting the container.
+- The A2/A3 Docker images are based on Ubuntu 22.04 and Python 3.12.
+- If `vLLM-Ascend` cannot be imported, reload the Ascend environment inside the container:
 
-### vLLM-Ascend Import Error
+  ```bash
+  source /usr/local/Ascend/ascend-toolkit/set_env.sh
+  source /usr/local/Ascend/nnal/atb/set_env.sh
+  ```
 
-Verify that the CANN environment is properly sourced:
+- These commands are added to `/root/.bashrc` during image build. If you switch to a non-root user, source them manually when necessary.
+- If an NPU is not visible, check the mounted device files, driver paths, and `npu-smi info` output.
 
-```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-source /usr/local/Ascend/nnal/atb/set_env.sh
-```
+---
 
-These commands are automatically added to `/root/.bashrc` during the image build. If you switch to a non-root user, you may need to source them manually.
+## License
 
-### Out of Memory
+ROLL is released under the [Apache License 2.0](https://github.com/alibaba/ROLL/blob/main/LICENSE).
 
-Reduce `rollout_batch_size` or `num_return_sequences_in_group` in your configuration file to lower NPU memory usage.
-
-## Disclaimer
-
-The Ascend support provided in ROLL is intended as a reference example. For production use, please consult official channels.
+CANN, Ascend driver components, Python packages, system libraries, and other pre-installed dependencies may be subject to their own licenses.

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_npu_env_config.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_npu_env_config.md
@@ -1,6 +1,6 @@
 # Ascend NPU Environment Configuration Guide
 
-Last updated: 06/23/2026.
+Last updated: 08/17/2026.
 
 This document describes the key environment variables for running ROLL on Huawei Ascend NPU, covering device management, HCCL communication, memory optimization, CPU scheduling, vLLM-Ascend inference, and debugging.
 
@@ -24,6 +24,7 @@ The pre-built Ascend images described in [Ascend NPU Docker Usage Guide](ascend_
 | -------- | ----- | ----------- |
 | `ASCEND_HOME_PATH` | `/usr/local/Ascend/ascend-toolkit/latest` | CANN toolkit root path |
 | `LD_LIBRARY_PATH` | Includes multiple Ascend `lib64` paths | Dynamic library search path, ensures `libascendcl.so` etc. can be loaded |
+| `HCCL_NPU_SOCKET_PORT_RANGE` | `auto` | Allows HCCL to allocate non-default device-side NIC ports for same-device multi-process workloads |
 
 The following CANN environment scripts are automatically sourced via `/root/.bashrc` in the pre-built images:
 
@@ -151,8 +152,9 @@ export CPU_AFFINITY_CONF=1,npu0:0-1,npu1:2-3,npu2:4-5,npu3:6-7
 
 | Variable | Recommended Value | Description |
 | -------- | ----------------- | ----------- |
-| `VLLM_USE_V1` | `1` | Enable vLLM V1 architecture. Required for vLLM-Ascend |
+| `VLLM_USE_V1` | `1` | Keep the current ROLL vLLM path enabled. ROLL sets this to `1` by default; vLLM versions >= 0.11.1 deprecate this switch |
 | `VLLM_ATTENTION_BACKEND` | `XFORMERS` | vLLM attention computation backend |
+| `VLLM_ASCEND_ENABLE_NZ` | `0` | Disable FRACTAL_NZ for ROLL reinforcement-learning weight reload flows |
 | `VLLM_ASCEND_ENABLE_FLASHCOMM` | `1` | Enable Ascend FlashComm high-speed communication optimization |
 | `VLLM_ASCEND_ENABLE_PREFETCH_MLP` | `1` | Enable MLP layer weight prefetching. This replaces the older dense optimize toggle in current vLLM-Ascend releases. |
 | `VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE` | `1` | Enable TopK operator fusion optimization for generation decoding |
@@ -168,6 +170,10 @@ export VLLM_ATTENTION_BACKEND=XFORMERS
 export VLLM_ASCEND_ENABLE_FLASHCOMM=1
 export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
 ```
+
+:::note
+The memory and task-queue recommendations above apply to FSDP2 training and general NPU workloads. ROLL's vLLM workers override `TASK_QUEUE_ENABLE` to `1`, clear `PYTORCH_NPU_ALLOC_CONF`, and set `VLLM_ASCEND_ENABLE_NZ=0` for vLLM runtime stability.
+:::
 
 ## vLLM-Ascend Build Variables
 

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_npu_examples.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_npu_examples.md
@@ -55,7 +55,7 @@ docker run -dit \
     -v /path/to/data:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
@@ -487,7 +487,7 @@ docker run -dit \
     -v /shared/storage:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_npu_faq.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_npu_faq.md
@@ -1,6 +1,6 @@
 # Ascend NPU FAQ
 
-Last updated: 04/27/2026.
+Last updated: 08/17/2026.
 
 This document compiles common issues encountered when running ROLL on Huawei Ascend NPU and their solutions.
 
@@ -51,8 +51,8 @@ These commands are automatically added to `/root/.bashrc` during the Docker imag
 
 **Solution:** Make sure you are using the correct pre-built image for your hardware:
 
-- **Atlas 900 A2 PODc** → Use `roll:ascend-a2` (`ascend910b1`)
-- **Atlas 900 A3 PODc** → Use `roll:ascend-a3` (`ascend910_9391`)
+- **Atlas 900 A2 PODc** → Use `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` (`ascend910b1`)
+- **Atlas 900 A3 PODc** → Use `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` (`ascend910_9391`)
 
 The current repository includes `docker/Dockerfile.A2` and `docker/Dockerfile.A3` for building custom images. If you maintain a custom image, ensure its SOC version matches the target hardware.
 
@@ -284,7 +284,7 @@ To make it persistent, add the following line to `/etc/security/limits.conf` ins
 
 **Solution:**
 
-1. Ensure CANN and vLLM-Ascend versions are compatible (current images use CANN 9.0.0 with vLLM-Ascend v0.18).
+1. Ensure CANN and the Ascend software stack are compatible. The current ROLL A2/A3 images use CANN 9.1.0, PyTorch 2.10.0, torch-npu 2.10.0.post4, vLLM 0.23.0, and vLLM-Ascend v0.23.0rc1.
 2. Check that the SOC version matches your hardware.
 3. Adjust vLLM parameters such as `gpu_memory_utilization` and `max_model_len` in your config.
 4. Verify that `triton-ascend` is installed (not `triton`), as the wrong triton backend can cause kernel compilation fallbacks.

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_npu_rlvr.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_npu_rlvr.md
@@ -1,6 +1,6 @@
 # Running RLVR Pipeline on Ascend NPU
 
-Last updated: 04/28/2026.
+Last updated: 08/17/2026.
 
 This guide provides a complete end-to-end walkthrough for running the RLVR (Reinforcement Learning with Verifiable Rewards) pipeline on Huawei Ascend NPU, covering environment setup, data preparation, model download, configuration, training launch, monitoring & evaluation, and checkpoint resumption.
 
@@ -22,7 +22,13 @@ Ensure your hardware and host drivers are ready:
 | ---- | ----------- |
 | Hardware | Atlas 900 A2 PODc (Ascend 910B1) or Atlas 900 A3 PODc (Ascend 910_9391) |
 | Host OS | Ubuntu 22.04 |
-| CANN | 9.0.0 |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| PyTorch | 2.10.0 |
+| torch-npu | 2.10.0.post4 |
+| vLLM | 0.23.0 |
+| vLLM-Ascend | 0.23.0rc1 |
+| triton-ascend | 3.2.1 |
 | Ascend NPU Driver | Installed on host (`npu-smi info` shows devices) |
 | Docker | >= 20.10 |
 
@@ -33,11 +39,11 @@ Use the pre-built Ascend image that matches your hardware. Official ROLL NPU ima
 ```bash
 # For A2 hardware
 docker pull quay.io/ascend/roll:main-a2
-docker tag quay.io/ascend/roll:main-a2 roll:ascend-a2
+docker tag quay.io/ascend/roll:main-a2 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12
 
 # For A3 hardware
 docker pull quay.io/ascend/roll:main-a3
-docker tag quay.io/ascend/roll:main-a3 roll:ascend-a3
+docker tag quay.io/ascend/roll:main-a3 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12
 ```
 
 The current repository includes `docker/Dockerfile.A2` and `docker/Dockerfile.A3` for building custom images. If you maintain a custom image, keep the dependency versions aligned with the pre-built image.
@@ -68,7 +74,7 @@ docker run -dit \
     -v /path/to/data:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
@@ -1,6 +1,6 @@
 # ROLL x Ascend
 
-Last updated: 06/23/2026.
+Last updated: 08/17/2026.
 
 We have added support for Huawei Ascend devices in ROLL.
 
@@ -10,8 +10,8 @@ ROLL's Ascend support is currently validated on training-series Ascend hardware:
 
 | Product | Support status | Notes |
 | ------- | -------------- | ----- |
-| Atlas 900 A2 PODc (Ascend 910B1) / Atlas A2 training series | √ | Use `docker/Dockerfile.A2` or the `roll:ascend-a2` image. |
-| Atlas 900 A3 PODc (Ascend 910_9391) / Atlas A3 training series | √ | Use `docker/Dockerfile.A3` or the `roll:ascend-a3` image. |
+| Atlas 900 A2 PODc (Ascend 910B1) / Atlas A2 training series | √ | Use `docker/Dockerfile.A2` or the `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` image. |
+| Atlas 900 A3 PODc (Ascend 910_9391) / Atlas A3 training series | √ | Use `docker/Dockerfile.A3` or the `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` image. |
 | Ascend 950 training series | √ | Use the Ascend 950 installation profile: torch 2.10, vLLM v0.20.2, vLLM-Ascend `main`, and `COMPILE_CUSTOM_KERNELS=1` when building vLLM-Ascend. |
 | Atlas A2/A3 inference series and Atlas 200I/500 A2 inference products | x | Current ROLL NPU images and examples target training-series devices. |
 | Other Ascend training or inference products | Not validated | Validate the driver, firmware, CANN, `torch_npu`, and vLLM-Ascend versions before use. |
@@ -23,7 +23,7 @@ Supported operating systems:
 | Deployment scenario | Supported OS | Notes |
 | ------------------- | ------------ | ----- |
 | Physical host | Ubuntu 22.04 | Recommended and validated by the current ROLL Ascend guides. |
-| ROLL Ascend container | Ubuntu 22.04 | The A2/A3 Dockerfiles are based on `quay.io/ascend/cann:9.0.0-*-ubuntu22.04-py3.11`. |
+| ROLL Ascend container | Ubuntu 22.04 | The A2/A3 Dockerfiles are based on `quay.io/ascend/cann:9.1.0-*-ubuntu22.04-py3.12-devel`. |
 | Ascend 950 manual installation | Ubuntu 22.04 | Use the Ascend 950-specific torch/vLLM stack below. Keep the driver, firmware, CANN, and `torch_npu` versions aligned with the target Ascend 950 environment. |
 | VM/container deployments on other host OS versions | Follow Ascend/CANN compatibility guidance | Check the Ascend compatibility query assistant and the CANN Software Installation OS compatibility notes for the target hardware. |
 
@@ -33,8 +33,8 @@ Supported operating systems:
 
 | Software | Version |
 | -------- |---------|
-| Python   | 3.11    |
-| CANN     | 9.0.0   |
+| Python   | 3.12    |
+| CANN     | 9.1.0   |
 
 For Ascend 950 , keep Python 3.11 and use the Ascend 950-specific torch/vLLM stack described in [Ascend 950 Installation Profile](#Ascend 950-installation-profile).
 
@@ -43,7 +43,7 @@ For Ascend 950 , keep Python 3.11 and use the Ascend 950-specific torch/vLLM sta
 Use the following commands to create a new conda environment in Miniconda:
 
 ```
-conda create --name roll python=3.11
+conda create --name roll python=3.12
 conda activate roll
 ```
 
@@ -53,10 +53,12 @@ To use torch and torch_npu in ROLL, install them using the commands below:
 
 ```
 # Use CPU-only torch when installing outside the pre-built image
-pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu
 
 # Install the torch_npu version matching torch/CANN
-pip install torch_npu==2.9.0
+python -m pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    --no-deps torch-npu==2.10.0.post4
 ```
 
 ### Install vllm & vllm-ascend
@@ -65,28 +67,33 @@ To use vllm in ROLL, compile and install vllm and vllm-ascend as follows:
 
 ```
 # vllm
-git clone -b v0.18.0 --depth 1 https://github.com/vllm-project/vllm.git
+git clone -b v0.23.0 --depth 1 https://github.com/vllm-project/vllm.git
 cd vllm
-pip install -r requirements/build.txt
 
 VLLM_TARGET_DEVICE=empty pip install -v -e .
 cd ..
 
 # vllm-ascend
-git clone -b v0.18.0 --depth 1 https://github.com/vllm-project/vllm-ascend.git
+git clone -b v0.23.0rc1 --depth 1 https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
+git submodule update --init --recursive
 
-pip install -e .
+pip install -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 cd ..
+
+# Install the Ascend Triton implementation after the other packages
+pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 Or you could install `vllm` and `vllm-ascend` from pre-built wheel:
 ```
-# Install vllm-project/vllm. The newest supported version is v0.18.0.
-pip install vllm==0.18.0
+# Install vllm-project/vllm. The newest supported version is v0.23.0.
+pip install vllm==0.23.0
 
 # Install vllm-project/vllm-ascend from pypi.
-pip install vllm-ascend==0.18
+pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    vllm-ascend==0.23.0rc1
 ```
 
 ### Ascend 950 Installation Profile
@@ -130,6 +137,8 @@ cd ..
 | Software                    | Description   |
 | --------------------------- | ------------- |
 | transformers                | >= v4.57.6    |
+| torch-npu                   | 2.10.0.post4  |
+| triton-ascend               | 3.2.1 (required instead of `triton`) |
 | flash_attn                  | not supported |
 | transformer-engine[pytorch] | not supported |
 
@@ -139,6 +148,8 @@ cd ..
 
 ```
 pip install transformers==4.57.6
+pip uninstall -y triton triton-ascend
+pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 ## Quick Start: Single-Node Deployment

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_docker_usage.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_docker_usage.md
@@ -1,114 +1,128 @@
 # 使用 Docker 在昇腾 NPU 上运行 ROLL
 
-最后更新：2026/06/23。
+最后更新：2026 年 8 月 18 日。
 
-本指南介绍如何在**华为昇腾 NPU** 上获取、构建并运行 ROLL 镜像。推荐优先使用预构建镜像；如需自定义依赖，再使用 `Dockerfile.A2` 或 `Dockerfile.A3` 构建。Atlas 950 当前使用 [ROLL x Ascend](ascend_usage.md) 中的手动安装配置。
+## 快速参考
 
-## 硬件与软件要求
+- ROLL 仓库：[alibaba/ROLL](https://github.com/alibaba/ROLL)
+- 昇腾使用指南：[ROLL x Ascend](ascend_usage.md)
+- 昇腾 NPU 示例：[昇腾 NPU 示例](ascend_npu_examples.md)
+- 可用的预构建镜像：[Quay 上的 ROLL 镜像](https://quay.io/repository/ascend/roll?tab=tags)
+- Issue 跟踪器：[GitHub Issues](https://github.com/alibaba/ROLL/issues)
 
-| 项目 | Dockerfile.A2 | Dockerfile.A3 |
-| ---- | ------------- | ------------- |
-| 硬件 | Atlas 900 A2 PODc（Ascend 910B1） | Atlas 900 A3 PODc（Ascend 910_9391） |
-| 宿主机操作系统 | Ubuntu 22.04 | Ubuntu 22.04 |
-| CANN | 9.0.0 | 9.0.0 |
-| Python | 3.11 | 3.11 |
-| Docker | >= 20.10 | >= 20.10 |
-| 昇腾 NPU 驱动 | 已安装在宿主机上 | 已安装在宿主机上 |
+---
 
-本 Docker 指南覆盖 A2/A3 Dockerfile。Ascend 950 请使用手动安装配置：torch 2.10、vLLM v0.20.2、vLLM-Ascend `main`，并在构建 vLLM-Ascend 时设置 `COMPILE_CUSTOM_KERNELS=1`。
+## ROLL NPU 镜像
 
-## 主要组件
+ROLL 昇腾 NPU 镜像提供在华为昇腾训练系列 NPU 上运行 ROLL 所需的运行时和 Python 依赖。建议优先使用预构建镜像；如果需要自定义镜像或在本地重新构建，请使用 `Dockerfile.A2` 或 `Dockerfile.A3`。
 
-两个 Dockerfile 安装的核心依赖版本相同：
+当前 Dockerfile 覆盖 Atlas 900 A2 和 A3 训练系列设备。
+
+---
+
+## 支持的标签和 Dockerfile 链接
+
+| 硬件 | 本地标签 | 预构建镜像 | Dockerfile | 基础镜像 |
+|---|---|---|---|---|
+| Atlas 900 A2 PODc / Ascend 910B1 | `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` | `quay.io/ascend/roll:main-a2` | [`docker/Dockerfile.A2`](https://github.com/alibaba/ROLL/blob/main/docker/Dockerfile.A2) | `quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12-devel` |
+| Atlas 900 A3 PODc / Ascend 910_9391 | `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` | `quay.io/ascend/roll:main-a3` | [`docker/Dockerfile.A3`](https://github.com/alibaba/ROLL/blob/main/docker/Dockerfile.A3) | `quay.io/ascend/cann:9.1.0-a3-ubuntu22.04-py3.12-devel` |
+
+---
+
+## 镜像内容
 
 | 组件 | 版本 |
-| ---- | ---- |
-| PyTorch | 2.9.0+cpu |
-| vLLM | 0.18.0 |
-| vLLM-Ascend | 0.18 |
+|---|---|
+| CANN | 9.1.0 |
+| Python | 3.12 |
+| PyTorch | 2.10.0 |
+| torch-npu | 2.10.0.post4 |
+| vLLM | 0.23.0 |
+| vLLM-Ascend | 0.23.0rc1 |
 | Transformers | 4.57.6 |
 | triton-ascend | 3.2.1 |
 
-Ascend 950 使用更新的手动安装版本组合：
+---
 
-| 组件 | Ascend 950 版本 / 设置 |
-| ---- | -------------------- |
-| PyTorch | 2.10 |
-| vLLM | v0.20.2 |
-| vLLM-Ascend | `main` 分支 |
-| 必需构建变量 | `COMPILE_CUSTOM_KERNELS=1` |
+## 支持的硬件
 
-主要区别在于基础镜像和 SOC 版本：
+| 硬件 | SOC_VERSION | Docker 支持 |
+|---|---|---|
+| Atlas 900 A2 PODc / Ascend 910B1 | `ascend910b1` | `Dockerfile.A2` 和 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` 支持 |
+| Atlas 900 A3 PODc / Ascend 910_9391 | `ascend910_9391` | `Dockerfile.A3` 和 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` 支持 |
 
-| 项目 | Dockerfile.A2 | Dockerfile.A3 |
-| ---- | ------------- | ------------- |
-| 基础镜像 | `quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.11` | `quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.11` |
-| SOC_VERSION | `ascend910b1` | `ascend910_9391` |
+A2/A3 Docker 镜像的宿主机要求：
 
-## 获取 Docker 镜像
+| 项目 | 要求 |
+|---|---|
+| 宿主机操作系统 | Ubuntu 22.04 |
+| Docker | >= 20.10 |
+| 昇腾 NPU 驱动 | 安装在宿主机上 |
 
-### 方式 A：使用预构建镜像（推荐）
+---
 
-根据你的硬件拉取对应镜像，并打成本指南后续命令使用的本地标签：
+## 快速开始
 
-**Atlas 900 A2 PODc（Ascend 910B1）：**
+### 获取镜像
+
+拉取与目标硬件匹配的镜像，并设置后续命令使用的本地标签：
+
+Atlas 900 A2 PODc：
 
 ```bash
 docker pull quay.io/ascend/roll:main-a2
-docker tag quay.io/ascend/roll:main-a2 roll:ascend-a2
+docker tag quay.io/ascend/roll:main-a2 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12
 ```
 
-**Atlas 900 A3 PODc（Ascend 910_9391）：**
+Atlas 900 A3 PODc：
 
 ```bash
 docker pull quay.io/ascend/roll:main-a3
-docker tag quay.io/ascend/roll:main-a3 roll:ascend-a3
+docker tag quay.io/ascend/roll:main-a3 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12
 ```
 
-可用镜像标签请以 https://quay.io/repository/ascend/roll?tab=tags 为准。如果你使用预构建镜像，可以直接跳到 [运行容器](#运行容器)。
+### 构建镜像
 
-### 方式 B：从 Dockerfile 构建镜像
-
-### 1. 克隆 ROLL 仓库
+从 Dockerfile 构建前，先克隆仓库：
 
 ```bash
 git clone https://github.com/alibaba/ROLL.git
 cd ROLL
 ```
 
-### 2. 构建镜像
-
-根据你的硬件选择对应的 Dockerfile：
-
-**Atlas 900 A2 PODc（Ascend 910B1）：**
+构建 Atlas 900 A2 PODc 镜像：
 
 ```bash
-docker build -f docker/Dockerfile.A2 -t roll:ascend-a2 .
+docker build -f docker/Dockerfile.A2 -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 .
 ```
 
-**Atlas 900 A3 PODc（Ascend 910_9391）：**
+构建 Atlas 900 A3 PODc 镜像：
 
 ```bash
-docker build -f docker/Dockerfile.A3 -t roll:ascend-a3 .
+docker build -f docker/Dockerfile.A3 -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 .
 ```
 
-> **注意：** 构建过程会从源码编译 vLLM 和 vLLM-Ascend，耗时较长，请确保有足够的磁盘空间（至少 50GB）和网络访问。
+构建过程会从源码编译 vLLM 和 vLLM-Ascend。请预留至少 50 GB 磁盘空间，并确保构建主机可以访问所需的软件包和源码仓库。
 
-你也可以在构建时自定义 SOC 版本：
+也可以显式覆盖 SOC 版本：
 
 ```bash
-# A2 自定义 SOC 版本
-docker build -f docker/Dockerfile.A2 --build-arg SOC_VERSION=ascend910b1 -t roll:ascend-a2 .
+# A2
+docker build -f docker/Dockerfile.A2 \
+    --build-arg SOC_VERSION=ascend910b1 \
+    -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 .
 
-# A3 自定义 SOC 版本
-docker build -f docker/Dockerfile.A3 --build-arg SOC_VERSION=ascend910_9391 -t roll:ascend-a3 .
+# A3
+docker build -f docker/Dockerfile.A3 \
+    --build-arg SOC_VERSION=ascend910_9391 \
+    -t roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 .
 ```
+
+---
 
 ## 运行容器
 
-### 基本启动
-
-**A2：**
+宿主机必须向容器暴露昇腾设备文件和驱动目录。下面的示例启动一个挂载 8 个 NPU 的 A2 容器：
 
 ```bash
 docker run -dit \
@@ -131,13 +145,15 @@ docker run -dit \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /home/$USER:/home/$USER \
+    -v /path/to/models:/path/to/models \
+    -v /path/to/data:/path/to/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a2 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
-**A3：**
+A3 使用 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12`，并修改容器名称、增加可用的设备文件。完整的 16 卡 A3 节点还需要挂载 `/dev/davinci8` 到 `/dev/davinci15`：
 
 ```bash
 docker run -dit \
@@ -168,52 +184,17 @@ docker run -dit \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /home/$USER:/home/$USER \
-    --ipc=host \
-    --net=host \
-    roll:ascend-a3 \
-    /bin/bash
-```
-
-### 多卡启动（训练推荐）
-
-多 NPU 训练时，需要挂载所有可用的 NPU 设备。根据节点上的 NPU 数量调整 `--device /dev/davinciX` 的数量：
-
-```bash
-docker run -dit \
-    --name roll_ascend \
-    --ulimit nofile=65536:65536 \
-    --device /dev/davinci0 \
-    --device /dev/davinci1 \
-    --device /dev/davinci2 \
-    --device /dev/davinci3 \
-    --device /dev/davinci4 \
-    --device /dev/davinci5 \
-    --device /dev/davinci6 \
-    --device /dev/davinci7 \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-    -v /usr/local/Ascend/add-ons:/usr/local/Ascend/add-ons \
-    -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
-    -v /home/$USER:/home/$USER \
     -v /path/to/models:/path/to/models \
     -v /path/to/data:/path/to/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
-> **注意：**
-> - `--device /dev/davinciX`：挂载 NPU 设备，根据可用 NPU 数量增减。
-> - `--device /dev/davinci_manager`、`--device /dev/devmm_svm`、`--device /dev/hisi_hdc`：昇腾 NPU 必需的管理设备。
-> - `-v /usr/local/Ascend/driver`：挂载宿主机昇腾驱动。
-> - `-v /path/to/models` 和 `-v /path/to/data`：根据需要挂载模型权重和训练数据目录。
+根据宿主机上的 NPU 数量调整 `/dev/davinciX` 条目。进行多 NPU 训练时，请挂载训练拓扑所需的全部设备。
 
-### 进入容器
+进入运行中的容器：
 
 ```bash
 # A2
@@ -223,63 +204,61 @@ docker exec -it roll_a2 /bin/bash
 docker exec -it roll_a3 /bin/bash
 ```
 
+---
+
 ## 验证环境
 
-进入容器后，验证昇腾环境是否正确配置：
+在容器内执行以下检查：
 
 ```bash
-# 验证 NPU 可见性
+# 检查 NPU 是否可见
 npu-smi info
 
-# 验证 CANN 环境已加载
+# 检查 CANN 环境变量
 env | grep -E "ASCEND|LD_LIBRARY_PATH|PATH"
 
-# 验证 Python 包
+# 检查 Python 软件包和 NPU 可用性
 python -c "import torch; import torch_npu; print(torch.npu.is_available())"
 python -c "import vllm; print(f'vllm: {vllm.__version__}')"
-python -c "import vllm_ascend; print(f'vllm_ascend available')"
+python -c "import vllm_ascend; print('vllm_ascend available')"
 ```
 
-## 运行 ROLL 流水线
+---
 
-### 重要配置说明
+## 在昇腾 NPU 上运行 ROLL 流水线
 
-由于昇腾 NPU 上不支持 Megatron-LM 训练，需要使用 **FSDP2** 作为训练后端。请确保配置文件中使用以下设置：
+ROLL 的昇腾 NPU 示例使用 **FSDP2** 作为训练后端。当前昇腾配置不支持 Megatron-LM。启动流水线前，请修改模型路径，并根据 NPU 拓扑设置 `device_mapping`。
 
-1. 将 `strategy_args` 设置为使用 FSDP2
-
-
-### 示例：RLVR 流水线
+RLVR 流水线示例：
 
 ```bash
 python examples/start_rlvr_pipeline.py \
-    --config_path ascend_examples \
-    --config_name qwen3_30b_rlvr_fsdp2
+    --config_path examples/ascend_examples \
+    --config_name qwen3_8b_rlvr_fsdp2
 ```
 
-> **注意：** `qwen3_30b_rlvr_fsdp2` 配置专为昇腾 NPU 设计，使用 FSDP2 作为训练后端。请根据你的 NPU 拓扑调整配置文件中的 `device_mapping`。
+仓库还在 `examples/ascend_examples` 下提供了 `qwen3_30b_rlvr_fsdp2.yaml` 和 `run_rlvr_pipeline.sh`。请根据可用 NPU 的显存和拓扑选择配置。
 
-## 常见问题
+---
 
-### 容器内 NPU 不可见
+## 注意事项
 
-确保所有必需的设备和管理路径已正确挂载。在容器内使用 `npu-smi info` 检查。
+- 启动容器前，请在宿主机上安装兼容的昇腾 NPU 驱动。
+- A2/A3 Docker 镜像基于 Ubuntu 22.04 和 Python 3.12。
+- 如果无法导入 `vLLM-Ascend`，请在容器内重新加载昇腾环境：
 
-### vLLM-Ascend 导入错误
+  ```bash
+  source /usr/local/Ascend/ascend-toolkit/set_env.sh
+  source /usr/local/Ascend/nnal/atb/set_env.sh
+  ```
 
-验证 CANN 环境是否正确加载：
+- 镜像构建时会将这些命令写入 `/root/.bashrc`。如果切换到非 root 用户，必要时请手动执行这些命令。
+- 如果 NPU 不可见，请检查挂载的设备文件、驱动路径和 `npu-smi info` 输出。
 
-```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-source /usr/local/Ascend/nnal/atb/set_env.sh
-```
+---
 
-这些命令在镜像构建时已自动添加到 `/root/.bashrc`。如果切换到非 root 用户，可能需要手动执行。
+## 许可证
 
-### 显存不足
+ROLL 基于 [Apache License 2.0](https://github.com/alibaba/ROLL/blob/main/LICENSE) 发布。
 
-在配置文件中减小 `rollout_batch_size` 或 `num_return_sequences_in_group` 以降低 NPU 显存占用。
-
-## 声明
-
-ROLL 中提供的 Ascend 支持代码皆为参考样例，生产环境使用请通过官方正式途径沟通。
+CANN、昇腾驱动组件、Python 软件包、系统库和其他预安装依赖可能分别受其各自许可证约束。

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_env_config.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_env_config.md
@@ -1,6 +1,6 @@
 # 昇腾 NPU 环境变量配置指南
 
-最后更新：2026/06/23。
+最后更新：2026/08/17。
 
 本文档说明在华为昇腾 NPU 上运行 ROLL 时涉及的关键环境变量，涵盖设备管理、HCCL 通信、显存优化、CPU 调度、vLLM-Ascend 推理及调试日志等方面。
 
@@ -24,6 +24,7 @@ ROLL 在运行时自动注入以下环境变量（定义在 `roll/platforms/npu.
 | ---- | -- | ---- |
 | `ASCEND_HOME_PATH` | `/usr/local/Ascend/ascend-toolkit/latest` | CANN 工具包根路径 |
 | `LD_LIBRARY_PATH` | 包含多个 Ascend lib64 路径 | 动态库搜索路径，确保 `libascendcl.so` 等可被加载 |
+| `HCCL_NPU_SOCKET_PORT_RANGE` | `auto` | 同一 NPU 上多进程运行时允许 HCCL 自动分配非默认 device 侧网卡端口 |
 
 预构建镜像会通过 `/root/.bashrc` 自动加载以下 CANN 环境脚本：
 
@@ -151,8 +152,9 @@ export CPU_AFFINITY_CONF=1,npu0:0-1,npu1:2-3,npu2:4-5,npu3:6-7
 
 | 变量 | 推荐值 | 说明 |
 | ---- | ------ | ---- |
-| `VLLM_USE_V1` | `1` | 启用 vLLM V1 架构，vLLM-Ascend 必需 |
+| `VLLM_USE_V1` | `1` | 保持当前 ROLL vLLM 路径启用。ROLL 默认将其设为 `1`；vLLM >= 0.11.1 已将该开关标记为过时 |
 | `VLLM_ATTENTION_BACKEND` | `XFORMERS` | vLLM 注意力计算后端 |
+| `VLLM_ASCEND_ENABLE_NZ` | `0` | ROLL 强化学习权重刷新场景禁用 FRACTAL_NZ |
 | `VLLM_ASCEND_ENABLE_FLASHCOMM` | `1` | 启用昇腾 FlashComm 高速通信优化 |
 | `VLLM_ASCEND_ENABLE_PREFETCH_MLP` | `1` | 启用 MLP 层权重预取。它替代了较早版本中的 dense optimize 开关。 |
 | `VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE` | `1` | 启用 TopK 算子融合优化，提升生成解码性能 |
@@ -168,6 +170,10 @@ export VLLM_ATTENTION_BACKEND=XFORMERS
 export VLLM_ASCEND_ENABLE_FLASHCOMM=1
 export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
 ```
+
+:::note
+上面的显存和任务队列配置适用于 FSDP2 训练及一般 NPU 任务。ROLL 的 vLLM worker 会将 `TASK_QUEUE_ENABLE` 覆盖为 `1`、清空 `PYTORCH_NPU_ALLOC_CONF`，并设置 `VLLM_ASCEND_ENABLE_NZ=0`，以保证 vLLM 运行稳定。
+:::
 
 ## vLLM-Ascend 构建相关变量
 

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_examples.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_examples.md
@@ -56,7 +56,7 @@ docker run -dit \
     -v /path/to/data:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 
@@ -488,7 +488,7 @@ docker run -dit \
     -v /shared/storage:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_faq.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_faq.md
@@ -1,6 +1,6 @@
 # 昇腾 NPU 常见问题
 
-最后更新：2026/04/27。
+最后更新：2026/08/17。
 
 本文档汇总了在华为昇腾 NPU 上运行 ROLL 时可能遇到的常见问题及解决方案。
 
@@ -51,8 +51,8 @@ source /usr/local/Ascend/nnal/atb/set_env.sh
 
 **解决方案：** 确保使用了与硬件匹配的预构建镜像：
 
-- **Atlas 900 A2 PODc** → 使用 `roll:ascend-a2`（`ascend910b1`）
-- **Atlas 900 A3 PODc** → 使用 `roll:ascend-a3`（`ascend910_9391`）
+- **Atlas 900 A2 PODc** → 使用 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12`（`ascend910b1`）
+- **Atlas 900 A3 PODc** → 使用 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12`（`ascend910_9391`）
 
 当前仓库包含用于构建自定义镜像的 `docker/Dockerfile.A2` 和 `docker/Dockerfile.A3`。如果维护自定义镜像，请确保 SOC 版本与目标硬件匹配。
 
@@ -284,7 +284,7 @@ ulimit -n 65536
 
 **解决方案：**
 
-1. 确保 CANN 和 vLLM-Ascend 版本兼容（当前镜像使用 CANN 9.0.0 与 vLLM-Ascend v0.18）。
+1. 确保 CANN 与昇腾软件栈版本兼容。当前 ROLL A2/A3 镜像使用 CANN 9.1.0、PyTorch 2.10.0、torch-npu 2.10.0.post4、vLLM 0.23.0、vLLM-Ascend v0.23.0rc1。
 2. 检查 SOC 版本是否与硬件匹配。
 3. 调整配置中 vLLM 的 `gpu_memory_utilization` 和 `max_model_len` 参数。
 4. 确认已安装 `triton-ascend`（而非 `triton`），错误的 triton 后端会导致算子编译回退。

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_rlvr.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_npu_rlvr.md
@@ -1,6 +1,6 @@
 # 在昇腾 NPU 上运行 RLVR 流水线
 
-最后更新：2026/04/28。
+最后更新：2026/08/17。
 
 本文档提供在华为昇腾 NPU 上运行 RLVR（Reinforcement Learning with Verifiable Rewards）流水线的端到端指南，涵盖环境准备、数据准备、模型下载、配置编写、训练启动、监控与评估，以及从 checkpoint 恢复训练。
 
@@ -22,7 +22,13 @@
 | ---- | ---- |
 | 硬件 | Atlas 900 A2 PODc（Ascend 910B1）或 Atlas 900 A3 PODc（Ascend 910_9391） |
 | 宿主机 OS | Ubuntu 22.04 |
-| CANN | 9.0.0 |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| PyTorch | 2.10.0 |
+| torch-npu | 2.10.0.post4 |
+| vLLM | 0.23.0 |
+| vLLM-Ascend | 0.23.0rc1 |
+| triton-ascend | 3.2.1 |
 | Ascend NPU 驱动 | 已在宿主机安装（`npu-smi info` 能看到设备） |
 | Docker | >= 20.10 |
 
@@ -33,11 +39,11 @@
 ```bash
 # A2 硬件
 docker pull quay.io/ascend/roll:main-a2
-docker tag quay.io/ascend/roll:main-a2 roll:ascend-a2
+docker tag quay.io/ascend/roll:main-a2 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12
 
 # A3 硬件
 docker pull quay.io/ascend/roll:main-a3
-docker tag quay.io/ascend/roll:main-a3 roll:ascend-a3
+docker tag quay.io/ascend/roll:main-a3 roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12
 ```
 
 当前仓库提供 `docker/Dockerfile.A2` 和 `docker/Dockerfile.A3`，用于构建自定义镜像。如果你维护自定义镜像，请确保依赖版本与预构建镜像保持一致。
@@ -68,7 +74,7 @@ docker run -dit \
     -v /path/to/data:/data \
     --ipc=host \
     --net=host \
-    roll:ascend-a3 \
+    roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12 \
     /bin/bash
 ```
 

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
@@ -1,6 +1,6 @@
 # ROLL x Ascend
 
-最后更新：2026/06/23。
+最后更新：2026/08/17。
 
 我们在 ROLL 上增加对华为昇腾设备的支持。
 
@@ -10,8 +10,8 @@ ROLL 昇腾适配当前覆盖以下训练系列硬件：
 
 | 产品 | 是否支持 | 说明 |
 | ---- | -------- | ---- |
-| Atlas 900 A2 PODc（Ascend 910B1）/ Atlas A2 训练系列产品 | √ | 使用 `docker/Dockerfile.A2` 或 `roll:ascend-a2` 镜像。 |
-| Atlas 900 A3 PODc（Ascend 910_9391）/ Atlas A3 训练系列产品 | √ | 使用 `docker/Dockerfile.A3` 或 `roll:ascend-a3` 镜像。 |
+| Atlas 900 A2 PODc（Ascend 910B1）/ Atlas A2 训练系列产品 | √ | 使用 `docker/Dockerfile.A2` 或 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-910b-ubuntu22.04-py3.12` 镜像。 |
+| Atlas 900 A3 PODc（Ascend 910_9391）/ Atlas A3 训练系列产品 | √ | 使用 `docker/Dockerfile.A3` 或 `roll:v0.3-cann9.1.0-torch_npu2.10.0.post4-a3-ubuntu22.04-py3.12` 镜像。 |
 | Ascend 950 训练系列产品 | √ | 使用 Ascend 950 安装配置：torch 2.10、vLLM v0.20.2、vLLM-Ascend `main`，并在构建 vLLM-Ascend 时设置 `COMPILE_CUSTOM_KERNELS=1`。 |
 | Atlas A2/A3 推理系列产品、Atlas 200I/500 A2 推理产品 | x | 当前 ROLL NPU 镜像和示例面向训练系列设备。 |
 | 其他昇腾训练或推理产品 | 未验证 | 使用前请确认驱动、固件、CANN、`torch_npu` 与 vLLM-Ascend 版本配套。 |
@@ -23,7 +23,7 @@ ROLL 昇腾适配当前覆盖以下训练系列硬件：
 | 部署场景 | 支持的操作系统 | 说明 |
 | -------- | -------------- | ---- |
 | 物理机宿主机 | Ubuntu 22.04 | 当前 ROLL 昇腾文档推荐并验证的宿主机操作系统。 |
-| ROLL 昇腾容器 | Ubuntu 22.04 | A2/A3 Dockerfile 基于 `quay.io/ascend/cann:9.0.0-*-ubuntu22.04-py3.11`。 |
+| ROLL 昇腾容器 | Ubuntu 22.04 | A2/A3 Dockerfile 基于 `quay.io/ascend/cann:9.1.0-*-ubuntu22.04-py3.12-devel`。 |
 | Ascend 950  手动安装 | Ubuntu 22.04 | 使用下文 Ascend 950 专用 torch/vLLM 版本组合。驱动、固件、CANN 和 `torch_npu` 版本需要与目标 Ascend 950 环境匹配。 |
 | 其他宿主机 OS 上的虚拟机或容器部署 | 以昇腾/CANN 兼容性说明为准 | 请结合目标硬件查询昇腾兼容性查询助手，以及 CANN 软件安装文档中的操作系统兼容性说明。 |
 
@@ -33,8 +33,8 @@ ROLL 昇腾适配当前覆盖以下训练系列硬件：
 
 | 软件 | 版本 |
 |-----------|-------------|
-| Python    |  3.11       |
-| CANN      |  9.0.0      |
+| Python    |  3.12       |
+| CANN      |  9.1.0      |
 
 Ascend 950 请保持 Python 3.11，并使用下文 [Ascend 950 安装配置](#Ascend 950-安装配置) 中的专用 torch/vLLM 版本组合。
 
@@ -43,7 +43,7 @@ Ascend 950 请保持 Python 3.11，并使用下文 [Ascend 950 安装配置](#As
 使用以下命令在 Miniconda 中创建新的 conda 环境：
 
 ```
-conda create --name roll python=3.11
+conda create --name roll python=3.12
 conda activate roll
 ```
 
@@ -53,10 +53,12 @@ conda activate roll
 
 ```
 # 在预构建镜像外手动安装时，使用 CPU 版 torch
-pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu
 
 # 安装与 torch/CANN 匹配的 torch_npu
-pip install torch_npu==2.9.0
+python -m pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    --no-deps torch-npu==2.10.0.post4
 ```
 
 ### 安装 vllm & vllm-ascend
@@ -65,29 +67,34 @@ pip install torch_npu==2.9.0
 
 ```
 # vllm
-git clone -b v0.18.0 --depth 1 https://github.com/vllm-project/vllm.git
+git clone -b v0.23.0 --depth 1 https://github.com/vllm-project/vllm.git
 cd vllm
-pip install -r requirements/build.txt
 
 VLLM_TARGET_DEVICE=empty pip install -v -e .
 cd ..
 
 # vllm-ascend
-git clone -b v0.18.0 --depth 1 https://github.com/vllm-project/vllm-ascend.git
+git clone -b v0.23.0rc1 --depth 1 https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
+git submodule update --init --recursive
 
-pip install -e .
+pip install -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 cd ..
+
+# 在其他依赖安装完成后安装昇腾 Triton 实现
+pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 或者可以从预编译的 wheel 包安装 `vllm` 和 `vllm-ascend`：
 
 ```
-# 安装 vllm-project/vllm，最新支持版本为 v0.18.0
-pip install vllm==0.18.0
+# 安装 vllm-project/vllm，最新支持版本为 v0.23.0
+pip install vllm==0.23.0
 
 # 从 pypi 安装 vllm-project/vllm-ascend
-pip install vllm-ascend==0.18
+pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    vllm-ascend==0.23.0rc1
 ```
 
 ### Ascend 950 安装配置
@@ -131,6 +138,8 @@ cd ..
 | 软件 | 说明 |
 | ---- | ---- |
 | transformers | >= v4.57.6 |
+| torch-npu | 2.10.0.post4 |
+| triton-ascend | 3.2.1（替代 `triton`） |
 | flash_attn | 不支持 |
 | transformer-engine[pytorch] | 不支持 |
 
@@ -140,6 +149,8 @@ cd ..
 
 ```
 pip install transformers==4.57.6
+pip uninstall -y triton triton-ascend
+pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 ## 快速开始：单节点部署指引


### PR DESCRIPTION
  ## Summary

  Upgrade the Ascend NPU A2/A3 Docker images and synchronize all related documentation.

  ## Changes

  - Upgrade the base images from CANN 9.0.0 / Python 3.11 to CANN 9.1.0 / Python 3.12.
  - Upgrade core dependencies:
    - PyTorch: 2.9.0 → 2.10.0
    - torch-npu: 2.10.0.post4
    - vLLM: 0.18.0 → 0.23.0
    - vLLM-Ascend: 0.18.0 → 0.23.0rc1
  - Initialize vLLM-Ascend submodules and use the Ascend package mirror.
  - Exclude `gem-llm` from the common requirements when building NPU images.
  - Update A2/A3 Docker image tags to include CANN, torch-npu, hardware, Ubuntu, and Python versions.
  - Update NPU device mounting, `ulimit`, and environment verification instructions.
  - Synchronize English and Chinese documentation, including:
    - `OVERVIEW.md`
    - Docker usage guide
    - Ascend usage guide
    - RLVR and example guides
    - FAQ and environment configuration
  - Remove unrelated Ascend 950 content from the A2/A3 Docker usage guide.
