### PR TITLE
fix: fix NPU dockerfile

### DIFF
--- a/docker/Dockerfile.A2
+++ b/docker/Dockerfile.A2
@@ -36,14 +36,17 @@ RUN cd vllm && \
     pip cache purge && \
     cd ..
 
-RUN pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
+RUN pip install \
+        --index-url https://download.pytorch.org/whl/cpu \
+        --extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+        torch==2.10.0+cpu torchvision==0.25.0 torchaudio==2.10.0;
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     cd vllm-ascend && \
     git submodule update --init --recursive && \
     pip install -r requirements.txt --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
-    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --no-build-isolation --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 
 RUN python3 -m pip install --index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
         --no-deps torch-npu==2.10.0.post4
@@ -55,7 +58,7 @@ RUN grep -v '^gem-llm' requirements_common.txt > requirements_npu.txt && \
     pip install -r requirements_npu.txt && \
     rm -f requirements_npu.txt
 
-RUN pip install "transformers==4.57.6" "tensorboard==2.20.0"
+RUN pip install "transformers==4.57.6" "tensorboard==2.20.0" "hydra-core==1.3.5" "sympy==1.14.0"
 
 RUN pip install -e .
 

--- a/docker/Dockerfile.A3
+++ b/docker/Dockerfile.A3
@@ -36,14 +36,17 @@ RUN cd vllm && \
     pip cache purge && \
     cd ..
 
-RUN pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
+RUN pip install \
+        --index-url https://download.pytorch.org/whl/cpu \
+        --extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+        torch==2.10.0+cpu torchvision==0.25.0 torchaudio==2.10.0;
 
 RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     cd vllm-ascend && \
     git submodule update --init --recursive && \
     pip install -r requirements.txt --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
-    SOC_VERSION=${SOC_VERSION} pip install -v -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+    SOC_VERSION=${SOC_VERSION} pip install -v -e . --no-build-isolation --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 
 RUN python3 -m pip install --index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
         --no-deps torch-npu==2.10.0.post4
@@ -55,7 +58,7 @@ RUN grep -v '^gem-llm' requirements_common.txt > requirements_npu.txt && \
     pip install -r requirements_npu.txt && \
     rm -f requirements_npu.txt
 
-RUN pip install "transformers==4.57.6" "tensorboard==2.20.0"
+RUN pip install "transformers==4.57.6" "tensorboard==2.20.0" "hydra-core==1.3.5" "sympy==1.14.0"
 
 RUN pip install -e .
 

--- a/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/docs/User Guides/Hardware Support/ascend_usage.md
@@ -53,7 +53,10 @@ To use torch and torch_npu in ROLL, install them using the commands below:
 
 ```
 # Use CPU-only torch when installing outside the pre-built image
-pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+pip install \
+    --index-url https://download.pytorch.org/whl/cpu \
+    --extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+    torch==2.10.0+cpu torchvision==0.25.0 torchaudio==2.10.0
 
 # Install the torch_npu version matching torch/CANN
 python -m pip install \
@@ -78,7 +81,7 @@ git clone -b v0.23.0rc1 --depth 1 https://github.com/vllm-project/vllm-ascend.gi
 cd vllm-ascend
 git submodule update --init --recursive
 
-pip install -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+pip install -e . --no-build-isolation --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 cd ..
 
 # Install the Ascend Triton implementation after the other packages

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Hardware Support/ascend_usage.md
@@ -53,7 +53,10 @@ conda activate roll
 
 ```
 # 在预构建镜像外手动安装时，使用 CPU 版 torch
-pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+pip install \
+    --index-url https://download.pytorch.org/whl/cpu \
+    --extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple \
+    torch==2.10.0+cpu torchvision==0.25.0 torchaudio==2.10.0
 
 # 安装与 torch/CANN 匹配的 torch_npu
 python -m pip install \
@@ -78,7 +81,7 @@ git clone -b v0.23.0rc1 --depth 1 https://github.com/vllm-project/vllm-ascend.gi
 cd vllm-ascend
 git submodule update --init --recursive
 
-pip install -e . --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+pip install -e . --no-build-isolation --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 cd ..
 
 # 在其他依赖安装完成后安装昇腾 Triton 实现


### PR DESCRIPTION
Fix A2/A3 Docker installation for torch-npu and vllm-ascend.

  - Install the correct CPU PyTorch version.
  - Disable build isolation for vllm-ascend.
  - Pin required Hydra, SymPy, and related dependencies.
  - Update the Ascend installation documentation accordingly.