### PR TITLE
(feat): support OPSD

### DIFF
--- a/docs_roll/docs/User Guides/Pipeline/on_policy_distill_pipeline_start.md
+++ b/docs_roll/docs/User Guides/Pipeline/on_policy_distill_pipeline_start.md
@@ -30,6 +30,7 @@
   - [Multi-Teacher OPD](#multi-teacher-opd)
     - [Configuration Examples](#configuration-examples)
     - [Core Mechanisms](#core-mechanisms)
+  - [OPSD (On-Policy Self-Distillation)](#opsd-on-policy-self-distillation)
   - [FAQ](#faq)
   - [References](#references)
 
@@ -140,7 +141,7 @@ The main differences from standard RLVR/Agentic training are:
 
 * **Reward Computation**: Uses Teacher Model's log probabilities instead of external reward models
 * **Advantage Computation**: `advantage = teacher_log_prob - student_log_prob`
-* **Worker Mapping**: `student_train` → `actor_train`, `student_infer` → `actor_infer`, `teacher` → `reference`
+* **Worker Mapping**: `student_train` → `actor_train`, `student_infer` → `actor_infer`, `teacher` and/or `reference` → `reference` (merged into unified `_reference_configs`)
 
 **Source Code**:
 - Launcher script: `examples/start_onpolicy_distill_pipeline.py`
@@ -249,9 +250,9 @@ Configure three roles, automatically mapped to internal Workers:
 |----------|----------|------|
 | `student_train` | `actor_train` | Train student model, compute loss using Teacher KL |
 | `student_infer` | `actor_infer` | Generate trajectories, compute student log_probs |
-| `teacher` | `reference` / `references` | Compute teacher log_probs (supports single WorkerConfig or multi-teacher Dict) |
+| `teacher` and/or `reference` | `reference` / `references` | Compute teacher log_probs (supports single WorkerConfig or multi-teacher Dict) |
 
-**Note**: Config file uses `student_train`, `student_infer`, `teacher` names, system will automatically map them. For multi-teacher, `teacher` is `Dict[str, WorkerConfig]`, internally normalized to `self.references: Dict[str, Cluster]`.
+**Note**: Config file uses `student_train`, `student_infer`, `teacher` names, system will automatically map them. `reference` can be used alongside or instead of `teacher` — both are merged into a unified `_reference_configs` dict (`reference` → `"reference"`, single `teacher` → `"default"`, dict `teacher` → by keys). For multi-teacher, `teacher` is `Dict[str, WorkerConfig]`, internally normalized to `self.references: Dict[str, Cluster]`.
 
 #### Mixed Mode
 
@@ -322,14 +323,21 @@ bash examples/qwen3-8B-onpolicy-distill-megatron/run_onpolicy_distill_pipeline.s
 
 #### Pure OPD Mode
 
-**No additional OPD-related parameters need to be configured**. Users only need to configure the `teacher` model path, student model path, data, and Reward Workers.
+Launched via `start_onpolicy_distill_pipeline.py`, which automatically sets `is_pure_opd=True`.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `pure_opd_pipeline_type` | Pipeline type, one of `"rlvr"` or `"agentic"` | `"rlvr"` |
+| `student_train` | Student model training config (mapped to actor_train) | Required |
+| `student_infer` | Student model inference config (mapped to actor_infer) | Required |
+| `teacher` or `reference` | Teacher/reference model config (merged into _reference_configs) | Required |
 
 #### Mixed Mode (`PPOConfig` / `RLVRConfig`)
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `use_opd` | Enable mixed mode OPD (add Teacher KL to rewards) | `false` |
-| `teacher` | Teacher model config (auto-mapped to reference) | Required |
+| `teacher` or `reference` | Teacher/reference model config (merged into _reference_configs) | Required |
 
 #### Multi-Teacher Mode Parameters
 
@@ -339,6 +347,17 @@ bash examples/qwen3-8B-onpolicy-distill-megatron/run_onpolicy_distill_pipeline.s
 | `teacher.{name}.opd_kl_coef` | Per-teacher KL coefficient | `1.0` |
 | `teacher.{name}.tag_included` | Tags this teacher handles; empty means all | `[]` |
 | `tag_to_template` | Select different chat templates by tag | `{}` |
+
+#### OPSD Mode Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `opsd_mode` | Enable OPSD (inject reference solution y\* into teacher prompt). Requires `is_pure_opd=True` or `use_opd=True` | `false` |
+| `opsd_solution_key` | Dataset column name for the reference solution | `"reference_solution"` |
+| `opsd_teacher_template` | Format string for teacher prompt, placeholders `{problem}` and `{solution}` | Built-in default template |
+| `global_template` | Chat template name for teacher prompt formatting | — |
+| `sequence_length` | Total batch tensor length. OPSD teacher prompt (problem + y\*) is longer than student prompt — set larger than `prompt_length + response_length` to give buffer | `prompt_length + response_length` |
+| `opsd_max_solution_length` | Optional hard cap on reference solution (y\*) token length. If set, solutions exceeding this are truncated before building teacher prompt. If not set, solutions are auto-truncated to fit `sequence_length` (template overhead measured dynamically) | `None` |
 
 
 ---
@@ -560,6 +579,134 @@ Internally normalized to `{"default": WorkerConfig}`, the loop executes only onc
 
 ---
 
+## OPSD (On-Policy Self-Distillation)
+
+### Overview
+
+OPSD extends OPD: when the teacher evaluates the student's response, its prompt includes the **reference solution y\*** (privileged information) in addition to the original problem. This makes the teacher "know the answer," assigning higher probability to reasoning paths that lead to the correct answer, providing a more precise distillation signal.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    OPSD Data Flow                                 │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│   Student Infer:                                                  │
+│     prompt = original problem (no y*)                             │
+│     → generate response                                           │
+│                                                                   │
+│   Teacher Forward (OPSD transform):                                │
+│     prompt = original problem + y* + instruction (privileged)     │
+│     + same response tokens                                        │
+│     → compute ref_log_probs                                       │
+│     → align back to student layout                                │
+│                                                                   │
+│   Advantage = -KL(student || teacher)                            │
+│                                                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Difference from standard OPD**:
+
+| Feature | Standard OPD | OPSD |
+|---------|-------------|------|
+| Teacher prompt | Original problem only | Original problem + reference solution y\* |
+| Privileged info | None | y\* injected into teacher prompt |
+| Distillation signal | General behavior alignment | Guides reasoning toward correct answer |
+| Config | `is_pure_opd=True` or `use_opd=True` | Additionally enable `opsd_mode=True` |
+
+### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `opsd_mode` | Enable OPSD mode (inject y\* into teacher prompt). Requires `is_pure_opd=True` or `use_opd=True` | `false` |
+| `opsd_solution_key` | Dataset column name for the reference solution | `"reference_solution"` |
+| `opsd_teacher_template` | Format string for teacher prompt, supports `{problem}` and `{solution}` placeholders | Built-in default template |
+| `global_template` | Chat template name (e.g., `qwen3`) for teacher prompt formatting | — |
+
+### Data Requirements
+
+The dataset JSONL must contain a `reference_solution` field (or the field specified by `opsd_solution_key`), containing the **full CoT reasoning process** (not just the final answer):
+
+```json
+{
+    "id": "0",
+    "prompt": "Prove that for all positive integers n, n^3 - n is divisible by 6",
+    "messages": "[{\"role\": \"user\", \"content\": \"Prove that for all positive integers n, n^3 - n is divisible by 6\"}]",
+    "ground_truth": "Proof complete",
+    "reference_solution": "n^3 - n = n(n-1)(n+1) = (n-1)n(n+1)...\nThus n^3 - n is a product of three consecutive integers, divisible by 6.",
+    "tag": "math_opsd"
+}
+```
+
+### Teacher Prompt Construction
+
+The teacher prompt is built by formatting `opsd_teacher_template`, then wrapping with the chat template specified by `global_template`:
+
+```
+opsd_teacher_template.format(problem=..., solution=...)
+  → user_content (problem + y* + instruction)
+  → [{"role": "user", "content": user_content}]
+  → get_chat_template(global_template, tokenizer)(..., add_generation_prompt=True)
+  → teacher_prompt_text (with chat format tokens)
+```
+
+The default template instructs the student to reason independently rather than copy the reference solution. When customizing, use `{problem}` and `{solution}` as placeholders.
+
+### Configuration Example
+
+```yaml
+# OPSD configuration
+is_pure_opd: true  # Set automatically by start_onpolicy_distill_pipeline.py
+opsd_mode: true
+opsd_solution_key: "reference_solution"
+global_template: qwen3  # teacher prompt uses qwen3 chat template (with thinking)
+# Optional: hard cap on solution length. If not set, auto-truncates to fit sequence_length.
+opsd_max_solution_length: 2048
+
+# OPSD teacher prompt (problem + y*) is longer than student prompt.
+# Set sequence_length > prompt_length + response_length to give buffer.
+prompt_length: 2048
+response_length: 4096
+sequence_length: 6656  # 2048 + 4096 + 512 buffer for teacher prompt
+
+student_train:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B
+  data_args:
+    file_name:
+      - data/openthoughts_math_opsd.jsonl  # Must contain reference_solution field
+    domain_interleave_probs:
+      math_rule: 1.0
+  # ...
+
+student_infer:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B
+  # ...
+
+teacher:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B  # Self-distillation: teacher = student initial weights
+  # ...
+```
+
+### Compatibility
+
+- **Multi-Teacher**: OPSD is compatible with multi-teacher routing. Each teacher's `ref_log_probs_{name}` is automatically aligned back to student layout
+- **Reference + Teacher**: Both `reference` and `teacher` can be configured simultaneously. They are merged into a unified `_reference_configs` dict. Each entry's KL contributes to the advantage weighted by `opd_kl_coef`
+- **Mixed Mode**: OPSD can be combined with `use_opd=True`, advantage = `rl_advantages - total_weighted_kld`
+
+### Caveats
+
+- OPSD teacher prompt (problem + y\*) is longer than student prompt. Set `sequence_length` larger than `prompt_length + response_length` to give buffer. Solutions are auto-truncated to fit: the system measures template overhead dynamically (by building an empty-solution prompt), calculates available space for the solution, and truncates the solution text — preserving the OPSD template structure. Optionally set `opsd_max_solution_length` for a hard cap on solution length.
+- Literal curly braces in `opsd_teacher_template` must be escaped as `{{` and `}}` (standard Python `.format()`)
+- OPSD mode does not support configuring both `reference` and `teacher` simultaneously
+- OPSD supports both LoRA and non-LoRA branches:
+  - **Non-LoRA branch**: teacher is a separate cluster
+  - **LoRA branch**: teacher is the actor model itself (adapter disabled), no `teacher` config needed
+
+---
+
 ## FAQ
 
 ### Q1: How to configure mixed mode?
@@ -577,7 +724,8 @@ rewards:
     worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
     tag_included: [math]
 
-# Teacher configuration (automatically mapped to reference)
+# Teacher or reference configuration (automatically mapped to reference)
+# Both can be configured simultaneously — they are merged into _reference_configs
 teacher:
   model_args:
     model_name_or_path: Qwen/Qwen3-32B

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Pipeline/on_policy_distill_pipeline_start.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Pipeline/on_policy_distill_pipeline_start.md
@@ -30,6 +30,7 @@
   - [Multi-Teacher OPD](#️multi-teacher-opd多教师蒸馏)
     - [配置示例](#配置示例)
     - [核心机制](#核心机制)
+  - [OPSD（On-Policy Self-Distillation）](#️opsdon-policy-self-distillation)
   - [常见问题](#️常见问题)
   - [参考资料](#参考资料)
 
@@ -139,7 +140,7 @@ advantages = -reverse_kl  # 负号：最小化 KL = 最大化 advantage
 
 * **奖励计算方式**：使用 Teacher Model 的 log probabilities 替代外部奖励模型
 * **Advantage 计算**：`advantage = teacher_log_prob - student_log_prob`
-* **Worker 映射**：`student_train` → `actor_train`，`student_infer` → `actor_infer`，`teacher` → `reference`
+* **Worker 映射**：`student_train` → `actor_train`，`student_infer` → `actor_infer`，`teacher` 和/或 `reference` → `reference`（合并到统一的 `_reference_configs`）
 
 **源代码**：
 - 启动脚本：`examples/start_onpolicy_distill_pipeline.py`
@@ -248,9 +249,9 @@ On-Policy Distillation 的 Worker 角色根据模式有所不同：
 |----------|----------|------|
 | `student_train` | `actor_train` | 训练学生模型，使用 Teacher KL 计算损失 |
 | `student_infer` | `actor_infer` | 生成轨迹，计算 student log_probs |
-| `teacher` | `reference` / `references` | 计算 teacher log_probs（支持单个 WorkerConfig 或多 teacher Dict） |
+| `teacher` 和/或 `reference` | `reference` / `references` | 计算 teacher log_probs（支持单个 WorkerConfig 或多 teacher Dict） |
 
-**注意**：配置文件中使用 `student_train`、`student_infer`、`teacher` 名称，系统会自动映射。多 teacher 时 `teacher` 为 `Dict[str, WorkerConfig]`，内部归一化为 `self.references: Dict[str, Cluster]`。
+**注意**：配置文件中使用 `student_train`、`student_infer`、`teacher` 名称，系统会自动映射。`reference` 可与 `teacher` 同时或单独配置——两者合并到统一的 `_reference_configs` 字典（`reference` → `"reference"`，单个 `teacher` → `"default"`，字典 `teacher` → 按字典键）。多 teacher 时 `teacher` 为 `Dict[str, WorkerConfig]`，内部归一化为 `self.references: Dict[str, Cluster]`。
 
 #### 混合模式
 
@@ -328,7 +329,7 @@ bash examples/qwen3-8B-onpolicy-distill-megatron/run_onpolicy_distill_pipeline.s
 | `pure_opd_pipeline_type` | Pipeline 类型，可选 `"rlvr"` 或 `"agentic"` | `"rlvr"` |
 | `student_train` | 学生模型训练配置（映射到 actor_train） | 必须配置 |
 | `student_infer` | 学生模型推理配置（映射到 actor_infer） | 必须配置 |
-| `teacher` | 教师模型配置（映射到 reference） | 必须配置 |
+| `teacher` 或 `reference` | 教师/参考模型配置（合并到 _reference_configs） | 必须配置 |
 
 #### 混合模式
 
@@ -337,7 +338,7 @@ bash examples/qwen3-8B-onpolicy-distill-megatron/run_onpolicy_distill_pipeline.s
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `use_opd` | 启用混合模式 OPD（将 Teacher KL 添加到奖励中） | `false` |
-| `teacher` | 教师模型配置（自动映射到 reference） | 必须配置 |
+| `teacher` 或 `reference` | 教师/参考模型配置（合并到 _reference_configs） | 必须配置 |
 
 #### Multi-Teacher 模式参数
 
@@ -347,6 +348,17 @@ bash examples/qwen3-8B-onpolicy-distill-megatron/run_onpolicy_distill_pipeline.s
 | `teacher.{name}.opd_kl_coef` | 该教师的 KL 系数 | `1.0` |
 | `teacher.{name}.tag_included` | 该教师负责的 tag 列表，空表示全量 | `[]` |
 | `tag_to_template` | 按 tag 选择不同的 chat template | `{}` |
+
+#### OPSD 模式参数
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `opsd_mode` | 启用 OPSD（teacher prompt 注入参考解 y\*）。需配合 `is_pure_opd=True` 或 `use_opd=True` | `false` |
+| `opsd_solution_key` | 数据集中参考解字段的列名 | `"reference_solution"` |
+| `opsd_teacher_template` | Teacher prompt 格式化模板，占位符 `{problem}` 和 `{solution}` | 内置默认模板 |
+| `global_template` | Chat 模板名称，用于 teacher prompt 格式化 | — |
+| `sequence_length` | Batch 张量总长度。OPSD teacher prompt（problem + y\*）比 student prompt 更长，需设为大于 `prompt_length + response_length` 的值留出 buffer | `prompt_length + response_length` |
+| `opsd_max_solution_length` | 参考解（y\*）的最大 token 长度（可选硬上限）。设置后超过此长度的 solution 会在构建 teacher prompt 前被截断。不设置则自动按 `sequence_length` 截断（动态测量模板 overhead） | `None` |
 
 
 ---
@@ -568,6 +580,134 @@ teacher:
 
 ---
 
+## ✨️OPSD（On-Policy Self-Distillation）
+
+### 概述
+
+OPSD 是 OPD 的扩展模式：Teacher 在评估 student 生成的 response 时，prompt 中包含**参考解 y\***（特权信息），而非仅原始问题。这让 teacher "知道答案"，从而对通向正确答案的推理路径赋予更高概率，提供更精准的蒸馏信号。
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    OPSD 数据流                                     │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│   Student Infer:                                                 │
+│     prompt = 原始问题（不含 y*）                                   │
+│     → 生成 response                                              │
+│                                                                   │
+│   Teacher Forward（OPSD 变身）:                                    │
+│     prompt = 原始问题 + y* + 指令（特权信息）                      │
+│     + 同一 response tokens                                        │
+│     → 计算 ref_log_probs                                         │
+│     → 对齐回 student 布局                                         │
+│                                                                   │
+│   Advantage = -KL(student || teacher)                            │
+│                                                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**与标准 OPD 的区别**：
+
+| 特性 | 标准 OPD | OPSD |
+|------|---------|------|
+| Teacher prompt | 仅原始问题 | 原始问题 + 参考解 y\* |
+| 特权信息 | 无 | 有（y* 注入 teacher prompt） |
+| 蒸馏信号 | 通用行为对齐 | 引导推理路径走向正确答案 |
+| 配置 | `is_pure_opd=True` 或 `use_opd=True` | 额外开启 `opsd_mode=True` |
+
+### 配置参数
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `opsd_mode` | 启用 OPSD 模式（teacher prompt 注入 y\*）。需配合 `is_pure_opd=True` 或 `use_opd=True` | `false` |
+| `opsd_solution_key` | 数据集中参考解字段的列名 | `"reference_solution"` |
+| `opsd_teacher_template` | Teacher prompt 的格式化字符串模板，支持 `{problem}` 和 `{solution}` 占位符 | 内置默认模板 |
+| `global_template` | Chat 模板名称（如 `qwen3`），用于 teacher prompt 格式化 | — |
+
+### 数据要求
+
+数据集 JSONL 中必须包含 `reference_solution` 字段（或 `opsd_solution_key` 指定的字段名），内容为**完整 CoT 推理过程**（而非仅最终答案）：
+
+```json
+{
+    "id": "0",
+    "prompt": "证明对于所有正整数 n，n^3 - n 能被 6 整除",
+    "messages": "[{\"role\": \"user\", \"content\": \"证明对于所有正整数 n，n^3 - n 能被 6 整除\"}]",
+    "ground_truth": "证明完成",
+    "reference_solution": "n^3 - n = n(n-1)(n+1) = (n-1)n(n+1)...\n因此 n^3 - n 是三个连续整数之积，必被 6 整除。",
+    "tag": "math_opsd"
+}
+```
+
+### Teacher Prompt 构建
+
+Teacher prompt 由 `opsd_teacher_template` 格式化后，通过 `global_template` 指定的 chat 模板包装：
+
+```
+opsd_teacher_template.format(problem=..., solution=...)
+  → user_content（问题 + y* + 指令）
+  → [{"role": "user", "content": user_content}]
+  → get_chat_template(global_template, tokenizer)(..., add_generation_prompt=True)
+  → teacher_prompt_text（含 chat 格式 token）
+```
+
+默认模板引导学生独立推理而非复制参考解。自定义模板时，用 `{problem}` 和 `{solution}` 作为占位符。
+
+### 配置示例
+
+```yaml
+# OPSD 配置
+is_pure_opd: true  # 由 start_onpolicy_distill_pipeline.py 自动设置
+opsd_mode: true
+opsd_solution_key: "reference_solution"
+global_template: qwen3  # teacher prompt 使用 qwen3 chat 模板（含 thinking）
+# 可选：solution 长度硬上限。不设置则自动按 sequence_length 截断。
+opsd_max_solution_length: 2048
+
+# OPSD teacher prompt（problem + y*）比 student prompt 更长。
+# 设 sequence_length > prompt_length + response_length 留出 buffer。
+prompt_length: 2048
+response_length: 4096
+sequence_length: 6656  # 2048 + 4096 + 512 buffer for teacher prompt
+
+student_train:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B
+  data_args:
+    file_name:
+      - data/openthoughts_math_opsd.jsonl  # 必须含 reference_solution 字段
+    domain_interleave_probs:
+      math_rule: 1.0
+  # ...
+
+student_infer:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B
+  # ...
+
+teacher:
+  model_args:
+    model_name_or_path: Qwen/Qwen3-8B  # 自蒸馏：teacher = student 初始权重
+  # ...
+```
+
+### 兼容性
+
+- **多 Teacher**：OPSD 兼容多 teacher 路由。每个 teacher 的 `ref_log_probs_{name}` 都会被自动对齐回 student 布局
+- **Reference + Teacher**：`reference` 和 `teacher` 可同时配置，合并到统一的 `_reference_configs` 字典。每个条目的 KL 按 `opd_kl_coef` 加权后累加到 advantage
+- **混合模式**：OPSD 可与 `use_opd=True` 混合使用，advantage = `rl_advantages - total_weighted_kld`
+
+### 注意事项
+
+- OPSD teacher prompt（problem + y\*）比 student prompt 更长。需设置 `sequence_length` 大于 `prompt_length + response_length` 留出 buffer。Solution 超限时自动截断：系统动态测量模板 overhead（构建空 solution 的 prompt），计算 solution 可用空间，截断 solution 文本——保留 OPSD 模板结构完整。可选设置 `opsd_max_solution_length` 作为 solution 长度硬上限
+- `opsd_teacher_template` 中的字面花括号需用 `{{` 和 `}}` 转义（Python `.format()` 标准）
+- OPSD 模式不支持同时配置 `reference` 和 `teacher`
+- OPSD 同时支持 LoRA 和非 LoRA 分支：
+  - **非 LoRA 分支**：teacher 是独立 cluster
+  - **LoRA 分支**：teacher 是 actor 模型自身（adapter disabled），无需配置 `teacher`
+
+---
+
 ## ✨️常见问题
 
 ### Q1: 混合模式如何配置？
@@ -585,7 +725,8 @@ rewards:
     worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
     tag_included: [math]
 
-# Teacher 配置（自动映射到 reference）
+# Teacher 或 reference 配置（自动映射到 reference）
+# 两者可同时配置——合并到 _reference_configs
 teacher:
   model_args:
     model_name_or_path: Qwen/Qwen3-32B

--- a/examples/qwen3-8B-onpolicy-distill-megatron/opsd_distill_config.yaml
+++ b/examples/qwen3-8B-onpolicy-distill-megatron/opsd_distill_config.yaml
@@ -1,0 +1,150 @@
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+
+# Global Config
+exp_name: "qwen3-8B-opsd-distill-math"
+output_dir: ./output/
+logging_dir: ./output/logs
+rollout_dump_dir: ./output/rollout_dump
+seed: 42
+system_envs:
+  USE_MODELSCOPE: '1'
+  VLLM_USE_FLASHINFER_SAMPLER: '0'
+
+checkpoint_config:
+  type: file_system
+  output_dir: /data/cpfs_0/rl_examples/models/${exp_name}
+
+track_with: tensorboard
+
+num_nodes: 1
+num_gpus_per_node: 8
+
+max_steps: 1024
+save_steps: 100
+logging_steps: 1
+eval_steps: 10
+resume_from_checkpoint: false
+
+rollout_batch_size: 32  # paper effective batch size = 32, with G=1 → 32 prompts per rollout
+prompt_length: 2048
+response_length: 4096  # paper uses 1024/2048; 4096 gives Qwen3-8B room for math reasoning
+sequence_length: 6656  # prompt_length + response_length + 512 buffer for OPSD teacher prompt (problem + y*)
+
+num_return_sequences_in_group: 1  # G=1 per OPSD paper: single trajectory per prompt, advantage is purely per-token KL
+ppo_epochs: 1
+
+pretrain: Qwen/Qwen3-8B
+reward_pretrain: Qwen/Qwen3-8B
+
+global_template: qwen3
+
+# OPSD: teacher prompt includes reference solution y* as privileged information.
+# Dataset must contain "reference_solution" field (full CoT, not just final answer).
+opsd_mode: true
+opsd_solution_key: "reference_solution"
+opsd_max_solution_length: 2048  # Cap reference solution (y*) to 2048 tokens; preserves template structure via clean text truncation
+
+validation:
+  data_args:
+    file_name:
+      - data/math_benchmarks.jsonl
+  generating_args:
+    max_new_tokens: ${response_length}
+    top_p: 0.6
+    top_k: 50
+    num_beams: 1
+    temperature: 0.6
+    num_return_sequences: 1
+
+student_train:
+  model_args:
+    model_name_or_path: ${pretrain}
+    attn_implementation: fa2
+    disable_gradient_checkpointing: false
+    dtype: bf16
+    model_type: ~
+  training_args:
+    learning_rate: 5.0e-7
+    weight_decay: 0.1
+    per_device_train_batch_size: 1
+    gradient_accumulation_steps: 8
+    warmup_steps: 20
+    num_train_epochs: 50
+  data_args:
+    file_name:
+      # OPSD dataset with reference_solution field (full CoT).
+      # Download from: https://huggingface.co/datasets/siyanzhao/Openthoughts_math_30k_opsd
+      # Convert to ROLL JSONL format with fields: prompt, messages, ground_truth, reference_solution, tag
+      - data/openthoughts_math_opsd.jsonl
+    domain_interleave_probs:
+      math_rule: 1.0
+    dataset_dir: data
+    messages: messages
+    interleave_probs: "1.0"
+    preprocessing_num_workers: 16
+  strategy_args:
+    strategy_name: megatron_train
+    strategy_config:
+      tensor_model_parallel_size: 2
+      context_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      use_distributed_optimizer: true
+  device_mapping: list(range(0,8))
+  infer_batch_size: 4
+
+student_infer:
+  model_args:
+    model_name_or_path: ${pretrain}
+    disable_gradient_checkpointing: true
+    dtype: bf16
+  generating_args:
+    max_new_tokens: ${response_length}
+    top_p: 0.99
+    top_k: 100
+    num_beams: 1
+    temperature: 0.99
+    num_return_sequences: ${num_return_sequences_in_group}
+  strategy_args:
+    strategy_name: vllm
+    strategy_config:
+      gpu_memory_utilization: 0.7
+      block_size: 16
+      load_format: dummy
+      sleep_level: 2
+  device_mapping: list(range(0,8))
+  infer_batch_size: 1
+
+teacher:
+  # Self-distillation: teacher = same model as student (Qwen3-8B), independent reference cluster.
+  # Weights are fixed (not updated during training) = student's initial weights.
+  # Teacher prompt includes reference solution y* (privileged info) via opsd_teacher_context.
+  model_args:
+    model_name_or_path: ${pretrain}  # same as student
+    disable_gradient_checkpointing: true
+    dtype: bf16
+    model_type: ~
+  strategy_args:
+    strategy_name: megatron_infer
+    strategy_config:
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      context_parallel_size: 1
+      bf16: true
+  device_mapping: list(range(0,8))
+  infer_batch_size: 1
+
+
+rewards:
+  math_rule:
+    worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
+    model_args:
+      model_name_or_path: ${reward_pretrain}
+    data_args:
+      template: qwen3
+    tag_included: [math_opsd]
+    world_size: 8
+    infer_batch_size: 1

--- a/roll/configs/base_config.py
+++ b/roll/configs/base_config.py
@@ -626,6 +626,39 @@ class PPOConfig(BaseConfig):
                  "The OPD KL is computed as: reverse_kl = student_logp - teacher_logp, "
                  "and added to token_level_rewards as: reward - opd_kl_coef * reverse_kl"}
     )
+    opsd_mode: bool = field(
+        default=False,
+        metadata={"help": "Enable OPSD (On-Policy Self-Distillation): teacher prompt includes "
+                 "reference solution y* as privileged information before evaluating student response. "
+                 "Requires is_pure_opd=True or use_opd=True."}
+    )
+    opsd_solution_key: str = field(
+        default="reference_solution",
+        metadata={"help": "non_tensor_batch key for the reference solution (y*, full CoT). "
+                 "Must be present in the dataset JSONL."}
+    )
+    opsd_teacher_template: str = field(
+        default=(
+            "{problem}\n\n"
+            "Here is a reference solution to this problem:\n"
+            "=== Reference Solution Begin ===\n{solution}\n=== Reference Solution End ===\n"
+            "\n\nAfter reading the reference solution above, make sure you truly understand "
+            "the reasoning behind each step — do not copy or paraphrase it. Now, using your "
+            "own words and independent reasoning, derive the same final answer to the problem above. "
+            "Think step by step, explore different approaches, and don't be afraid to backtrack "
+            "or reconsider if something doesn't work out:\n"
+        ),
+        metadata={"help": "Format string for OPSD teacher user message content. "
+                 "Placeholders: {problem} (original problem text), {solution} (reference solution y*). "
+                 "The result is wrapped via the chat template (global_template)."}
+    )
+    opsd_max_solution_length: Optional[int] = field(
+        default=None,
+        metadata={"help": "Max token length of the reference solution (y*) in OPSD teacher prompt. "
+                 "If set, solutions exceeding this are tokenized, truncated, and decoded back to text "
+                 "before building the teacher prompt — preserving the template structure. "
+                 "If None, no truncation (rely on sequence_length buffer + tokenized fallback)."}
+    )
 
     def __post_init__(self):
         super().__post_init__()
@@ -684,16 +717,49 @@ class PPOConfig(BaseConfig):
                 "or use_opd=True for mixed mode (external rewards + Teacher KL)."
             )
 
+        if self.opsd_mode and not (self.is_pure_opd or self.use_opd):
+            raise ValueError(
+                "opsd_mode=True requires is_pure_opd=True or use_opd=True. "
+                "OPSD modifies teacher forward, which requires OPD to be enabled."
+            )
+
         if has_teachers and has_teacher:
             raise ValueError("Cannot configure both multi-teacher dict and single-teacher WorkerConfig.")
 
-        # Step 1: Normalize teacher to _reference_configs dict (always Dict[str, WorkerConfig])
+        # OPSD mode: only teacher receives the OPSD transform (y* in prompt).
+        # reference would incorrectly receive y* too, so forbid coexistence.
+        if self.opsd_mode and has_reference_configured and (has_teacher or has_teachers):
+            raise ValueError(
+                "OPSD mode (opsd_mode=True) does not support configuring both 'reference' and 'teacher'. "
+                "In OPSD mode, only 'teacher' receives the reference solution y* in its prompt. "
+                "If you need a reference model without OPSD, use pure OPD mode (opsd_mode=False)."
+            )
+
+        # Step 1: Merge reference + teacher into unified _reference_configs dict.
+        # reference → "reference", single teacher → "default", dict teacher → by keys.
+        self._reference_configs = {}
+        if has_reference_configured:
+            self._reference_configs["reference"] = self.reference
         if has_teachers:
-            self._reference_configs = self.teacher
+            if has_reference_configured and "reference" in self.teacher:
+                raise ValueError(
+                    "Naming collision: 'reference' key exists in both the reference config "
+                    "and the teacher dict. Please rename the teacher dict key."
+                )
+            self._reference_configs.update(self.teacher)
         elif has_teacher:
-            self._reference_configs = {"default": self.teacher}
-        else:
-            self._reference_configs = {}
+            self._reference_configs["default"] = self.teacher
+
+        # Step 1a: LoRA auto-reference — no separate teacher/reference config needed,
+        # teacher = actor_train with adapter disabled at runtime
+        if not self._reference_configs and (self.is_pure_opd or self.use_opd):
+            is_lora = (
+                self.student_train.is_configured
+                and self.student_train.model_args.lora_target is not None
+            )
+            if is_lora:
+                logger.info("OPD + LoRA: no separate teacher, using student_train as reference")
+                self._reference_configs = {"reference": self.student_train}
 
         # Step 1.5: Build tag → teacher_names routing map for multi-teacher OPD
         self._tag_to_teacher_names: Dict[str, List[str]] = {}
@@ -711,20 +777,20 @@ class PPOConfig(BaseConfig):
         # Step 2: Pure OPD mode
         if self.is_pure_opd:
             if not self._reference_configs:
-                raise ValueError("Pure OPD requires teacher config.")
+                raise ValueError("Pure OPD requires teacher or reference config.")
             if not (self.student_train.is_configured and self.student_infer.is_configured):
                 raise ValueError(
                     "In pure OPD mode (is_pure_opd=True), 'student_train', 'student_infer' "
-                    "and teacher must be configured.\n"
+                    "and teacher/reference must be configured.\n"
                 )
             logger.info(f"Pure OPD mode: mapping student_train to actor_train, "
                         f"student_infer to actor_infer, "
-                        f"{len(self._reference_configs)} teacher(s) to reference")
+                        f"{len(self._reference_configs)} reference(s) to reference")
             self.actor_train = self.student_train
             self.actor_infer = self.student_infer
             self.reference = next(iter(self._reference_configs.values()))
             self.enable_reference = True
-            # Propagate opd_kl_coef default (1.0) to each teacher if not explicitly set
+            # Propagate opd_kl_coef default (1.0) to each reference if not explicitly set
             for ref_cfg in self._reference_configs.values():
                 if ref_cfg.opd_kl_coef is None:
                     ref_cfg.opd_kl_coef = 1.0
@@ -732,15 +798,11 @@ class PPOConfig(BaseConfig):
         # Step 3: Mixed OPD mode
         elif self.use_opd:
             if not self._reference_configs:
-                raise ValueError("Mixed OPD requires teacher config.")
-            if has_reference_configured:
-                raise ValueError(
-                    "In mixed OPD mode (use_opd=True), 'reference' should NOT be configured. "
-                )
-            logger.info(f"Mixed OPD mode: mapping {len(self._reference_configs)} teacher(s) to reference")
+                raise ValueError("Mixed OPD requires teacher or reference config.")
+            logger.info(f"Mixed OPD mode: mapping {len(self._reference_configs)} reference(s) to reference")
             self.reference = next(iter(self._reference_configs.values()))
             self.enable_reference = True
-            # Propagate opd_kl_coef default (1.0) to each teacher if not explicitly set
+            # Propagate opd_kl_coef default (1.0) to each reference if not explicitly set
             for ref_cfg in self._reference_configs.values():
                 if ref_cfg.opd_kl_coef is None:
                     ref_cfg.opd_kl_coef = 1.0
@@ -825,9 +887,10 @@ class PPOConfig(BaseConfig):
     @property
     def reference_configs(self) -> Dict[str, WorkerConfig]:
         """Always returns Dict[str, WorkerConfig] for unified pipeline usage.
-        Single teacher is normalized to {"default": cfg}, multi-teacher to {name: cfg, ...}."""
+        Single teacher is normalized to {"default": cfg}, multi-teacher to {name: cfg, ...}.
+        Reference config is named "reference"."""
         if not hasattr(self, '_reference_configs') or not self._reference_configs:
-            self._reference_configs = {"default": self.reference}
+            self._reference_configs = {"reference": self.reference}
         return self._reference_configs
 
     @property

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -3,7 +3,7 @@ import json
 import os
 import time
 import uuid
-from contextlib import ExitStack
+from contextlib import ExitStack, nullcontext
 from datetime import datetime
 from functools import partial
 from typing import Any, Dict, List, Optional
@@ -40,6 +40,7 @@ from roll.utils.functionals import (
     compute_ref_log_probs_with_routing,
     compute_token_reward,
     get_sample_level_mask,
+    opsd_teacher_context,
     reduce_metrics,
     reward_postprocess,
     batch_balance,
@@ -576,6 +577,7 @@ class RLVRPipeline(BasePipeline):
                 with Timer(name="cal_ref_log_probs", logger=None) as cal_ref_log_probs_timer, \
                         tracer.start_as_current_span("ref_log_probs"):
                     if self.pipeline_config.enable_reference:
+                        opsd_active = getattr(self.pipeline_config, "opsd_mode", False)
                         if not self.use_ref_model:
                             # LoRA branch: use actor_train with disabled adapter
                             worker_config = self.pipeline_config.actor_train
@@ -593,23 +595,29 @@ class RLVRPipeline(BasePipeline):
                                     "reference/compute_log_probs",
                                 )
                                 metrics_mgr.add_metrics(dynamic_batching_metrics)
-                            ref_log_probs = self.actor_train.compute_log_probs(batch, blocking=True)
-                            ref_log_probs.rename(old_keys="log_probs", new_keys="ref_log_probs")
-                            batch = batch.union(ref_log_probs)
-                            metrics_mgr.add_reduced_metrics(ref_log_probs.meta_info.pop("metrics", {}))
+                            with opsd_teacher_context(batch, self.tokenizer, self.pipeline_config) if opsd_active else nullcontext():
+                                ref_log_probs = self.actor_train.compute_log_probs(batch, blocking=True)
+                                ref_name = list(self.pipeline_config.reference_configs.keys())[0]
+                                ref_log_probs.rename(old_keys="log_probs", new_keys=f"ref_log_probs_{ref_name}")
+                                for key in ref_log_probs.batch.keys():
+                                    if key not in batch.batch:
+                                        batch.batch[key] = ref_log_probs.batch[key]
+                                batch.batch["ref_log_probs"] = batch.batch[f"ref_log_probs_{ref_name}"]
+                                metrics_mgr.add_reduced_metrics(ref_log_probs.meta_info.pop("metrics", {}))
                         else:
                             saved_routed_experts = batch.batch.pop("routed_experts", None)
                             domain_to_teacher_names, domain_values = build_domain_routing_context(
                                 batch, self.pipeline_config, domain_key="domain"
                             )
-                            batch = compute_ref_log_probs_with_routing(
-                                batch=batch,
-                                references=self.references,
-                                pipeline_config=self.pipeline_config,
-                                domain_to_teacher_names=domain_to_teacher_names,
-                                domain_values=domain_values,
-                                metrics_fn=metrics_mgr.add_metrics,
-                            )
+                            with opsd_teacher_context(batch, self.tokenizer, self.pipeline_config) if opsd_active else nullcontext():
+                                batch = compute_ref_log_probs_with_routing(
+                                    batch=batch,
+                                    references=self.references,
+                                    pipeline_config=self.pipeline_config,
+                                    domain_to_teacher_names=domain_to_teacher_names,
+                                    domain_values=domain_values,
+                                    metrics_fn=metrics_mgr.add_metrics,
+                                )
                             if saved_routed_experts is not None:
                                 batch.batch["routed_experts"] = saved_routed_experts
                 metrics_mgr.add_metric("time/ref_log_probs_values", cal_ref_log_probs_timer.last)

--- a/roll/utils/functionals.py
+++ b/roll/utils/functionals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,6 +18,7 @@ import torch.nn.functional as F
 from tensordict import TensorDict
 
 from roll.configs.base_config import PPOConfig
+from roll.datasets.chat_template import get_chat_template
 from roll.pipeline.rlvr.rlvr_config import RLVRConfig
 from roll.platforms import current_platform
 from roll.utils.kl_controller import AdaptiveKLController
@@ -925,6 +927,215 @@ def clusters_have_disjoint_devices(clusters: Union[Dict[str, object], List[objec
             return False
         seen_devices |= devices
     return True
+
+
+# === OPSD (On-Policy Self-Distillation) ===
+
+_DEFAULT_OPSD_TEMPLATE = (
+    "{problem}\n\n"
+    "Here is a reference solution to this problem:\n"
+    "=== Reference Solution Begin ===\n{solution}\n=== Reference Solution End ===\n"
+    "\n\nAfter reading the reference solution above, make sure you truly understand "
+    "the reasoning behind each step — do not copy or paraphrase it. Now, using your "
+    "own words and independent reasoning, derive the same final answer to the problem above. "
+    "Think step by step, explore different approaches, and don't be afraid to backtrack "
+    "or reconsider if something doesn't work out:\n"
+)
+
+
+def _build_teacher_prompt_text(problem, solution, tokenizer, pipeline_config):
+    opsd_teacher_template = getattr(pipeline_config, "opsd_teacher_template", _DEFAULT_OPSD_TEMPLATE)
+    user_content = opsd_teacher_template.format(problem=problem, solution=solution)
+    messages = [{"role": "user", "content": user_content}]
+    template_name = (
+        getattr(pipeline_config, "global_template", None)
+        or pipeline_config.actor_train.data_args.template
+    )
+    chat_template_fn = get_chat_template(template_name, tokenizer)
+    return chat_template_fn(conversation=messages, add_generation_prompt=True)
+
+
+def _align_response_log_probs(teacher_log_probs, teacher_resp_mask, student_resp_mask):
+    bs = teacher_log_probs.shape[0]
+    student_seq_len = student_resp_mask.shape[1]
+    aligned = torch.zeros(
+        bs, student_seq_len - 1,
+        dtype=teacher_log_probs.dtype, device=teacher_log_probs.device,
+    )
+    # Shift by 1: log_probs[i] predicts token i+1, so action positions are mask[1:]
+    teacher_action = teacher_resp_mask[:, 1:].bool()
+    student_action = student_resp_mask[:, 1:].bool()
+    for i in range(bs):
+        values = teacher_log_probs[i][teacher_action[i]]
+        positions = student_action[i].nonzero(as_tuple=True)[0]
+        copy_len = min(len(values), len(positions))
+        if copy_len > 0:
+            aligned[i, positions[:copy_len]] = values[:copy_len]
+    return aligned
+
+
+def _prepare_opsd_teacher_batch(batch, tokenizer, pipeline_config):
+    # Transform batch from student format to teacher format: replace student prompt
+    # with teacher prompt (containing reference solution y*), keep response tokens unchanged.
+    device = batch.batch.device
+    input_ids = batch.batch["input_ids"]
+    response_mask = batch.batch["response_mask"]
+    attention_mask = batch.batch["attention_mask"]
+    bs, seq_len = input_ids.shape
+
+    saved = {
+        "input_ids": input_ids.clone(),
+        "attention_mask": attention_mask.clone(),
+        "response_mask": response_mask.clone(),
+        "_original_keys": set(batch.batch.keys()),
+    }
+    if "position_ids" in batch.batch:
+        saved["position_ids"] = batch.batch["position_ids"].clone()
+
+    prompts = batch.non_tensor_batch["prompt"]
+    solutions = batch.non_tensor_batch[pipeline_config.opsd_solution_key]
+    pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
+
+    new_input_ids = []
+    new_attention_masks = []
+    new_response_masks = []
+
+    for i in range(bs):
+        resp_mask_i = response_mask[i].bool()
+        response_ids = input_ids[i][resp_mask_i]
+        num_response = response_ids.shape[0]
+        max_prompt_len = seq_len - num_response
+
+        problem_text = prompts[i] if isinstance(prompts[i], str) else str(prompts[i])
+        solution_text = solutions[i] if isinstance(solutions[i], str) else str(solutions[i])
+
+        # Stage 1: optional hard cap on solution length (user-configured)
+        opsd_max_solution_length = getattr(pipeline_config, "opsd_max_solution_length", None)
+        if opsd_max_solution_length is not None:
+            solution_tokens = tokenizer.encode(solution_text, add_special_tokens=False)
+            if len(solution_tokens) > opsd_max_solution_length:
+                logger.warning(
+                    f"OPSD: truncated solution from {len(solution_tokens)} to "
+                    f"{opsd_max_solution_length} tokens (opsd_max_solution_length) for sample {i}."
+                )
+                solution_text = tokenizer.decode(
+                    solution_tokens[:opsd_max_solution_length], skip_special_tokens=True
+                )
+
+        # Stage 2: build teacher prompt, auto-truncate solution if still too long
+        teacher_prompt_text = _build_teacher_prompt_text(
+            problem_text, solution_text, tokenizer, pipeline_config
+        )
+        teacher_prompt_ids = torch.tensor(
+            tokenizer.encode(teacher_prompt_text, add_special_tokens=False),
+            dtype=input_ids.dtype, device=device,
+        )
+
+        if len(teacher_prompt_ids) > max_prompt_len:
+            # Measure template overhead: problem + OPSD template + chat template, no solution.
+            # This dynamically accounts for the actual template length (user-configurable).
+            empty_prompt_text = _build_teacher_prompt_text(problem_text, "", tokenizer, pipeline_config)
+            empty_ids = tokenizer.encode(empty_prompt_text, add_special_tokens=False)
+            available_for_solution = max_prompt_len - len(empty_ids)
+
+            if available_for_solution > 0:
+                solution_tokens = tokenizer.encode(solution_text, add_special_tokens=False)
+                if len(solution_tokens) > available_for_solution:
+                    logger.warning(
+                        f"OPSD: auto-truncating solution from {len(solution_tokens)} to "
+                        f"{available_for_solution} tokens to fit sequence_length for sample {i}."
+                    )
+                    solution_text = tokenizer.decode(
+                        solution_tokens[:available_for_solution], skip_special_tokens=True
+                    )
+                    teacher_prompt_text = _build_teacher_prompt_text(
+                        problem_text, solution_text, tokenizer, pipeline_config
+                    )
+                    teacher_prompt_ids = torch.tensor(
+                        tokenizer.encode(teacher_prompt_text, add_special_tokens=False),
+                        dtype=input_ids.dtype, device=device,
+                    )
+
+            # Final fallback: problem + template overhead alone exceeds max_prompt_len.
+            # Truncate the tokenized prompt — no solution to cut further.
+            if len(teacher_prompt_ids) > max_prompt_len:
+                logger.warning(
+                    f"OPSD: teacher prompt ({len(teacher_prompt_ids)} tokens) still exceeds "
+                    f"available space ({max_prompt_len}) even with empty solution. "
+                    f"Truncating tokenized prompt. Sample index: {i}."
+                )
+                teacher_prompt_ids = teacher_prompt_ids[:max_prompt_len]
+        num_teacher_prompt = teacher_prompt_ids.shape[0]
+
+        teacher_seq = torch.cat([teacher_prompt_ids, response_ids])
+        total_len = teacher_seq.shape[0]
+        pad_len = seq_len - total_len
+        if pad_len > 0:
+            teacher_seq = torch.cat([
+                teacher_seq,
+                torch.full((pad_len,), pad_token_id, dtype=input_ids.dtype, device=device),
+            ])
+
+        new_input_ids.append(teacher_seq)
+
+        attn = torch.zeros(seq_len, dtype=attention_mask.dtype, device=device)
+        attn[:total_len] = 1
+        new_attention_masks.append(attn)
+
+        resp = torch.zeros(seq_len, dtype=response_mask.dtype, device=device)
+        resp[num_teacher_prompt:num_teacher_prompt + num_response] = 1
+        new_response_masks.append(resp)
+
+    batch.batch["input_ids"] = torch.stack(new_input_ids)
+    batch.batch["attention_mask"] = torch.stack(new_attention_masks)
+    batch.batch["response_mask"] = torch.stack(new_response_masks)
+    batch.batch["position_ids"] = torch.clip(
+        torch.cumsum(batch.batch["attention_mask"], dim=-1) - 1, min=0
+    )
+    return saved
+
+
+def _restore_opsd_student_batch(batch, saved, pipeline_config):
+    teacher_resp_mask = batch.batch["response_mask"]
+    student_resp_mask = saved["response_mask"]
+    original_keys = saved["_original_keys"]
+    expected_action_len = teacher_resp_mask.shape[1] - 1
+
+    # Align keys added by teacher forward (ref_log_probs*) from teacher to student response positions.
+    # Skip keys that pre-existed (in original_keys) or are masks — they just need restoration below.
+    for key in list(batch.batch.keys()):
+        if key in original_keys:
+            continue
+        if key.endswith("_mask"):
+            continue
+        tensor = batch.batch[key]
+        if not torch.is_tensor(tensor) or tensor.dim() != 2:
+            continue
+        if tensor.shape[1] != expected_action_len:
+            continue
+        batch.batch[key] = _align_response_log_probs(
+            tensor, teacher_resp_mask, student_resp_mask
+        )
+
+    batch.batch["input_ids"] = saved["input_ids"]
+    batch.batch["attention_mask"] = saved["attention_mask"]
+    batch.batch["response_mask"] = saved["response_mask"]
+    if saved.get("position_ids") is not None:
+        batch.batch["position_ids"] = saved["position_ids"]
+
+
+@contextmanager
+def opsd_teacher_context(batch, tokenizer, pipeline_config):
+    """Transform batch to teacher format (prompt with y*) on enter,
+    restore to student format with aligned ref_log_probs on exit.
+
+    Ensures batch is restored even if teacher forward raises an exception.
+    """
+    saved = _prepare_opsd_teacher_batch(batch, tokenizer, pipeline_config)
+    try:
+        yield batch
+    finally:
+        _restore_opsd_student_batch(batch, saved, pipeline_config)
 
 
 def compute_ref_log_probs_with_routing(


### PR DESCRIPTION
Enable On-Policy Self-Distillation (OPSD): inject the reference solution into the
teacher prompt so that the teacher scores the student's own on-policy rollout with
privileged information.

### Motivation

In plain OPD the teacher sees exactly the same prompt as the student, so it can only
tell the student "this token looks unlikely to me" — its judgement is no better than
its own unconditioned belief. OPSD gives the teacher the reference solution y\* as
privileged context. Knowing where the trajectory should end up, the teacher assigns
higher probability to the reasoning paths that actually lead to the correct answer,
which turns the per-token KL into a sharper distillation signal without changing the
student's rollout distribution (still fully on-policy).

### Changes

- `roll/configs/base_config.py`: add `opsd_mode`, `opsd_solution_key`,
  `opsd_teacher_template`, `opsd_max_solution_length`; validate `opsd_mode` against
  `is_pure_opd` / `use_opd`; merge `reference` and `teacher` into a unified
  `_reference_configs`.
- `roll/utils/functionals.py`: add `opsd_teacher_context` (plus helpers) that rebuilds
  the teacher input as `[teacher_prompt_with_y* | student_response]`, scatters the
  teacher log-probs back to the student's response positions, and restores the student
  batch on exit.
- `roll/pipeline/rlvr/rlvr_pipeline.py`: wrap the `cal_ref_log_probs` stage in
  `opsd_teacher_context` when `opsd_mode` is enabled (both the LoRA and the
  separate-reference paths).
- `examples/qwen3-8B-onpolicy-distill-megatron/opsd_distill_config.yaml`: runnable
  example config for Qwen3-8B.
- `docs_roll/...` (EN + zh-Hans): document the OPSD parameters and the mode comparison.

### How it works

1. Before the teacher forward, the student prompt is replaced by
   `opsd_teacher_template.format(problem, solution)` rendered through the chat
   template; the student's generated response tokens are spliced on **as raw token
   ids** (never decoded and re-tokenized), so the teacher scores exactly what the
   student produced.
2. If the teacher prompt does not fit, y\* is truncated first — either at the explicit
   `opsd_max_solution_length` cap, or automatically against the space left by
   `sequence_length`, measuring the template overhead dynamically. The student's
   response is never truncated.
3. Because the teacher prefix is longer, the same response token sits at a different
   absolute index in the two sequences. Teacher log-probs are therefore scattered back
   to the student's response positions in response-token order before the batch is
   restored, so downstream `compute_advantage` keeps using the student's
   `response_mask`.
4. The student batch (`input_ids` / `attention_mask` / `response_mask` /
   `position_ids`) is restored in a `finally` block, so it is recovered even if the
   teacher forward raises.

### Usage

```yaml
is_pure_opd: true
opsd_mode: true
opsd_solution_key: "reference_solution"
opsd_max_solution_length: 2048
# teacher prompt (problem + y*) is longer than the student prompt — leave buffer
prompt_length: 2048
response_length: 4096
sequence_length: 6656