### PR TITLE
[WIP]feat(npu): add Ascend FP8/MXFP8 RLVR support and Qwen3.5 MoE reload

### DIFF
--- a/docker/Dockerfile.A5
+++ b/docker/Dockerfile.A5
@@ -1,0 +1,75 @@
+FROM swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-950-ubuntu22.04-py3.12-devel
+
+ARG VLLM_VERSION=v0.23.0
+ARG VLLM_ASCEND_VERSION=v0.23.0rc1
+ARG MEGATRON_VERSION=core_r0.17.0
+ARG MEGATRON_ADAPTOR_VERSION=core_r0.17.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_INDEX_URL=https://repo.huaweicloud.com/repository/pypi/simple \
+    VLLM_TARGET_DEVICE=empty \
+    ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest \
+    SOC_VERSION=ascend950pr_9599 \
+    HF_ENDPOINT=https://hf-mirror.com \
+    VLLM_USE_MODELSCOPE=True \
+    PYTORCH_NPU_ALLOC_CONF=expandable_segments:True \
+    TASK_QUEUE_ENABLE=2 \
+    HCCL_NPU_SOCKET_PORT_RANGE=auto
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential ca-certificates git iproute2 \
+        openjdk-17-jdk pkg-config tmux zip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --upgrade pip setuptools wheel setuptools-rust setuptools-scm packaging "cmake>=3.26" ninja && \
+    python3 -m pip install --index-url https://download.pytorch.org/whl/cpu \
+        torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 && \
+    python3 -m pip install --no-deps torch-npu==2.10.0.post4 && \
+    python3 -m pip install --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple \
+        triton-ascend==3.2.2
+
+WORKDIR /workspace
+
+RUN git clone --depth 1 --branch ${VLLM_VERSION} \
+        https://github.com/vllm-project/vllm.git vllm-${VLLM_VERSION} && \
+    git clone --depth 1 --branch ${VLLM_ASCEND_VERSION} \
+        https://github.com/vllm-project/vllm-ascend.git vllm-ascend-${VLLM_ASCEND_VERSION} && \
+    git clone --depth 1 --branch ${MEGATRON_VERSION} \
+        https://github.com/NVIDIA/Megatron-LM.git Megatron-LM && \
+    git clone --depth 1 https://gitcode.com/Ascend/TransformerEngineNPU TransformerEngineNPU && \
+    git clone --depth 1 --branch ${MEGATRON_ADAPTOR_VERSION} \
+        https://gitcode.com/Ascend/MegatronAdaptor MegatronAdaptor
+
+RUN source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    python3 -m pip install -r /workspace/vllm-${VLLM_VERSION}/requirements/common.txt && \
+    python3 -m pip install numpy==1.26.4 opencv-python-headless==4.10.0.84 && \
+    python3 -m pip install --no-build-isolation --no-deps -e /workspace/vllm-${VLLM_VERSION} && \
+    python3 -m pip install decorator msgpack numba pandas pandas-stubs \
+        pybind11 quart scipy && \
+    python3 -m pip install --no-build-isolation --no-deps \
+        -e /workspace/vllm-ascend-${VLLM_ASCEND_VERSION}
+
+WORKDIR /workspace/ROLL
+COPY . .
+
+RUN source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    python3 -m pip install --ignore-requires-python gem-llm==0.0.4 && \
+    grep -v '^gem-llm==0.0.4$' requirements_common.txt > /tmp/requirements_common_nogem.txt && \
+    python3 -m pip install -r /tmp/requirements_common_nogem.txt && \
+    python3 -m pip install deepspeed==0.16.4 tensorboard && \
+    python3 -m pip install --no-build-isolation -e /workspace/Megatron-LM && \
+    python3 -m pip install --no-build-isolation -e /workspace/TransformerEngineNPU && \
+    python3 -m pip install --no-build-isolation -e /workspace/MegatronAdaptor && \
+    python3 -m pip install --no-build-isolation -e /workspace/ROLL && \
+    rm -f /tmp/requirements_common_nogem.txt
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc && \
+    echo "source /usr/local/Ascend/nnal/atb/set_env.sh" >> /root/.bashrc && \
+    echo "export HCCL_NPU_SOCKET_PORT_RANGE=auto" >> /root/.bashrc
+
+CMD ["bash"]

--- a/examples/ascend_examples/qwen3_0_6b_rlvr_megatron_bf16_bf16_4npu.yaml
+++ b/examples/ascend_examples/qwen3_0_6b_rlvr_megatron_bf16_bf16_4npu.yaml
@@ -1,0 +1,152 @@
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+
+exp_name: "qwen3-0.6B-rlvr-megatron-fp8-vllm-mxfp8-4npu"
+seed: 42
+logging_dir: ./output/logs
+output_dir: ./output
+system_envs:
+  USE_MODELSCOPE: '1'
+
+checkpoint_config:
+  type: file_system
+  output_dir: ./rl_examples/models/${exp_name}
+
+track_with: tensorboard
+tracker_kwargs:
+  log_dir: ./rl_examples/llm/tensorboard/roll_exp/rlvr
+rpc_timeout: 72000
+
+num_gpus_per_node: 4
+
+max_steps: 500
+save_steps: 100
+logging_steps: 1
+eval_steps: 10
+resume_from_checkpoint: false
+
+rollout_batch_size: 32
+prompt_length: 2048
+response_length: 4096
+
+num_return_sequences_in_group: 8
+ppo_epochs: 1
+adv_estimator: "reinforce"
+
+value_clip: 0.5
+reward_clip: 10
+advantage_clip: 2.0
+dual_clip_loss: true
+
+norm_mean_type: ~
+norm_std_type: ~
+
+max_len_mask: true
+difficulty_mask: true
+difficulty_low_threshold: 0.1
+difficulty_high_threshold: 0.95
+error_max_len_clip: false
+
+difficulty_loss_weight: false
+length_loss_weight: false
+
+add_token_level_kl: false
+whiten_advantages: true
+
+pretrain: Qwen/Qwen3-0.6B
+reward_pretrain: Qwen/Qwen3-0.6B
+
+actor_train:
+  model_args:
+    disable_gradient_checkpointing: false
+    dtype: bf16
+    model_type: ~
+  training_args:
+    learning_rate: 1.0e-6
+    weight_decay: 0
+    per_device_train_batch_size: 2
+    gradient_accumulation_steps: 8
+    warmup_steps: 20
+    num_train_epochs: 50
+  data_args:
+    template: qwen2_5
+    file_name:
+      - data/math_deepmath_deal.jsonl
+    domain_interleave_probs:
+      math_rule: 1
+    dataset_dir: data
+    messages: messages
+    interleave_probs: "1.0"
+    preprocessing_num_workers: 16
+  strategy_args:
+    strategy_name: megatron_train
+    strategy_config:
+      tensor_model_parallel_size: 2
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+      use_distributed_optimizer: true
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+      use_flash_attn: true
+      moe_router_dtype: fp32
+  use_sequence_packing: false
+  use_remove_padding: false
+  device_mapping: list(range(0,4))
+  infer_batch_size: 2
+
+actor_infer:
+  model_args:
+    disable_gradient_checkpointing: true
+    dtype: bf16
+  generating_args:
+    max_new_tokens: ${response_length}
+    top_p: 0.99
+    top_k: 100
+    num_beams: 1
+    temperature: 0.99
+    num_return_sequences: ${num_return_sequences_in_group}
+  data_args:
+    template: qwen2_5
+  strategy_args:
+    strategy_name: vllm
+    strategy_config:
+      gpu_memory_utilization: 0.8
+      block_size: 16
+      max_model_len: 6144
+      tensor_parallel_size: 2
+      enforce_eager: true
+      load_format: dummy
+  device_mapping: list(range(0,4))
+  infer_batch_size: 1
+
+reference:
+  model_args:
+    disable_gradient_checkpointing: true
+    dtype: bf16
+    model_type: ~
+  data_args:
+    template: qwen2_5
+  strategy_args:
+    strategy_name: megatron_infer
+    strategy_config:
+      tensor_model_parallel_size: 2
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+  device_mapping: list(range(0,4))
+  infer_batch_size: 2
+
+rewards:
+  math_rule:
+    worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
+    model_args:
+      model_name_or_path: ${reward_pretrain}
+    data_args:
+      template: qwen2_5
+    tag_included: [deepmath_103k, aime]
+    world_size: 4
+    infer_batch_size: 1

--- a/examples/ascend_examples/qwen3_0_6b_rlvr_megatron_fp8_mxfp8_4npu.yaml
+++ b/examples/ascend_examples/qwen3_0_6b_rlvr_megatron_fp8_mxfp8_4npu.yaml
@@ -1,0 +1,157 @@
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+
+exp_name: "qwen3-0.6B-rlvr-megatron-fp8-vllm-mxfp8-4npu"
+seed: 42
+logging_dir: ./output/logs
+output_dir: ./output
+system_envs:
+  USE_MODELSCOPE: '1'
+
+checkpoint_config:
+  type: file_system
+  output_dir: ./rl_examples/models/${exp_name}
+
+track_with: tensorboard
+tracker_kwargs:
+  log_dir: ./rl_examples/llm/tensorboard/roll_exp/rlvr
+rpc_timeout: 72000
+
+num_gpus_per_node: 4
+
+max_steps: 500
+save_steps: 100
+logging_steps: 1
+eval_steps: 10
+resume_from_checkpoint: false
+
+rollout_batch_size: 32
+prompt_length: 2048
+response_length: 4096
+
+num_return_sequences_in_group: 8
+ppo_epochs: 1
+adv_estimator: "reinforce"
+
+value_clip: 0.5
+reward_clip: 10
+advantage_clip: 2.0
+dual_clip_loss: true
+
+norm_mean_type: ~
+norm_std_type: ~
+
+max_len_mask: true
+difficulty_mask: true
+difficulty_low_threshold: 0.1
+difficulty_high_threshold: 0.95
+error_max_len_clip: false
+
+difficulty_loss_weight: false
+length_loss_weight: false
+
+add_token_level_kl: false
+whiten_advantages: true
+
+pretrain: Qwen/Qwen3-0.6B
+reward_pretrain: Qwen/Qwen3-0.6B
+
+actor_train:
+  model_args:
+    disable_gradient_checkpointing: false
+    dtype: bf16
+    model_type: ~
+  training_args:
+    learning_rate: 1.0e-6
+    weight_decay: 0
+    per_device_train_batch_size: 2
+    gradient_accumulation_steps: 8
+    warmup_steps: 20
+    num_train_epochs: 50
+  data_args:
+    template: qwen2_5
+    file_name:
+      - data/math_deepmath_deal.jsonl
+    domain_interleave_probs:
+      math_rule: 1
+    dataset_dir: data
+    messages: messages
+    interleave_probs: "1.0"
+    preprocessing_num_workers: 16
+  strategy_args:
+    strategy_name: megatron_train
+    strategy_config:
+      tensor_model_parallel_size: 2
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+      use_distributed_optimizer: true
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+      fp8: e4m3
+      fp8_recipe: mxfp8
+      use_flash_attn: true
+      moe_router_dtype: fp32
+  use_sequence_packing: false
+  use_remove_padding: false
+  device_mapping: list(range(0,4))
+  infer_batch_size: 2
+
+actor_infer:
+  model_args:
+    disable_gradient_checkpointing: true
+    dtype: bf16
+  generating_args:
+    max_new_tokens: ${response_length}
+    top_p: 0.99
+    top_k: 100
+    num_beams: 1
+    temperature: 0.99
+    num_return_sequences: ${num_return_sequences_in_group}
+  data_args:
+    template: qwen2_5
+  strategy_args:
+    strategy_name: vllm
+    strategy_config:
+      gpu_memory_utilization: 0.8
+      block_size: 16
+      max_model_len: 6144
+      tensor_parallel_size: 2
+      enforce_eager: true
+      load_format: dummy
+      online_quantization: ascend_mxfp8
+      online_quantization_config:
+        group_size: 32
+  device_mapping: list(range(0,4))
+  infer_batch_size: 1
+
+reference:
+  model_args:
+    disable_gradient_checkpointing: true
+    dtype: bf16
+    model_type: ~
+  data_args:
+    template: qwen2_5
+  strategy_args:
+    strategy_name: megatron_infer
+    strategy_config:
+      tensor_model_parallel_size: 2
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+  device_mapping: list(range(0,4))
+  infer_batch_size: 2
+
+rewards:
+  math_rule:
+    worker_cls: roll.pipeline.rlvr.rewards.math_rule_reward_worker.MathRuleRewardWorker
+    model_args:
+      model_name_or_path: ${reward_pretrain}
+    data_args:
+      template: qwen2_5
+    tag_included: [deepmath_103k, aime]
+    world_size: 4
+    infer_batch_size: 1

--- a/mcore_adapter/src/mcore_adapter/adapters/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/adapters/__init__.py
@@ -1,9 +1,13 @@
 from transformers.utils import is_peft_available
 
+from ..platforms import current_platform
 from ..utils import get_logger
 
 
 logger = get_logger(__name__)
+
+if current_platform.is_npu():
+    import megatron_adaptor  # noqa: F401
 
 if is_peft_available():
     from .lora_layer import apply_megatron_lora

--- a/mcore_adapter/src/mcore_adapter/constants.py
+++ b/mcore_adapter/src/mcore_adapter/constants.py
@@ -7,3 +7,7 @@ DIST_OPTIMIZER_DIR = "dist_optimizer"
 HUGGINGFACE_AUTOMAP_CACHE = "./.cache/huggingface/automap"
 
 ADAPTER_CONFIG_NAME = "adapter_config.json"
+
+ASCEND_MXFP8_QUANT_TYPE = "W8A8_MXFP8"
+FLOAT_QUANT_TYPE = "FLOAT"
+QUANT_MODEL_DESCRIPTION_NAME = "quant_model_description.json"

--- a/mcore_adapter/src/mcore_adapter/initialize.py
+++ b/mcore_adapter/src/mcore_adapter/initialize.py
@@ -5,6 +5,10 @@ import numpy as np
 import torch
 from megatron.core import mpu, tensor_parallel
 
+from .npu_runtime import (
+    bootstrap_npu_runtime as _bootstrap_npu_runtime,
+    sync_megatron_adaptor_args as _sync_megatron_adaptor_args,
+)
 from .platforms import current_platform
 from .training_args import TrainingArguments
 from .utils import get_logger
@@ -29,13 +33,15 @@ def _set_random_seed(seed_):
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
-        if current_platform.device_count() > 0:
+        if (current_platform.is_cuda() or current_platform.is_npu()) and current_platform.device_count() > 0:
             tensor_parallel.model_parallel_cuda_manual_seed(seed)
     else:
         raise ValueError("Seed ({}) should be a positive integer.".format(seed))
 
 
 def initialize_megatron(args: "TrainingArguments"):
+    _bootstrap_npu_runtime()
+    _sync_megatron_adaptor_args(args)
     if not is_distribute_initialized():
         _initialize_distributed(args)
     _set_random_seed(args.seed)

--- a/mcore_adapter/src/mcore_adapter/models/checkpoint_loaders/__init__.py
+++ b/mcore_adapter/src/mcore_adapter/models/checkpoint_loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Quantized checkpoint loader integrations."""

--- a/mcore_adapter/src/mcore_adapter/models/checkpoint_loaders/ascend_mxfp8.py
+++ b/mcore_adapter/src/mcore_adapter/models/checkpoint_loaders/ascend_mxfp8.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from transformers.configuration_utils import CONFIG_NAME as HF_CONFIG_NAME
+
+from ...constants import (
+    ASCEND_MXFP8_QUANT_TYPE,
+    FLOAT_QUANT_TYPE,
+    QUANT_MODEL_DESCRIPTION_NAME,
+)
+
+_QUANT_DESCRIPTION_META_KEYS = frozenset({"quant_method", "group_size", "version", "model_quant_type"})
+
+_TRAINABLE_STATE_DICT_LOADER_ENV = "ROLL_ASCEND_MXFP8_STATE_DICT_LOADER"
+_TRAINABLE_STATE_DICT_LOADER_CANDIDATES = (
+    "mindspeed.core.transformer.custom_layers.transformer_engine.load_modelslim_mxfp8_state_dict",
+    "mindspeed.core.transformer.custom_layers.transformer_engine.load_ascend_mxfp8_state_dict",
+)
+
+
+class AscendMxfp8CheckpointError(ValueError):
+    """Raised when an Ascend ModelSlim MXFP8 checkpoint is malformed or unsupported."""
+
+
+@dataclass(frozen=True)
+class AscendMxfp8Weight:
+    """Logical ModelSlim MXFP8 weight with its sidecar scale tensor."""
+
+    name: str
+    weight: torch.Tensor
+    scale: torch.Tensor
+    scale_name: str
+    quant_type: str
+
+
+def normalize_quant_description(raw_description: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize flat and nested ModelSlim quant descriptions."""
+    if not isinstance(raw_description, Mapping):
+        raise TypeError("Ascend MXFP8 quant description must be a mapping.")
+
+    nested_description = raw_description.get("quant_description")
+    if isinstance(nested_description, Mapping):
+        description = dict(nested_description)
+        for key in _QUANT_DESCRIPTION_META_KEYS:
+            if key in raw_description:
+                description.setdefault(key, raw_description[key])
+        return description
+
+    return dict(raw_description)
+
+
+def is_ascend_mxfp8_quant_description(description: Mapping[str, Any] | None) -> bool:
+    """Return True when a quant description represents Ascend MXFP8."""
+    if not isinstance(description, Mapping):
+        return False
+    if str(description.get("quant_method", "")).lower() != "ascend":
+        return False
+
+    model_quant_type = description.get("model_quant_type")
+    if model_quant_type is None:
+        return any(str(value).upper() == ASCEND_MXFP8_QUANT_TYPE for value in description.values())
+    return "MXFP8" in str(model_quant_type).upper()
+
+
+def detect_ascend_mxfp8_quant_description(model_path: str) -> dict[str, Any] | None:
+    """Return local Ascend MXFP8 metadata when the checkpoint declares it."""
+    description_path = os.path.join(model_path, QUANT_MODEL_DESCRIPTION_NAME)
+    if os.path.isfile(description_path):
+        with open(description_path, "r", encoding="utf-8") as f:
+            description = normalize_quant_description(json.load(f))
+        if not is_ascend_mxfp8_quant_description(description):
+            raise AscendMxfp8CheckpointError(f"{description_path} is not an Ascend MXFP8 quant description.")
+        return description
+
+    config_path = os.path.join(model_path, HF_CONFIG_NAME)
+    if not os.path.isfile(config_path):
+        return None
+    with open(config_path, "r", encoding="utf-8") as f:
+        quantization_config = json.load(f).get("quantization_config")
+    if not quantization_config:
+        return None
+
+    description = normalize_quant_description(quantization_config)
+    if is_ascend_mxfp8_quant_description(description):
+        return description
+    if str(description.get("quant_method", "")).lower() == "ascend":
+        raise AscendMxfp8CheckpointError(f"{config_path}.quantization_config is not a supported Ascend MXFP8 format.")
+    return None
+
+
+def load_ascend_mxfp8_quant_description(model_path: str) -> dict[str, Any]:
+    """Load required Ascend MXFP8 metadata from a local model directory."""
+    description = detect_ascend_mxfp8_quant_description(model_path)
+    if description is not None:
+        return description
+
+    raise AscendMxfp8CheckpointError(
+        f"Ascend MXFP8 checkpoint requires {QUANT_MODEL_DESCRIPTION_NAME} or "
+        f"{HF_CONFIG_NAME}.quantization_config with quant_method='ascend'."
+    )
+
+
+def scale_name_candidates(weight_name: str) -> tuple[str, ...]:
+    """Return supported ModelSlim scale sidecar names for a quantized weight name."""
+    candidates = (f"{weight_name}_scale", f"{weight_name}_scale_inv")
+    if not weight_name.endswith(".weight"):
+        return candidates
+    prefix = weight_name.removesuffix(".weight")
+    return (*candidates, f"{prefix}.scale", f"{prefix}.scale_inv")
+
+
+class AscendMxfp8CheckpointAdapter:
+    """Adapter for pairing ModelSlim MXFP8 weights with scale sidecars."""
+
+    def __init__(self, quant_description: Mapping[str, Any], strict: bool = True):
+        self.quant_description = normalize_quant_description(quant_description)
+        if not is_ascend_mxfp8_quant_description(self.quant_description):
+            raise AscendMxfp8CheckpointError("quant_description is not an Ascend MXFP8 description.")
+        self.strict = strict
+
+    @classmethod
+    def from_model_path(cls, model_path: str, strict: bool = True) -> "AscendMxfp8CheckpointAdapter":
+        """Build an adapter from a local ModelSlim checkpoint directory."""
+        return cls(load_ascend_mxfp8_quant_description(model_path), strict=strict)
+
+    def quant_type_for(self, name: str) -> str | None:
+        """Return the ModelSlim quant type for *name*, if the description declares it."""
+        value = self.quant_description.get(name)
+        return None if value is None else str(value)
+
+    def is_float_weight(self, name: str) -> bool:
+        """Return True when ModelSlim declares *name* as a FLOAT weight."""
+        return str(self.quant_description.get(name, "")).upper() == FLOAT_QUANT_TYPE
+
+    def is_quantized_weight(self, name: str) -> bool:
+        """Return True when ModelSlim declares *name* as an MXFP8 quantized weight."""
+        quant_type = str(self.quant_description.get(name, "")).upper()
+        return quant_type not in ("", FLOAT_QUANT_TYPE) and name not in _QUANT_DESCRIPTION_META_KEYS
+
+    def is_scale_name(self, name: str) -> bool:
+        """Return True when *name* is a known scale sidecar for any described quantized weight."""
+        return any(name in scale_name_candidates(weight_name) for weight_name in self.quantized_weight_names())
+
+    def quantized_weight_names(self) -> list[str]:
+        """Return all weight names declared as quantized in the description."""
+        return [name for name in self.quant_description if self.is_quantized_weight(name)]
+
+    def find_scale_name(self, weight_name: str, state_dict: Mapping[str, torch.Tensor]) -> str | None:
+        """Find the scale sidecar name present in *state_dict* for *weight_name*."""
+        return next((name for name in scale_name_candidates(weight_name) if name in state_dict), None)
+
+    def get_quantized_weight(
+        self,
+        weight_name: str,
+        state_dict: Mapping[str, torch.Tensor],
+    ) -> AscendMxfp8Weight:
+        """Return a paired MXFP8 weight payload from a state dict."""
+        if not self.is_quantized_weight(weight_name):
+            raise AscendMxfp8CheckpointError(f"{weight_name} is not declared as an MXFP8 weight.")
+        if weight_name not in state_dict:
+            raise AscendMxfp8CheckpointError(f"Missing MXFP8 weight tensor: {weight_name}")
+
+        scale_name = self.find_scale_name(weight_name, state_dict)
+        if scale_name is None:
+            raise AscendMxfp8CheckpointError(
+                f"Missing MXFP8 scale tensor for {weight_name}; expected one of {scale_name_candidates(weight_name)}."
+            )
+
+        weight = state_dict[weight_name]
+        scale = state_dict[scale_name]
+        if not torch.is_tensor(weight) or not torch.is_tensor(scale):
+            raise AscendMxfp8CheckpointError(f"MXFP8 weight and scale must be tensors for {weight_name}.")
+        return AscendMxfp8Weight(
+            name=weight_name,
+            weight=weight,
+            scale=scale,
+            scale_name=scale_name,
+            quant_type=str(self.quant_description[weight_name]),
+        )
+
+    def validate_state_dict(
+        self,
+        state_dict: Mapping[str, torch.Tensor],
+        is_needed_name: Callable[[str], bool] | None = None,
+    ) -> None:
+        """Validate that every needed quantized weight has its scale sidecar."""
+        for weight_name in self.quantized_weight_names():
+            if (is_needed_name is None or is_needed_name(weight_name)) and weight_name in state_dict:
+                self.get_quantized_weight(weight_name, state_dict)
+
+
+def _load_symbol(reference: str) -> Callable[..., Any] | None:
+    module_name, _, attr_name = reference.rpartition(".")
+    if not module_name or not attr_name:
+        raise ValueError(f"Invalid symbol reference: {reference!r}")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    value = getattr(module, attr_name, None)
+    return value if callable(value) else None
+
+
+def get_trainable_mxfp8_state_dict_loader() -> Callable[..., dict[str, torch.Tensor]] | None:
+    """Discover the configured or built-in MindSpeed-TE MXFP8 state-dict loader."""
+    user_loader = os.getenv(_TRAINABLE_STATE_DICT_LOADER_ENV)
+    references = (user_loader,) if user_loader else _TRAINABLE_STATE_DICT_LOADER_CANDIDATES
+    for reference in references:
+        loader = _load_symbol(reference)
+        if loader is not None:
+            return loader
+    return None
+
+
+def require_trainable_mxfp8_state_dict_loader() -> Callable[..., dict[str, torch.Tensor]]:
+    """Return a trainable MXFP8 state-dict loader or raise a clear unsupported error."""
+    loader = get_trainable_mxfp8_state_dict_loader()
+    if loader is not None:
+        return loader
+
+    raise RuntimeError(
+        "Ascend ModelSlim MXFP8 fp8_param training requires a MindSpeed-TE loader that can materialize "
+        "trainable FP8 parameters with scale metadata. ROLL detected the quantized checkpoint format, "
+        "but no compatible loader was found. Set ROLL_ASCEND_MXFP8_STATE_DICT_LOADER to a callable loader "
+        "or install a MindSpeed-TE version that exposes one; "
+        "ROLL will not silently dequantize to BF16."
+    )

--- a/mcore_adapter/src/mcore_adapter/models/converter/convert_utils.py
+++ b/mcore_adapter/src/mcore_adapter/models/converter/convert_utils.py
@@ -289,6 +289,9 @@ def get_tensor_size(tensor: "torch.Tensor") -> int:
 
 
 def te_grouped_moe_available():
+    if current_platform.is_npu():
+        return True
+
     try:
         import transformer_engine as te
     except ImportError:

--- a/mcore_adapter/src/mcore_adapter/models/model_config.py
+++ b/mcore_adapter/src/mcore_adapter/models/model_config.py
@@ -17,6 +17,8 @@ from transformers.configuration_utils import CONFIG_NAME as HF_CONFIG_NAME
 
 from ..constants import HUGGINGFACE_AUTOMAP_CACHE, MCA_CONFIG_NAME
 from ..initialize import initialize_megatron
+from ..npu_runtime import apply_megatron_adaptor_feature_defaults
+from ..platforms import current_platform
 from ..training_args import DistributingParallelArguments, TrainingArguments
 from ..utils import get_logger
 from .converter.template import get_template
@@ -272,6 +274,18 @@ class McaModelConfig(TransformerConfig, PretrainedConfig):
         default=0,
         metadata={"help": "Maximum size of sequence. This is used for positional embedding"},
     )
+    micro_batch_size: Optional[int] = field(
+        default=None,
+        metadata={"help": "Micro batch size used by MegatronAdaptor attention mask generation."},
+    )
+    use_flash_attn: Optional[bool] = field(
+        default=None,
+        metadata={"help": "MegatronAdaptor NPU flash attention switch."},
+    )
+    use_flash_attn_npu_batch_invariant: Optional[bool] = field(
+        default=None,
+        metadata={"help": "MegatronAdaptor flash-attn-npu batch-invariant attention switch."},
+    )
     moe_use_shared_expert_gate: bool = field(
         default=False,
         metadata={"help": "Use shared expert use sigmoid gate to control shared outputs."},
@@ -310,8 +324,18 @@ class McaModelConfig(TransformerConfig, PretrainedConfig):
             "set to true when etp_size != tp_size"
         }
     )
-
     def __post_init__(self):
+        fp8_enabled = bool(getattr(self, "fp8", None) or getattr(self, "fp8_format", None))
+        # Keep NPU BF16/FP16 and FP8 model construction on the same TE path.
+        if current_platform.is_npu() and self.transformer_impl in (None, "local"):
+            self.transformer_impl = "transformer_engine"
+        if fp8_enabled and self.transformer_impl != "transformer_engine":
+            raise ValueError("Megatron FP8 training requires transformer_impl='transformer_engine'.")
+        if current_platform.is_npu() and self.transformer_impl == "transformer_engine" and self.use_flash_attn is None:
+            self.use_flash_attn = not bool(self.use_flash_attn_npu_batch_invariant)
+        if current_platform.is_npu() and self.use_flash_attn_npu_batch_invariant:
+            self.use_flash_attn = False
+
         if self.virtual_pipeline_model_parallel_size is None and self.overlap_p2p_comm:
             self.overlap_p2p_comm = False
             logger.warning("Non-interleaved pipeline parallelism does not support overlapping p2p communication!")
@@ -392,6 +416,7 @@ class McaModelConfig(TransformerConfig, PretrainedConfig):
                 pipeline_model_parallel_size=self.pipeline_model_parallel_size,
             )
 
+        apply_megatron_adaptor_feature_defaults(self)
         super().__post_init__()
         pipeline_size = self.pipeline_model_parallel_size
         if self.virtual_pipeline_model_parallel_size is not None:

--- a/mcore_adapter/src/mcore_adapter/models/model_factory.py
+++ b/mcore_adapter/src/mcore_adapter/models/model_factory.py
@@ -6,19 +6,19 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import torch
 from megatron.core import mpu, tensor_parallel
 from megatron.core.models.gpt import GPTModel
-from megatron.core.models.gpt.gpt_layer_specs import (
-    get_gpt_decoder_block_spec,
-    get_gpt_layer_local_spec,
-    get_gpt_layer_with_transformer_engine_spec,
-    get_gpt_mtp_block_spec,
-)
 from megatron.core.transformer.module import MegatronModule
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.utils import is_peft_available
 
 from ..checkpointing import find_dist_ckpt, generate_model_state_dict, load_state_dict_from_checkpoint, save_config_and_state_dict
+from ..npu_runtime import ensure_npu_transformer_engine_symbols
 from ..platforms import current_platform
 from ..utils import get_logger
+from .checkpoint_loaders.ascend_mxfp8 import (
+    AscendMxfp8CheckpointAdapter,
+    detect_ascend_mxfp8_quant_description,
+    require_trainable_mxfp8_state_dict_loader,
+)
 from .converter.convert_utils import MAX_SHARD_SIZE
 from .converter.model_converter import ModelConverter
 from .model_config import McaModelConfig
@@ -42,6 +42,38 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
+
+
+def _replace_with_rmsnorm(submodules, attr_name):
+    if not hasattr(submodules, attr_name):
+        return
+    norm = getattr(submodules, attr_name)
+    norm_name = norm.__name__ if isinstance(norm, type) else norm.__class__.__name__
+    if not norm_name.endswith("RMSNorm"):
+        setattr(submodules, attr_name, RMSNorm)
+
+
+def _apply_npu_rmsnorm_overrides(module_spec, qk_layernorm: bool = False, set_layer_norm: bool = False):
+    if set_layer_norm:
+        module_spec.layer_norm = RMSNorm
+
+    _replace_with_rmsnorm(module_spec.submodules, "input_layernorm")
+    _replace_with_rmsnorm(module_spec.submodules, "pre_mlp_layernorm")
+
+    self_attn = getattr(module_spec.submodules, "self_attention", None)
+    if qk_layernorm and hasattr(self_attn, "submodules"):
+        _replace_with_rmsnorm(self_attn.submodules, "q_layernorm")
+        _replace_with_rmsnorm(self_attn.submodules, "k_layernorm")
+
+
+def _get_gpt_layer_specs():
+    from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_decoder_block_spec,
+        get_gpt_layer_local_spec,
+        get_gpt_mtp_block_spec,
+    )
+
+    return get_gpt_decoder_block_spec, get_gpt_layer_local_spec, get_gpt_mtp_block_spec
 
 
 class VirtualModels:
@@ -262,6 +294,19 @@ class PretrainedModel(MegatronModule, ModuleUtilsMixin):
                     f"{model_name_or_path} is not valid for current training, because not exists hf ckpt "
                     f"and not mca_ckpt_exist: {mca_ckpt_exist} or not dist_config_match: {dist_config_match}"
                 )
+            mxfp8_adapter = None
+            mxfp8_state_dict_loader = None
+            mxfp8_description = detect_ascend_mxfp8_quant_description(model_name_or_path)
+            if mxfp8_description is not None:
+                if not getattr(config, "fp8_param", False):
+                    raise ValueError(
+                        "Detected an Ascend ModelSlim MXFP8 checkpoint; Megatron training requires fp8_param=True."
+                    )
+                mxfp8_adapter = AscendMxfp8CheckpointAdapter(mxfp8_description)
+                mxfp8_state_dict_loader = require_trainable_mxfp8_state_dict_loader()
+            elif getattr(config, "fp8_param", False):
+                raise ValueError("fp8_param=True requires an Ascend ModelSlim MXFP8 checkpoint.")
+
             state_dict = {}
             converter = ModelConverter(config, resized_vocab_size=resized_vocab_size)
             for i in range(len(models)):
@@ -269,7 +314,16 @@ class PretrainedModel(MegatronModule, ModuleUtilsMixin):
                 if len(models) > 1:
                     mpu.set_virtual_pipeline_model_parallel_rank(i)
                     key = f"{key}{i}"
-                state_dict[key] = converter.load_mca_state_dict_from_hf(model_name_or_path, vp_stage=i)
+                if mxfp8_adapter is not None:
+                    state_dict[key] = mxfp8_state_dict_loader(
+                        model_path=model_name_or_path,
+                        config=config,
+                        converter=converter,
+                        vp_stage=i,
+                        adapter=mxfp8_adapter,
+                    )
+                else:
+                    state_dict[key] = converter.load_mca_state_dict_from_hf(model_name_or_path, vp_stage=i)
         missing_keys, unexpected_keys = models.load_state_dict(state_dict, strict=False)
         if missing_keys:
             missing_keys = [key for key in missing_keys if not key.endswith("._extra_state")]
@@ -377,7 +431,10 @@ class McaGPTModel(GPTModel, PretrainedModel):
     def _get_transformer_layer_spec(self, config: Optional["McaModelConfig"] = None):
         config = config or self.config
         use_te = config.transformer_impl == "transformer_engine"
-        if config.num_moe_experts:
+        get_gpt_decoder_block_spec, get_gpt_layer_local_spec, _ = _get_gpt_layer_specs()
+        if config.num_moe_experts or (current_platform.is_npu() and use_te):
+            if current_platform.is_npu() and use_te:
+                ensure_npu_transformer_engine_symbols()
             transformer_block_spec = get_gpt_decoder_block_spec(
                 config, use_transformer_engine=use_te, vp_stage=self.vp_stage
             )
@@ -385,14 +442,34 @@ class McaGPTModel(GPTModel, PretrainedModel):
                 transformer_block_spec.layer_norm = RMSNorm
             for transformer_layer_spec in transformer_block_spec.layer_specs:
                 if not use_te and config.normalization == "RMSNorm":
-                    transformer_layer_spec.submodules.input_layernorm = RMSNorm
-                    transformer_layer_spec.submodules.pre_mlp_layernorm = RMSNorm
+                    if current_platform.is_npu():
+                        _apply_npu_rmsnorm_overrides(transformer_layer_spec)
+                    else:
+                        transformer_layer_spec.submodules.input_layernorm = RMSNorm
+                        transformer_layer_spec.submodules.pre_mlp_layernorm = RMSNorm
             return transformer_block_spec
         if use_te:
+            from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+
             return get_gpt_layer_with_transformer_engine_spec(
                 config.num_moe_experts, config.moe_grouped_gemm, qk_layernorm=config.qk_layernorm
             )
         else:
+            if current_platform.is_npu():
+                module_spec = get_gpt_layer_local_spec(
+                    config.num_moe_experts,
+                    config.moe_grouped_gemm,
+                    qk_layernorm=config.qk_layernorm,
+                    normalization=config.normalization,
+                )
+                if config.normalization == "RMSNorm":
+                    _apply_npu_rmsnorm_overrides(
+                        module_spec,
+                        qk_layernorm=config.qk_layernorm,
+                        set_layer_norm=True,
+                    )
+                return module_spec
+
             module_spec = get_gpt_layer_local_spec(
                 config.num_moe_experts, config.moe_grouped_gemm, qk_layernorm=config.qk_layernorm
             )
@@ -406,6 +483,7 @@ class McaGPTModel(GPTModel, PretrainedModel):
         if config.mtp_num_layers and config.mtp_num_layers > 0:
             transformer_layer_spec = self._get_transformer_layer_spec(config)
             use_te = config.transformer_impl == "transformer_engine"
+            _, _, get_gpt_mtp_block_spec = _get_gpt_layer_specs()
             spec = get_gpt_mtp_block_spec(config, transformer_layer_spec, use_te, vp_stage=vp_stage)
             return spec
         else:

--- a/mcore_adapter/src/mcore_adapter/models/qwen3_vl/transformer_block.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_vl/transformer_block.py
@@ -83,8 +83,10 @@ class Qwen3VLTransformerBlock(TransformerBlock):
             return custom_forward
 
         def checkpoint_handler(forward_func):
-            """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
+            """Use the TE-compatible checkpoint path only when FP8 is enabled."""
             if self.config.fp8:
+                if te_checkpoint is None:
+                    raise RuntimeError("FP8 activation checkpointing requires TransformerEngine support.")
                 return te_checkpoint(
                     forward_func,
                     self.config.distribute_saved_activations,
@@ -96,16 +98,16 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                     context_mask,
                     rotary_pos_emb,
                 )
-            else:
-                return tensor_parallel.checkpoint(
-                    forward_func,
-                    self.config.distribute_saved_activations,
-                    hidden_states,
-                    attention_mask,
-                    context,
-                    context_mask,
-                    rotary_pos_emb,
-                )
+
+            return tensor_parallel.checkpoint(
+                forward_func,
+                self.config.distribute_saved_activations,
+                hidden_states,
+                attention_mask,
+                context,
+                context_mask,
+                rotary_pos_emb,
+            )
 
         if self.config.recompute_method == "uniform":
             # Uniformly divide the total number of Transformer layers and checkpoint

--- a/mcore_adapter/src/mcore_adapter/npu_runtime.py
+++ b/mcore_adapter/src/mcore_adapter/npu_runtime.py
@@ -1,0 +1,155 @@
+import importlib.util
+import sys
+from typing import TYPE_CHECKING, Any
+
+import torch
+from megatron.core import tensor_parallel
+
+from .platforms import current_platform
+from .utils import get_logger
+
+if TYPE_CHECKING:
+    from .training_args import TrainingArguments
+
+
+logger = get_logger(__name__)
+
+# Core NPU Megatron adaptor args that ROLL always overrides when deriving fp8/attention settings.
+_MEGATRON_ADAPTOR_DERIVED_ARGS = frozenset({
+    "transformer_impl",
+    "fp8",
+    "fp8_format",
+    "use_flash_attn",
+    "use_flash_attn_npu_batch_invariant",
+    "te_comparison_with_cpu",
+    "te_comparison_with_bf16",
+})
+
+_NPU_RUNTIME_BOOTSTRAPPED = False
+
+
+def _import_megatron_adaptor():
+    try:
+        return __import__("megatron_adaptor")
+    except ImportError as exc:
+        raise RuntimeError(
+            "MegatronAdaptor core_r0.17.0 is required to initialize Megatron on Ascend NPU."
+        ) from exc
+
+
+def _get_mindspeed_args(**kwargs: Any) -> Any:
+    try:
+        from megatron_adaptor.utils.args_utils import get_mindspeed_args
+    except ImportError as exc:
+        raise RuntimeError(
+            "The installed MegatronAdaptor is incompatible: megatron_adaptor.utils.args_utils is missing."
+        ) from exc
+    return get_mindspeed_args(**kwargs)
+
+
+def _npu_te_checkpoint(function, distribute_saved_activations, get_rng_state_tracker, tp_group, *args):
+    return tensor_parallel.checkpoint(function, distribute_saved_activations, *args)
+
+
+def ensure_npu_transformer_engine_symbols():
+    if not current_platform.is_npu():
+        return
+
+    try:
+        import megatron.core.extensions.transformer_engine as te_ext
+    except ImportError as exc:
+        raise RuntimeError(
+            "TransformerEngineNPU is required for Megatron FP8 on Ascend NPU."
+        ) from exc
+
+    if not hasattr(te_ext, "TENorm"):
+        raise RuntimeError(
+            "TransformerEngineNPU did not provide megatron.core.extensions.transformer_engine.TENorm."
+        )
+    if not hasattr(te_ext, "te_checkpoint"):
+        te_ext.te_checkpoint = _npu_te_checkpoint
+
+
+def bootstrap_npu_runtime():
+    global _NPU_RUNTIME_BOOTSTRAPPED
+
+    if _NPU_RUNTIME_BOOTSTRAPPED or not current_platform.is_npu():
+        return
+
+    import torch_npu  # noqa: F401
+
+    _import_megatron_adaptor()
+    ensure_npu_transformer_engine_symbols()
+
+    import megatron.core.tensor_parallel.random as meg_random
+
+    if not hasattr(meg_random, "_npu_patched"):
+        meg_random.initialize_rng_tracker()
+
+        def patched_set(new_state, device=-1, graph_safe=False):
+            torch.npu.set_rng_state(new_state)
+            return
+
+        def patched_get(device="npu", clone=False, graph_safe=False):
+            return torch.npu.get_rng_state()
+
+        meg_random._set_cuda_rng_state = patched_set
+        meg_random._get_cuda_rng_state = patched_get
+
+        meg_random._npu_patched = True
+
+    if not hasattr(torch.cuda, "_npu_patched"):
+        torch.cuda.current_device = lambda: torch.npu.current_device()
+        torch.cuda._npu_patched = True
+
+    _NPU_RUNTIME_BOOTSTRAPPED = True
+
+
+def apply_megatron_adaptor_feature_defaults(config):
+    if "megatron_adaptor" not in sys.modules:
+        return
+
+    for name, value in vars(_get_mindspeed_args(get_defaults=True)).items():
+        if not hasattr(config, name):
+            setattr(config, name, value)
+
+
+def sync_megatron_adaptor_args(args: "TrainingArguments"):
+    if "megatron_adaptor" not in sys.modules:
+        return
+
+    adaptor_args = _get_mindspeed_args()
+
+    # Auto-discover syncable args: any field present on both ROLL TrainingArguments
+    # and MegatronAdaptor is eligible. The derived-args set ensures fp8/attention rules
+    # are applied even when the source arg was not directly set on args.
+    adaptor_arg_names = set(vars(_get_mindspeed_args(get_defaults=True)))
+    updates = {
+        name: value
+        for name in adaptor_arg_names | _MEGATRON_ADAPTOR_DERIVED_ARGS
+        if (value := getattr(args, name, None)) is not None
+    }
+    fp8 = updates.get("fp8") or updates.get("fp8_format")
+    if fp8:
+        updates.setdefault("fp8", fp8)
+        updates.setdefault("fp8_format", fp8)
+        updates.setdefault("transformer_impl", "transformer_engine")
+    if current_platform.is_npu():
+        if updates.get("use_flash_attn_npu_batch_invariant"):
+            updates["use_flash_attn"] = False
+        elif updates.get("transformer_impl") == "transformer_engine":
+            updates.setdefault("use_flash_attn", True)
+
+    changed_updates = {name: value for name, value in updates.items() if getattr(adaptor_args, name, None) != value}
+    for name, value in changed_updates.items():
+        setattr(adaptor_args, name, value)
+
+    if changed_updates and current_platform.is_npu() and importlib.util.find_spec("megatron.training") is not None:
+        try:
+            megatron_adaptor = sys.modules.get("megatron_adaptor")
+            if hasattr(megatron_adaptor, "repatch"):
+                megatron_adaptor.repatch(updates)
+        except Exception as e:
+            logger.warning("Failed to repatch NPU Megatron adaptor args: %s", e)
+    if updates.get("fp8") or updates.get("transformer_impl") == "transformer_engine":
+        ensure_npu_transformer_engine_symbols()

--- a/mcore_adapter/src/mcore_adapter/trainer/trainer.py
+++ b/mcore_adapter/src/mcore_adapter/trainer/trainer.py
@@ -507,6 +507,7 @@ class McaTrainer(Trainer):
             adam_beta1=self.args.adam_beta1,
             adam_beta2=self.args.adam_beta2,
             adam_eps=self.args.adam_epsilon,
+            fp8_recipe=self.args.fp8_recipe,
             fp16=self.args.fp16,
             bf16=self.args.bf16,
             params_dtype=params_dtype,

--- a/mcore_adapter/src/mcore_adapter/training_args.py
+++ b/mcore_adapter/src/mcore_adapter/training_args.py
@@ -6,6 +6,7 @@ from megatron.core.transformer.pipeline_parallel_layer_layout import PipelinePar
 from transformers import Seq2SeqTrainingArguments as HFSeq2SeqTrainingArguments
 from transformers import TrainingArguments as HFTrainingArguments
 
+from .platforms import current_platform
 from .utils import get_logger
 
 
@@ -226,6 +227,10 @@ class DistributingParallelArguments:
             "global batch, versus the default behavior of assuming all tokens are non-padded."
         },
     )
+    micro_batch_size: Optional[int] = field(
+        default=None,
+        metadata={"help": "MegatronAdaptor alias for per_device_train_batch_size."},
+    )
     transformer_impl: Optional[Literal["local", "transformer_engine"]] = field(
         default=None,
         metadata={
@@ -257,13 +262,29 @@ class DistributingParallelArguments:
     )
     fp8_param: bool = field(
         default=False,
-        # TODO: fp8_param does not work with mxfp8 for now, check TE support later.
-        metadata={"help": "If true, use fp8 weights during training instead of bf16."},
+        metadata={"help": "If true, use trainable fp8 weights during Megatron training instead of bf16."},
     )
     fp8: Optional[str] = field(
         default=None,
         metadata={
             "help": "FP8 format to use. Supported formats: 'e4m3', 'hybrid'. Do not change if unsure",
+        },
+    )
+    fp8_format: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Alias of fp8 used by MegatronAdaptor on Ascend. If omitted, fp8 is used.",
+        },
+    )
+    use_flash_attn: Optional[bool] = field(
+        default=None,
+        metadata={"help": "Forward the MegatronAdaptor NPU flash attention switch."},
+    )
+    use_flash_attn_npu_batch_invariant: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "Use MegatronAdaptor flash-attn-npu batch-invariant attention. "
+            "When enabled on NPU, use_flash_attn is forced to False to avoid duplicate attention patches.",
         },
     )
     additional_configs: Optional[Union[str, dict]] = field(
@@ -284,6 +305,34 @@ class DistributingParallelArguments:
 
         if self.recompute_modules is not None and isinstance(self.recompute_modules, str):
             self.recompute_modules = self.recompute_modules.split(",")
+
+        if self.micro_batch_size is None and getattr(self, "per_device_train_batch_size", None) is not None:
+            self.micro_batch_size = self.per_device_train_batch_size
+
+        if self.fp8 and self.fp8_format and self.fp8 != self.fp8_format:
+            raise ValueError(f"fp8 ({self.fp8}) and fp8_format ({self.fp8_format}) must match when both are set.")
+        if self.fp8_recipe and not (self.fp8 or self.fp8_format):
+            raise ValueError("fp8_recipe requires fp8 or fp8_format to enable Megatron FP8 training.")
+        if self.fp8 and self.fp8_format is None:
+            self.fp8_format = self.fp8
+        if self.fp8_format and self.fp8 is None:
+            self.fp8 = self.fp8_format
+        # Ascend uses TransformerEngine for both reduced-precision and FP8 paths;
+        # the FP8 format and recipe are configured independently by ``self.fp8`` and ``self.fp8_recipe``.
+        if current_platform.is_npu() and self.transformer_impl in (None, "local"):
+            self.transformer_impl = "transformer_engine"
+        if self.fp8 and self.transformer_impl == "local":
+            raise ValueError("Megatron FP8 training requires transformer_impl='transformer_engine'.")
+        if (
+            current_platform.is_npu()
+            and self.transformer_impl == "transformer_engine"
+            and self.use_flash_attn is None
+        ):
+            self.use_flash_attn = not bool(self.use_flash_attn_npu_batch_invariant)
+        if current_platform.is_npu() and self.use_flash_attn_npu_batch_invariant:
+            self.use_flash_attn = False
+        if self.fp8_param:
+            self._validate_fp8_param_training()
 
         logger.info(f"cuda_graph_scope before processing: {self.cuda_graph_scope}, type: {type(self.cuda_graph_scope)}")
         if self.cuda_graph_scope is not None and isinstance(self.cuda_graph_scope, str):
@@ -309,6 +358,18 @@ class DistributingParallelArguments:
             self.virtual_pipeline_model_parallel_size = num_stages // self.pipeline_model_parallel_size
             if self.virtual_pipeline_model_parallel_size == 1:
                 self.virtual_pipeline_model_parallel_size = None
+
+    def _validate_fp8_param_training(self):
+        if not current_platform.is_npu():
+            raise ValueError("fp8_param=True is only supported for Ascend NPU ModelSlim MXFP8 checkpoints.")
+        if self.transformer_impl is None:
+            self.transformer_impl = "transformer_engine"
+        if self.transformer_impl != "transformer_engine":
+            raise ValueError("fp8_param=True requires transformer_impl='transformer_engine'.")
+        if not self.fp8:
+            raise ValueError("fp8_param=True requires fp8 or fp8_format to be set.")
+        if not self.fp8_recipe:
+            raise ValueError("fp8_param=True requires fp8_recipe to be set.")
 
     def get_config_dict(self):
         config_dict = {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}

--- a/roll/distributed/strategy/megatron_strategy.py
+++ b/roll/distributed/strategy/megatron_strategy.py
@@ -1131,6 +1131,16 @@ class MegatronTrainStrategy(MegatronInferStrategy, TrainStrategy):
         if self.enable_router_replay:
             logger.info(f"Router Replay {self.router_replay_mode} mode: REPLAY enabled in MegatronTrainStrategy")
 
+        if (
+            current_platform.is_npu()
+            and self.use_sequence_packing
+            and getattr(self.megatron_train_args, "transformer_impl", None) == "transformer_engine"
+        ):
+            raise ValueError(
+                "Ascend Megatron Transformer Engine training does not support use_sequence_packing yet; "
+                "disable use_sequence_packing to avoid NPU varlen fused attention failures."
+            )
+
     def initialize(self, model_provider):
         self.seq_length = self.worker.pipeline_config.sequence_length
         self.weight_updaters: dict[str, MegatronWeightUpdater] = {}
@@ -1187,6 +1197,7 @@ class MegatronTrainStrategy(MegatronInferStrategy, TrainStrategy):
             adam_beta1=self.megatron_train_args.adam_beta1,
             adam_beta2=self.megatron_train_args.adam_beta2,
             adam_eps=self.megatron_train_args.adam_epsilon,
+            fp8_recipe=self.megatron_train_args.fp8_recipe,
             fp16=self.megatron_train_args.fp16,
             bf16=self.megatron_train_args.bf16,
             params_dtype=params_dtype,
@@ -1345,7 +1356,8 @@ class MegatronTrainStrategy(MegatronInferStrategy, TrainStrategy):
         for mini_metrics in metrics_tensors:
             append_to_dict(metrics, mini_metrics)
 
-        metrics.update({self.worker_config.name + "/" + "grad_norm": grad_norm})
+        grad_norm_value = grad_norm.detach().item() if isinstance(grad_norm, torch.Tensor) else grad_norm
+        metrics.update({self.worker_config.name + "/" + "grad_norm": grad_norm_value})
 
         if self.model.config.num_moe_experts is not None and self.model.config.num_moe_experts > 1:
             reduce_aux_losses_tracker_across_ranks()

--- a/roll/distributed/strategy/strategy.py
+++ b/roll/distributed/strategy/strategy.py
@@ -349,6 +349,9 @@ class InferenceStrategy(ABC):
         gathered_logits = torch.gather(student_logits, dim=-1, index=teacher_indices)
         return gathered_logits
     
+    async def begin_model_update(self, *args, **kwargs):
+        pass
+
     async def process_weights_after_loading(self,*args, **kwargs):
         pass
 

--- a/roll/distributed/strategy/vllm_strategy.py
+++ b/roll/distributed/strategy/vllm_strategy.py
@@ -29,6 +29,7 @@ from roll.utils.functionals import (
 )
 from roll.utils.logging import get_logger
 from roll.utils.offload_states import OffloadStateType, clear_memory
+from roll.utils.vllm_online_quantization import default_load_format_for_quantization
 from roll.platforms import current_platform
 
 
@@ -114,7 +115,9 @@ class VllmStrategy(InferenceStrategy):
                     "disable_custom_all_reduce", True
                 ),  # potentially hangs in tp>1
                 "enable_prefix_caching": vllm_config.get("enable_prefix_caching", True),
-                "load_format": vllm_config.get("load_format", "dummy"),  # use model update passed value
+                "load_format": vllm_config.get(
+                    "load_format", default_load_format_for_quantization(vllm_config)
+                ),  # use model update passed value
                 "max_num_batched_tokens": vllm_config.get("max_num_batched_tokens", 8192), # use default value of LLM class usage context
             }
         )
@@ -373,7 +376,10 @@ class VllmStrategy(InferenceStrategy):
                 await self.model.offload_states(self.sleep_level)
                 self.is_model_in_gpu = False
         clear_memory()
-    
+
+    async def begin_model_update(self, *args, **kwargs):
+        await self.model.begin_model_update()
+
     async def process_weights_after_loading(self,*args, **kwargs):
         await self.model.process_weights_after_loading()
 

--- a/roll/pipeline/base_pipeline.py
+++ b/roll/pipeline/base_pipeline.py
@@ -96,6 +96,7 @@ class BasePipeline:
     def model_update(self, global_step):
         metrics = {}
         for model_update_group in self.model_update_groups:
+            model_update_group.tgt_cluster.begin_model_update()
             metrics.update(model_update_group.model_update(global_step))
             model_update_group.tgt_cluster.process_weights_after_loading()
         return metrics

--- a/roll/pipeline/base_worker.py
+++ b/roll/pipeline/base_worker.py
@@ -457,8 +457,7 @@ class InferWorker(Worker):
 
             # Verify offloaded workers have near-zero GPU memory usage
             if self.rank_info.dp_rank in target_dp_ranks:
-                import torch
-                gpu_memory_gb = torch.cuda.memory_allocated() / 1024**3
+                gpu_memory_gb = current_platform.memory_allocated() / 1024**3
                 if gpu_memory_gb > 1.0:
                     raise RuntimeError(
                         f"GPU memory not properly offloaded for Worker {self.rank} (DP {self.rank_info.dp_rank}): "
@@ -537,7 +536,12 @@ class InferWorker(Worker):
 
     async def abort_requests(self, request_ids):
         await self.strategy.abort_requests(request_ids)
-    
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    async def begin_model_update(self):
+        if getattr(self, "strategy", None) is not None:
+            await self.strategy.begin_model_update()
+
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     async def process_weights_after_loading(self):
         if getattr(self, "strategy", None) is not None:

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -328,12 +328,8 @@ class RLVRPipeline(BasePipeline):
                 is_val=True,
             )
 
-        refs = []
-        refs.extend(self.actor_infer.initialize(pipeline_config=self.pipeline_config, blocking=False))
-        if self.reward_model_cluster:
-            refs.extend(self.reward_model_cluster.initialize(pipeline_config=self.pipeline_config, blocking=False))
-        ray.get(refs)
-
+        # Reference workers offload their model states at the end of initialize().
+        # Initialize them before vLLM reserves its KV cache on colocated devices.
         if self.use_ref_model:
             if clusters_have_disjoint_devices(self.references):
                 ref_init_refs = []
@@ -345,7 +341,13 @@ class RLVRPipeline(BasePipeline):
                     ref_cluster.initialize(pipeline_config=self.pipeline_config, blocking=True)
 
         refs = []
-        for key, cluster in self.rewards.items():
+        refs.extend(self.actor_infer.initialize(pipeline_config=self.pipeline_config, blocking=False))
+        if self.reward_model_cluster:
+            refs.extend(self.reward_model_cluster.initialize(pipeline_config=self.pipeline_config, blocking=False))
+        ray.get(refs)
+
+        refs = []
+        for cluster in self.rewards.values():
             refs.extend(cluster.initialize(pipeline_config=self.pipeline_config, blocking=False))
         ray.get(refs)
 

--- a/roll/platforms/__init__.py
+++ b/roll/platforms/__init__.py
@@ -25,26 +25,31 @@ def _init_platform() -> Platform:
     Returns:
         An instance of a subclass of Platform corresponding to the detected hardware.
     """
+    try:
+        import torch_npu  # noqa: F401
+
+        if hasattr(torch, "npu") and torch.npu.is_available():
+            logger.debug("Detected NPU (torch_npu). Initializing NPU platform.")
+            return NpuPlatform()
+    except ImportError:
+        pass
+
     if torch.cuda.is_available():
         device_name = torch.cuda.get_device_name().upper()
         logger.debug(f"Detected CUDA device: {device_name}")
+
         if "NVIDIA" in device_name:
             logger.debug("Initializing CUDA platform (NVIDIA).")
             return CudaPlatform()
         elif "AMD" in device_name:
             logger.debug("Initializing ROCm platform (AMD).")
             return RocmPlatform()
+
         logger.warning("Unrecognized CUDA device. Falling back to UnknownPlatform.")
         return UnknownPlatform()
-    else:
-        try:
-            import torch_npu  # noqa: F401
 
-            logger.debug("Detected torch_npu. Initializing NPU platform.")
-            return NpuPlatform()
-        except ImportError:
-            logger.debug("No supported accelerator detected. Initializing CPU platform.")
-            return CpuPlatform()
+    logger.debug("No supported accelerator detected. Initializing CPU platform.")
+    return CpuPlatform()
 
 
 # Global singleton representing the current platform in use.

--- a/roll/platforms/npu.py
+++ b/roll/platforms/npu.py
@@ -1,3 +1,4 @@
+import os
 from importlib import import_module
 
 import torch
@@ -45,7 +46,23 @@ class NpuPlatform(Platform):
             "RAY_get_check_signal_interval_milliseconds": "1",
             "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
             "RAY_CGRAPH_get_timeout": '600',
+            # ---- Ascend NPU quantization / inference env vars ----
+            # Disable vLLM-Ascend's automatic quantization detection – ROLL manages
+            # quantization explicitly (MXFP8 online quant, blockwise FP8, etc.).
+            "VLLM_ASCEND_AUTO_DETECT_QUANTIZATION": "0",
+            # Required All2All backend for Ascend NPU in vLLM.
+            "VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv",
+            # Disable NZ format on NPU (required for compatibility).
+            "VLLM_ASCEND_ENABLE_NZ": "0",
+            # Prevent hanging / crash during weight sync between actor and rollout
+            # in disaggregated mode.  See:
+            # https://docs.vllm.ai/en/latest/usage/troubleshooting.html#known-issues
+            "NCCL_CUMEM_ENABLE": "0",
         }
+        # Support different TASK_QUEUE_ENABLE mode for train vs rollout on NPU.
+        task_queue = os.environ.get("VLLM_ASCEND_TASK_QUEUE_ENABLE", None)
+        if task_queue is not None:
+            env_vars["TASK_QUEUE_ENABLE"] = task_queue
         return env_vars
 
     @classmethod

--- a/roll/third_party/megatron/model_update.py
+++ b/roll/third_party/megatron/model_update.py
@@ -28,6 +28,32 @@ if is_peft_available():
 logger = get_logger()
 
 
+def normalize_weight_for_model_update(weight: torch.Tensor) -> torch.Tensor:
+    """Return a regular floating tensor suitable for HF conversion and vLLM loading."""
+    if not torch.is_tensor(weight):
+        dequantize = getattr(weight, "dequantize", None)
+        if callable(dequantize):
+            weight = dequantize()
+            if not torch.is_tensor(weight):
+                raise TypeError(f"Unsupported dequantized weight type for model update: {type(weight)!r}")
+        else:
+            data = getattr(weight, "data", None)
+            if torch.is_tensor(data):
+                dtype = getattr(weight, "dtype", None)
+                weight = data.to(dtype=dtype) if isinstance(dtype, torch.dtype) and data.dtype != dtype else data
+            else:
+                raise TypeError(f"Unsupported weight type for model update: {type(weight)!r}")
+
+    if str(weight.dtype).startswith("torch.float8"):
+        return weight.to(torch.bfloat16)
+    return weight
+
+
+def estimate_weight_size_for_model_update(weight: torch.Tensor, group_size: int = 1) -> int:
+    weight = normalize_weight_for_model_update(weight)
+    return weight.numel() * weight.element_size() * group_size
+
+
 def gather_and_convert_weights(
     weights_info: list[tuple[str, torch.Tensor]],
     model_converter: ModelConverter,
@@ -43,6 +69,7 @@ def gather_and_convert_weights(
         handles, gathered_named_weights = [], []
         group_size = dist.get_world_size(ep_group)
         for mcore_name, weight in weights_info:
+            weight = normalize_weight_for_model_update(weight)
             if group_size == 1:
                 gathered_named_weights.append((mcore_name, [weight]))
                 handles.append(None)
@@ -73,6 +100,7 @@ def gather_and_convert_weights(
     handles, gathered_named_weights = [], []
     group_size = 1 if tp_group is None else dist.get_world_size(tp_group)
     for mcore_name, weight in weights_info:
+        weight = normalize_weight_for_model_update(weight)
         if group_size == 1:
             gathered_named_weights.append((mcore_name, [weight]))
             handles.append(None)
@@ -133,9 +161,9 @@ def _gather_hf_weights(
         group_size = 1 if group is None else dist.get_world_size(group)
         group_size *= 1 if ep_group is None else dist.get_world_size(ep_group)
         for mcore_name, weight in weights_info:
-            weight_size = weight.numel() * weight.element_size() * group_size
+            weight_size = estimate_weight_size_for_model_update(weight, group_size)
             if buffer_size is not None and waiting_weights_size + weight_size > buffer_size:
-                yield gather_and_convert_weights(waiting_weights, model_converter, group, ep_group)
+                yield gather_and_convert_weights(waiting_weights, model_converter, group, ep_group, **kwargs)
                 waiting_weights, waiting_weights_size = [], 0
             waiting_weights.append((mcore_name, weight))
             waiting_weights_size += weight_size
@@ -186,6 +214,7 @@ def gather_weights_meta_cross_pp(models: list[McaGPTModel]):
     model_converter = ModelConverter(model_config, to_hf=True, efficient_mode=True)
     named_weights_meta = []
     for mcore_name, weight in _iter_vp_stage_named_weights(models, model_converter):
+        weight = normalize_weight_for_model_update(weight)
         weight_size = weight.numel() * weight.element_size()
         if model_converter.dist_converter.is_expert_parallel_weight(mcore_name):
             weight_size *= model_config.expert_model_parallel_size * model_config.expert_tensor_parallel_size
@@ -235,7 +264,8 @@ def gather_all_hf_weights(models: list[McaGPTModel], buffer_size: int, weights_m
         models[0].config, pipeline_model_parallel_rank=pp_rank, to_hf=True, efficient_mode=True
     )
     cur_stage_state_dict = {
-        mcore_name: weight for mcore_name, weight in _iter_vp_stage_named_weights(models, model_converter)
+        mcore_name: normalize_weight_for_model_update(weight)
+        for mcore_name, weight in _iter_vp_stage_named_weights(models, model_converter)
     }
 
     def _gather_batch_params(named_weights_with_stage: list[tuple[str, torch.Tensor, int]]):

--- a/roll/third_party/megatron/offload_states_patch.py
+++ b/roll/third_party/megatron/offload_states_patch.py
@@ -219,9 +219,7 @@ def move_ddp_model_params_tensor_to_device(optimizer: DistributedOptimizer,
                 param_range = gbuf_range["param_map"][model_param]["param"]
 
                 # fp16, bf16 params.
-                if model_param.type() in [f'torch.{current_platform.device_type}.HalfTensor', f'torch.{current_platform.device_type}.BFloat16Tensor',
-                                          'torch.BFloat16Tensor', 'torch.HalfTensor'] or \
-                   (current_platform.device_type == "cuda" and model_param.type() in ['torch.HalfTensor', 'torch.BFloat16Tensor']):
+                if model_param.dtype in (torch.float16, torch.bfloat16):
                     # Clone model -> main.
                     shard_model_param = model_param.detach().view(-1)[param_range.start: param_range.end]
 
@@ -233,7 +231,7 @@ def move_ddp_model_params_tensor_to_device(optimizer: DistributedOptimizer,
                         len(shard_float16_params_this_group)] = shard_model_param
                     shard_float16_params_this_group.append(shard_model_param)
                 # fp32 params.
-                elif model_param.type() in [f'torch.{current_platform.device_type}.FloatTensor', 'torch.FloatTensor']:
+                elif model_param.dtype == torch.float32:
                     shard_model_param = model_param.view(-1)[param_range.start: param_range.end]
                     optimizer.shard_fp32_groups[group_index][
                         len(shard_fp32_params_this_group)].data = shard_model_param.data

--- a/roll/third_party/megatron/optimizer.py
+++ b/roll/third_party/megatron/optimizer.py
@@ -69,9 +69,15 @@ def get_megatron_optimizer(
     optimizers = []
     model_chunk_offset = 0
     kwargs = {}
-    if "config_overrides" in inspect.signature(_get_param_groups_and_buffers).parameters:
+    _param_groups_sig = inspect.signature(_get_param_groups_and_buffers).parameters
+    if "config_overrides" in _param_groups_sig:
         # config_overrides is required in mcore-core>=0.16
-        kwargs = {"config_overrides": None}
+        kwargs["config_overrides"] = None
+    if "no_weight_decay_cond" in _param_groups_sig:
+        # no_weight_decay_cond, scale_lr_cond, lr_mult are required in newer mcore versions
+        kwargs["no_weight_decay_cond"] = no_weight_decay_cond
+        kwargs["scale_lr_cond"] = scale_lr_cond
+        kwargs["lr_mult"] = lr_mult
     for dense_model_chunks, overlap_param_gather_with_optimizer_step in zip(
         all_dense_model_chunks, overlap_param_gather_with_optimizer_step_flags
     ):

--- a/roll/third_party/megatron/tensor_parallel.py
+++ b/roll/third_party/megatron/tensor_parallel.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state as mpu
@@ -6,11 +8,25 @@ from roll.utils.logging import get_logger
 
 try:
     from .fused_entropy import entropy_fwd, entropy_bwd
+
     FUSED_KERNEL_AVAILABLE = True
 except ImportError:
     FUSED_KERNEL_AVAILABLE = False
 
 logger = get_logger()
+
+
+@torch.compile(dynamic=True)
+def _mul_reduce(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return (a * b).sum(dim=-1, keepdim=True)
+
+
+@lru_cache(maxsize=None)
+def _warn_fused_kernel_disabled(tp_world_size: int, fused_kernel_available: bool) -> None:
+    logger.warning(
+        "Disabling fused entropy kernel because "
+        f"{tp_world_size=} and {fused_kernel_available=}."
+    )
 
 
 class _VocabParallelEntropy(torch.autograd.Function):
@@ -19,16 +35,13 @@ class _VocabParallelEntropy(torch.autograd.Function):
         ctx,
         vocab_parallel_logits: torch.Tensor,
         used_fp32: bool = True,
-        use_fused_kernel: bool = True
+        use_fused_kernel: bool = True,
     ) -> torch.Tensor:
+        tp_world_size = mpu.get_tensor_model_parallel_world_size()
 
-        # Only use fused kernel when TP=1 and use_fused_kernel is True
-        if use_fused_kernel:
-            # Get tensor parallel world size
-            tp_world_size = mpu.get_tensor_model_parallel_world_size()
-            if tp_world_size != 1 or not FUSED_KERNEL_AVAILABLE:
-                logger.warning(f"Disable use_fused_kernel because {tp_world_size=} and {FUSED_KERNEL_AVAILABLE=}.")
-                use_fused_kernel = False
+        if use_fused_kernel and (tp_world_size != 1 or not FUSED_KERNEL_AVAILABLE):
+            _warn_fused_kernel_disabled(tp_world_size, FUSED_KERNEL_AVAILABLE)
+            use_fused_kernel = False
 
         if use_fused_kernel:
             vocab_parallel_logits_2d = vocab_parallel_logits.view(-1, vocab_parallel_logits.shape[-1])
@@ -38,42 +51,38 @@ class _VocabParallelEntropy(torch.autograd.Function):
 
             # Convert output back to original shape
             if vocab_parallel_logits.dim() == 3:
-                batch_size, seq_len, vocab_size = vocab_parallel_logits.shape
-                entropy = entropy.view(batch_size, seq_len)
+                entropy = entropy.view(vocab_parallel_logits.shape[:-1])
 
             # Save for backward: vocab_parallel_logits and intermediate results
             ctx.save_for_backward(vocab_parallel_logits, x_max, x_sum_exp, x_sum_softmax_times)
             ctx.use_fused_kernel = True
-            # ctx.original_shape = original_shape
             return entropy
-        else:
-            # Original implementation for TP>1 or when fused kernel is not available
-            @torch.compile(dynamic=True)
-            def mul_reduce(a, b):
-                return (a * b).sum(dim=-1, keepdim=True)
 
-            ctx.input_dtype = vocab_parallel_logits.dtype
+        ctx.input_dtype = vocab_parallel_logits.dtype
 
-            if used_fp32:
-                vocab_parallel_logits = vocab_parallel_logits.float()
+        if used_fp32:
+            vocab_parallel_logits = vocab_parallel_logits.float()
 
-            logits_max = vocab_parallel_logits.max(dim=-1, keepdim=True).values
+        logits_max = vocab_parallel_logits.max(dim=-1, keepdim=True).values
+        if tp_world_size > 1:
             dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=mpu.get_tensor_model_parallel_group())
-            normalized_vocab_parallel_logits = vocab_parallel_logits - logits_max
-            normalized_exp_logits = normalized_vocab_parallel_logits.exp_()
-            normalized_sum_exp_logits = normalized_exp_logits.sum(dim=-1, keepdim=True)
+        normalized_vocab_parallel_logits = vocab_parallel_logits - logits_max
+        normalized_exp_logits = normalized_vocab_parallel_logits.exp_()
+        normalized_sum_exp_logits = normalized_exp_logits.sum(dim=-1, keepdim=True)
+        if tp_world_size > 1:
             dist.all_reduce(normalized_sum_exp_logits, group=mpu.get_tensor_model_parallel_group())
-            softmax_logits = normalized_exp_logits.div_(normalized_sum_exp_logits)
-            sum_softmax_times_logits = mul_reduce(softmax_logits, vocab_parallel_logits)
+        softmax_logits = normalized_exp_logits.div_(normalized_sum_exp_logits)
+        sum_softmax_times_logits = _mul_reduce(softmax_logits, vocab_parallel_logits)
+        if tp_world_size > 1:
             dist.all_reduce(sum_softmax_times_logits, group=mpu.get_tensor_model_parallel_group())
-            entropy = logits_max + normalized_sum_exp_logits.log() - sum_softmax_times_logits
-            ctx.save_for_backward(vocab_parallel_logits, softmax_logits, sum_softmax_times_logits)
-            ctx.use_fused_kernel = False
+        entropy = logits_max + normalized_sum_exp_logits.log() - sum_softmax_times_logits
+        ctx.save_for_backward(vocab_parallel_logits, softmax_logits, sum_softmax_times_logits)
+        ctx.use_fused_kernel = False
 
-            return entropy.squeeze(dim=-1)
+        return entropy.squeeze(dim=-1)
 
     @staticmethod
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, None, None]:
         if ctx.use_fused_kernel:
             # Use fused kernel backward with recomputation (only for TP=1)
             vocab_parallel_logits, x_max, x_sum_exp, x_sum_softmax_times = ctx.saved_tensors
@@ -89,24 +98,24 @@ class _VocabParallelEntropy(torch.autograd.Function):
                 x_sum_softmax_times
             )
 
-            grad_input = grad_input_2d.view_as(vocab_parallel_logits)
+            return grad_input_2d.view_as(vocab_parallel_logits), None, None
 
-            return grad_input, None, None
-        else:
-            # Original implementation for TP>1
-            vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
-            # reuse softmax_logits as grad
-            vocab_parallel_logits.sub_(sum_softmax_times_logits)
-            softmax_logits.mul_(vocab_parallel_logits)
-            softmax_logits.mul_(grad_output.unsqueeze(dim=-1))
-            # recover vocab_parallel_logits
-            vocab_parallel_logits.add_(sum_softmax_times_logits)
-            softmax_logits.mul_(-1)
-            softmax_logits = softmax_logits.to(ctx.input_dtype)
+        vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
+        # Reuse saved tensors to avoid allocating an additional gradient buffer.
+        vocab_parallel_logits.sub_(sum_softmax_times_logits)
+        softmax_logits.mul_(vocab_parallel_logits)
+        softmax_logits.mul_(grad_output.unsqueeze(dim=-1))
+        vocab_parallel_logits.add_(sum_softmax_times_logits)
+        softmax_logits.mul_(-1)
 
-            return softmax_logits, None, None
+        return softmax_logits.to(ctx.input_dtype), None, None
 
-def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor, used_fp32=True, use_fused_kernel: bool = True) -> torch.Tensor:
+
+def vocab_parallel_entropy(
+    vocab_parallel_logits: torch.Tensor,
+    used_fp32: bool = True,
+    use_fused_kernel: bool = True,
+) -> torch.Tensor:
     """
     ref: https://github.com/volcengine/verl/blob/78532923368aeb058f62201489546d013df47710/verl/utils/megatron/tensor_parallel.py#L109
     Compute entropy when the logits are sharded in tp ranks

--- a/roll/third_party/vllm/__init__.py
+++ b/roll/third_party/vllm/__init__.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List
 
 import dataclasses
@@ -15,6 +16,7 @@ from roll.platforms import current_platform
 import roll.third_party.vllm.fp8 as fp8
 from roll.utils.import_utils import safe_import_class
 from roll.utils.logging import get_logger
+from roll.utils.vllm_online_quantization import apply_online_quantization_config
 
 
 logger = get_logger()
@@ -47,7 +49,7 @@ logger.info(f"Using vllm version {vllm.__version__}")
 
 async def create_async_llm(resource_placement_groups: List[Dict], **kwargs):
     kwargs["enable_sleep_mode"] = True
-    if "attention_config" not in kwargs and "attention_config" in {
+    if not current_platform.is_npu() and "attention_config" not in kwargs and "attention_config" in {
         f.name: f for f in dataclasses.fields(AsyncEngineArgs)
     }:  # vllm<=0.12.0 not has attention_config in AsyncEngineArgs
         kwargs["attention_config"] = {"backend": "FLASH_ATTN"}
@@ -79,11 +81,19 @@ async def create_async_llm(resource_placement_groups: List[Dict], **kwargs):
         os.environ["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
         # os.environ["VLLM_ATTENTION_BACKEND"] = "FLASH_ATTN" # for 280 rollout pipeline 乱码
 
+    online_quant_config = apply_online_quantization_config(kwargs)
+    if online_quant_config is not None:
+        logger.info(
+            "Enabled ROLL online quantization, %d quant config entries",
+            len(online_quant_config),
+        )
+
     engine_args = AsyncEngineArgs(**kwargs)
     # VLLM_USE_V1 may be modified inside create_engine_config
     vllm_config = engine_args.create_engine_config(UsageContext.ENGINE_CONTEXT)
 
     fp8.update_quant_config(config=kwargs, vllm_config=vllm_config)
+    fp8.update_mxfp8_quant_config(vllm_config)  # Ascend NPU MXFP8 detection & setup
 
     # change parallel_config.placement_group for CustomRayDistributedExecutor
     parallel_config = vllm_config.parallel_config

--- a/roll/third_party/vllm/async_llm.py
+++ b/roll/third_party/vllm/async_llm.py
@@ -24,5 +24,8 @@ class CustomAsyncLLM(AsyncLLM):
     async def add_lora(self, *args, **kwargs):
         await self.engine_core.collective_rpc_async(method="custom_add_lora", args=args, kwargs=kwargs)
 
+    async def begin_model_update(self):
+        await self.engine_core.collective_rpc_async(method="begin_model_update")
+
     async def process_weights_after_loading(self):
         await self.engine_core.collective_rpc_async(method="process_weights_after_loading")

--- a/roll/third_party/vllm/async_llm_engine.py
+++ b/roll/third_party/vllm/async_llm_engine.py
@@ -23,5 +23,8 @@ class CustomAsyncLLMEngine(AsyncLLMEngine):
     async def add_lora(self, *args, **kwargs):
         self.engine.model_executor.collective_rpc(method="custom_add_lora", args=args, kwargs=kwargs)
 
+    async def begin_model_update(self):
+        self.engine.model_executor.collective_rpc(method="begin_model_update")
+
     async def process_weights_after_loading(self):
         self.engine.model_executor.collective_rpc(method="process_weights_after_loading")

--- a/roll/third_party/vllm/fp8.py
+++ b/roll/third_party/vllm/fp8.py
@@ -1,6 +1,6 @@
-from typing import List
-from functools import partial
 import weakref
+from functools import partial
+from typing import List
 
 import torch
 from torch.nn import Module
@@ -11,15 +11,17 @@ from vllm.model_executor.layers.quantization.fp8 import (
 from vllm.model_executor.parameter import (BlockQuantScaleParameter,
                                            ModelWeightParameter,
                                            PerTensorScaleParameter)
-from vllm.platforms import current_platform
+from vllm.platforms import current_platform as vllm_platform
 from vllm.model_executor.utils import set_weight_attrs
 from vllm._custom_ops import scaled_fp8_quant as per_tensor_fp8_quant
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import requantize_with_max_scale
 
-from roll.utils.fp8 import per_block_fp8_quant
+from roll.platforms import current_platform as roll_platform
+from roll.utils.fp8 import is_mxfp8_ascend, per_block_fp8_quant, per_block_fp8_quant_ascend
 from roll.utils.logging import get_logger
 
 logger = get_logger()
+
 
 def update_quant_config(config, vllm_config):
     # Use hf_overrides arguments with weight_block_size
@@ -37,12 +39,22 @@ def update_quant_config(config, vllm_config):
     #           weight_block_size: [128, 128]
     if "hf_overrides" not in config or "quantization_config" not in config["hf_overrides"]:
         return
+    if not isinstance(vllm_config.quant_config, Fp8Config):
+        return
     assert config["hf_overrides"]["quantization_config"]["quant_method"] == "fp8"
     assert isinstance(vllm_config.quant_config, Fp8Config)
     assert vllm_config.quant_config.activation_scheme == "dynamic"
     assert vllm_config.quant_config.is_checkpoint_fp8_serialized
     vllm_config.quant_config.skip_process_weights_after_loading = True
     logger.info(f"Using custom vLLM quantization, block size {vllm_config.quant_config.weight_block_size}")
+
+
+def update_mxfp8_quant_config(vllm_config):
+    """Mark the fixed vLLM-Ascend quant config as serialized MXFP8."""
+    if not is_mxfp8_ascend(vllm_config.quant_config):
+        return
+    vllm_config.quant_config.is_checkpoint_fp8_serialized = True
+
 
 def _fp8_linear_weight_loader(layer: weakref.ReferenceType, original_weight_loader, param: torch.Tensor, loaded_weight: torch.Tensor, *args, **kwargs) -> None:
     layer = layer()
@@ -118,8 +130,8 @@ def _fp8_linear_create_weights(
     assert not self.use_marlin # not implement yet, because lack weight loader for chanelwise weight_scale
 
     # TODO support ROCM
-    assert not current_platform.is_rocm()
-    assert not current_platform.is_fp8_fnuz()
+    assert not vllm_platform.is_rocm()
+    assert not vllm_platform.is_fp8_fnuz()
 
     # store essential config in layer for custom weight loader
     layer.weight_block_size = self.quant_config.weight_block_size
@@ -144,14 +156,16 @@ def _fp8_linear_create_weights(
     layer.register_parameter("input_scale", None)
 
 _original_fp8_linear_create_weights = Fp8LinearMethod.create_weights
-Fp8LinearMethod.create_weights = _fp8_linear_create_weights
+if not roll_platform.is_npu():
+    Fp8LinearMethod.create_weights = _fp8_linear_create_weights
 
 def _fp8_linear_process_weights_after_loading(self, layer: Module) -> None:
     if not getattr(self.quant_config, "skip_process_weights_after_loading", False):
         _original_fp8_linear_process_weights_after_loading(self, layer)
 
 _original_fp8_linear_process_weights_after_loading = Fp8LinearMethod.process_weights_after_loading
-Fp8LinearMethod.process_weights_after_loading = _fp8_linear_process_weights_after_loading
+if not roll_platform.is_npu():
+    Fp8LinearMethod.process_weights_after_loading = _fp8_linear_process_weights_after_loading
 
 def _fp8_moe_w13_weight_loader(layer: weakref.ReferenceType, original_weight_loader, param: torch.Tensor, loaded_weight: torch.Tensor, *args, **kwargs) -> None:
     layer = layer()
@@ -183,7 +197,7 @@ def _fp8_moe_create_weights(self, layer: Module, num_experts: int, hidden_size: 
                    intermediate_size_per_partition: int,
                    params_dtype: torch.dtype, **extra_weight_attrs):
     _original_fp8_moe_create_weights(self, layer, num_experts, hidden_size, intermediate_size_per_partition,
-                                     params_dtype, **extra_weight_attrs) 
+                                     params_dtype, **extra_weight_attrs)
     if not getattr(self.quant_config, "skip_process_weights_after_loading", False):
         return
 
@@ -193,9 +207,9 @@ def _fp8_moe_create_weights(self, layer: Module, num_experts: int, hidden_size: 
 
     # TODO support ROCM
     # https://github.com/vllm-project/vllm/blob/v0.8.4/vllm/model_executor/layers/quantization/fp8.py#L655
-    assert not current_platform.is_rocm()
-    assert not current_platform.is_fp8_fnuz()
-    assert current_platform.fp8_dtype() == torch.float8_e4m3fn
+    assert not vllm_platform.is_rocm()
+    assert not vllm_platform.is_fp8_fnuz()
+    assert vllm_platform.fp8_dtype() == torch.float8_e4m3fn
 
     self.rocm_aiter_moe_enabled = False # set in original process_weights_after_loading
 
@@ -239,7 +253,8 @@ def _fp8_moe_create_weights(self, layer: Module, num_experts: int, hidden_size: 
     assert type(layer.w2_weight_scale_inv) == Parameter
 
 _original_fp8_moe_create_weights = Fp8MoEMethod.create_weights
-Fp8MoEMethod.create_weights = _fp8_moe_create_weights
+if not roll_platform.is_npu():
+    Fp8MoEMethod.create_weights = _fp8_moe_create_weights
 
 def _fp8_moe_process_weights_after_loading(self, layer: Module) -> None:
     if not getattr(self.quant_config, "skip_process_weights_after_loading", False):
@@ -264,4 +279,50 @@ def _fp8_moe_process_weights_after_loading(self, layer: Module) -> None:
             assert w2_scale.data_ptr() == getattr(layer, f"w2_{self.weight_scale_name}").data_ptr()
 
 _original_fp8_moe_process_weights_after_loading = Fp8MoEMethod.process_weights_after_loading
-Fp8MoEMethod.process_weights_after_loading = _fp8_moe_process_weights_after_loading
+if not roll_platform.is_npu():
+    Fp8MoEMethod.process_weights_after_loading = _fp8_moe_process_weights_after_loading
+
+
+def _ascend_mxfp8_weight_loader(
+    layer: weakref.ReferenceType,
+    weight_loader,
+    scale_loader,
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *args,
+    **kwargs,
+) -> None:
+    layer = layer()
+    if loaded_weight.dtype == torch.float8_e4m3fn:
+        weight_loader(param, loaded_weight.to(param.device), *args, **kwargs)
+        return
+
+    qweight, scale = per_block_fp8_quant_ascend(
+        loaded_weight.to(param.device),
+        dtype=getattr(layer, "params_dtype", torch.bfloat16),
+    )
+    weight_loader(param, qweight, *args, **kwargs)
+    scale_loader(layer.weight_scale, scale, *args, **kwargs)
+
+
+try:
+    from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+except ImportError:
+    AscendLinearMethod = None
+
+
+if AscendLinearMethod is not None:
+    _original_ascend_create_weights = AscendLinearMethod.create_weights
+
+    def _ascend_create_weights(self, layer, *args, **kwargs):
+        _original_ascend_create_weights(self, layer, *args, **kwargs)
+        if self.quant_method.__class__.__name__ != "AscendW8A8MXFP8DynamicLinearMethod":
+            return
+        layer.weight.weight_loader = partial(
+            _ascend_mxfp8_weight_loader,
+            weakref.ref(layer),
+            layer.weight.weight_loader,
+            layer.weight_scale.weight_loader,
+        )
+
+    AscendLinearMethod.create_weights = _ascend_create_weights

--- a/roll/third_party/vllm/npu/__init__.py
+++ b/roll/third_party/vllm/npu/__init__.py
@@ -1,0 +1,1 @@
+"""NPU-specific vLLM integration helpers."""

--- a/roll/third_party/vllm/npu/ascend_moe.py
+++ b/roll/third_party/vllm/npu/ascend_moe.py
@@ -1,0 +1,299 @@
+"""Qwen3.5 MoE weight loading fixes for vLLM-Ascend.
+
+The Ascend unquantized MoE implementation transposes its weights during
+``process_weights_after_loading``.  RL weight updates happen after the first
+load, so the loader must write the incoming checkpoint shards into the
+already-transposed, TP/EP-local tensors and the post-processing transpose must
+not be applied a second time.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any, Mapping
+
+import torch
+
+
+def _is_w13(name: str) -> bool:
+    return "w13_weight" in name
+
+
+def _is_w2(name: str) -> bool:
+    return "w2_weight" in name
+
+
+def _find_param(params_dict: Mapping[str, Any], name: str) -> Any:
+    param = params_dict.get(name)
+    if param is not None:
+        return param
+    for candidate_name, candidate in params_dict.items():
+        if candidate_name.endswith(name) or name.endswith(candidate_name):
+            return candidate
+    return None
+
+
+def _get_tp_context() -> tuple[int, int]:
+    """Support both vLLM's old and new tensor-parallel helper names."""
+
+    try:
+        from vllm.distributed import get_tp_rank, get_tp_world_size
+
+        return get_tp_rank(), get_tp_world_size()
+    except ImportError:
+        try:
+            from vllm.distributed import (
+                get_tensor_model_parallel_rank,
+                get_tensor_model_parallel_world_size,
+            )
+
+            return get_tensor_model_parallel_rank(), get_tensor_model_parallel_world_size()
+        except ImportError:
+            # This is only used by lightweight unit tests without vLLM's
+            # distributed runtime; production NPU workers always provide one.
+            return 0, 1
+
+
+def _map_global_expert_to_local(experts: Any, global_expert_id: int) -> int:
+    """Return the local expert index, or ``-1`` for an EP-nonlocal expert."""
+
+    for method_name in (
+        "_map_global_expert_id_to_local_expert_id",
+        "map_global_expert_id_to_local_expert_id",
+    ):
+        mapper = getattr(experts, method_name, None)
+        if mapper is not None:
+            return int(mapper(global_expert_id))
+
+    manager = getattr(experts, "expert_map_manager", None)
+    if manager is not None:
+        for method_name in (
+            "map_global_to_local",
+            "map_global_expert_id_to_local_expert_id",
+        ):
+            mapper = getattr(manager, method_name, None)
+            if mapper is not None:
+                return int(mapper(global_expert_id))
+
+    expert_map = getattr(experts, "expert_map", None)
+    if expert_map is not None:
+        try:
+            return int(expert_map[global_expert_id])
+        except (IndexError, KeyError, TypeError):
+            return -1
+
+    # Models without expert parallelism use global IDs directly.
+    return global_expert_id
+
+
+def _copy_transposed_expert_shard(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    shard_id: str,
+    local_expert_id: int,
+    tp_rank: int,
+    tp_world_size: int,
+) -> bool:
+    """Copy one checkpoint expert shard into a transposed local parameter.
+
+    ``loaded_weight`` contains one fused expert shard per global expert.  The
+    source layout is ``[experts, I, H]`` for ``w1``/``w3`` and ``[experts, H,
+    I]`` for ``w2``.  Ascend stores the corresponding local parameter as
+    ``[local_experts, H, I_tp]`` (fused ``w13``) or ``[local_experts, I_tp,
+    H]`` (``w2``).
+    """
+
+    if local_expert_id < 0:
+        return False
+    if loaded_weight.ndim != 3:
+        raise ValueError(
+            f"Qwen3.5 fused expert weight must be rank-3, got shape {tuple(loaded_weight.shape)}"
+        )
+    if local_expert_id >= param.shape[0]:
+        raise ValueError(
+            "Qwen3.5 EP expert mapping produced local expert index "
+            f"{local_expert_id}, but parameter has {param.shape[0]} local experts"
+        )
+    if tp_world_size <= 0:
+        raise ValueError(f"Invalid TP world size {tp_world_size}")
+    source_width = loaded_weight.shape[-1]
+    if _is_w13(shard_id):
+        source_width = loaded_weight.shape[-2]
+    if source_width % tp_world_size:
+        raise ValueError(
+            "Qwen3.5 expert weight last dimension "
+            f"{source_width} is not divisible by TP world size {tp_world_size}"
+        )
+
+    shard_width = source_width // tp_world_size
+    start = tp_rank * shard_width
+    end = start + shard_width
+    if tp_rank < 0 or end > source_width:
+        raise ValueError(f"Invalid TP rank {tp_rank} for world size {tp_world_size}")
+
+    if loaded_weight.shape[0] != 1:
+        raise ValueError(
+            "_copy_transposed_expert_shard expects one global expert at a time, "
+            f"got shape {tuple(loaded_weight.shape)}"
+        )
+    with torch.no_grad():
+        if _is_w2(shard_id):
+            # [H, I_tp] -> [I_tp, H]
+            source = loaded_weight[0, ..., start:end]
+            target = source.transpose(-1, -2).contiguous()
+            expected = tuple(param.shape[1:])
+            if tuple(target.shape) != expected:
+                raise ValueError(
+                    f"Qwen3.5 w2 shard shape {tuple(target.shape)} does not match local "
+                    f"parameter shape {expected}"
+                )
+            param.data[local_expert_id].copy_(target)
+        elif _is_w13(shard_id):
+            # [I, H] -> [H, I_tp], then place into the w1/w3 half.
+            source = loaded_weight[0].transpose(-1, -2).contiguous()
+            target = source[..., start:end]
+            half_width = param.shape[-1] // 2
+            if target.shape[-2] != param.shape[-2] or target.shape[-1] != half_width:
+                raise ValueError(
+                    f"Qwen3.5 {shard_id} shard shape {tuple(target.shape)} does not match "
+                    f"local fused parameter shape {tuple(param.shape)}"
+                )
+            offset = 0 if shard_id == "w1" else half_width
+            param.data[local_expert_id, :, offset : offset + half_width].copy_(target)
+        else:
+            raise ValueError(f"Unsupported Qwen3.5 fused expert shard ID: {shard_id!r}")
+    return True
+
+
+def _patch_transposed_fused_expert_loader() -> None:
+    """Patch Qwen3.5's fused loader once, keeping the original fallback."""
+
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+
+    if getattr(Qwen3_5Model, "_roll_transposed_expert_loader_patched", False):
+        return
+
+    original = Qwen3_5Model.load_fused_expert_weights
+
+    def load_fused_expert_weights(
+        self,
+        name,
+        params_dict,
+        loaded_weight,
+        shard_id,
+        num_experts,
+        *args,
+        **kwargs,
+    ):
+        param = _find_param(params_dict, name)
+        experts = getattr(param, "_roll_expert_module", None) if param is not None else None
+        if param is None or experts is None or not getattr(param, "_roll_ascend_transposed", False):
+            return original(self, name, params_dict, loaded_weight, shard_id, num_experts, *args, **kwargs)
+
+        if loaded_weight.shape[0] != num_experts:
+            raise ValueError(
+                f"Qwen3.5 fused expert weight has {loaded_weight.shape[0]} experts, "
+                f"expected {num_experts}"
+            )
+
+        tp_rank, tp_world_size = _get_tp_context()
+
+        copied = False
+        for global_expert_id in range(num_experts):
+            local_expert_id = _map_global_expert_to_local(experts, global_expert_id)
+            copied = (
+                _copy_transposed_expert_shard(
+                    param,
+                    loaded_weight[global_expert_id : global_expert_id + 1],
+                    shard_id,
+                    local_expert_id,
+                    tp_rank,
+                    tp_world_size,
+                )
+                or copied
+            )
+        if copied:
+            param._roll_already_transposed = True
+        return True
+
+    Qwen3_5Model.load_fused_expert_weights = load_fused_expert_weights
+    Qwen3_5Model._roll_transposed_expert_loader_patched = True
+
+
+def _iter_text_layers(model: Any):
+    language_model = getattr(model, "language_model", None)
+    root = language_model if language_model is not None else model
+    nested_model = getattr(root, "model", root)
+    layers = getattr(nested_model, "layers", None)
+    if layers is None:
+        layers = getattr(getattr(nested_model, "language_model", None), "layers", None)
+    return layers or ()
+
+
+def _is_ascend_unquantized(experts: Any) -> bool:
+    try:
+        from vllm_ascend.quantization.unquantized_fused_moe import AscendUnquantizedFusedMoEMethod
+    except (ImportError, AttributeError):
+        try:
+            from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+        except (ImportError, AttributeError):
+            return False
+
+    quant_method = getattr(experts, "quant_method", None)
+    quant_method = getattr(quant_method, "quant_method", quant_method)
+    return isinstance(quant_method, AscendUnquantizedFusedMoEMethod)
+
+
+def _patch_process_weights_after_loading(model: Any) -> None:
+    """Skip only the duplicate transpose on patched unquantized MoE modules."""
+
+    for module in model.modules():
+        if not _is_ascend_unquantized(module):
+            continue
+        quant_method = getattr(module, "quant_method", None)
+        quant_method = getattr(quant_method, "quant_method", quant_method)
+        process = getattr(quant_method, "process_weights_after_loading", None)
+        if process is None or getattr(quant_method, "_roll_process_patched", False):
+            continue
+
+        original = process
+
+        def process_weights_after_loading(self, layer, *args, _original=original, **kwargs):
+            params = dict(layer.named_parameters())
+            w13 = next((p for n, p in params.items() if _is_w13(n)), None)
+            w2 = next((p for n, p in params.items() if _is_w2(n)), None)
+            if (
+                w13 is not None
+                and w2 is not None
+                and getattr(w13, "_roll_already_transposed", False)
+                and getattr(w2, "_roll_already_transposed", False)
+            ):
+                return
+            return _original(layer, *args, **kwargs)
+
+        quant_method.process_weights_after_loading = MethodType(process_weights_after_loading, quant_method)
+        quant_method._roll_process_patched = True
+
+
+def patch_ascend_moe_weight_loader(model: Any) -> None:
+    """Install the Qwen3.5 NPU loader only for Ascend unquantized MoE layers."""
+
+    _patch_transposed_fused_expert_loader()
+    patched = False
+    for layer in _iter_text_layers(model):
+        mlp = getattr(layer, "mlp", None)
+        experts = getattr(mlp, "experts", None)
+        if experts is None or not _is_ascend_unquantized(experts):
+            continue
+        patched = True
+        for name, param in mlp.named_parameters():
+            if getattr(param, "roll_skip_patch_moe", False):
+                continue
+            if _is_w13(name) or _is_w2(name):
+                param.is_transposed = True
+                param._roll_ascend_transposed = True
+                param._roll_expert_module = experts
+                param.weight_loader = experts.weight_loader
+
+    if patched:
+        _patch_process_weights_after_loading(model)

--- a/roll/third_party/vllm/vllm_utils.py
+++ b/roll/third_party/vllm/vllm_utils.py
@@ -3,6 +3,7 @@ from typing import List
 from packaging.version import Version
 
 import vllm
+from roll.platforms import current_platform
 from vllm.lora.request import LoRARequest
 from vllm.lora.utils import get_adapter_absolute_path
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
@@ -39,9 +40,33 @@ try:
 except ImportError:
     pass
 
+try:
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5MoeForCausalLM
+
+    SUPPORTED_MOE_MODELS.append(Qwen3_5MoeForCausalLM)
+except ImportError:
+    pass
+
+try:
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5MoeForConditionalGeneration
+
+    SUPPORTED_MOE_MODELS.append(Qwen3_5MoeForConditionalGeneration)
+except ImportError:
+    pass
+
 
 def patch_vllm_moe_model_weight_loader(model):
     if not isinstance(model, tuple(SUPPORTED_MOE_MODELS)):
+        return
+
+    if current_platform.is_npu():
+        from roll.third_party.vllm.npu.ascend_moe import patch_ascend_moe_weight_loader
+
+        patch_ascend_moe_weight_loader(model)
+        return
+
+    # vLLM 0.8.5 and newer already handle the fused MoE loader correctly.
+    if Version(vllm.__version__) >= Version("0.8.5"):
         return
 
     for layer in model.model.layers:

--- a/roll/third_party/vllm/worker.py
+++ b/roll/third_party/vllm/worker.py
@@ -1,29 +1,40 @@
 import gc
 import hashlib
 import json
-import time
 from collections import OrderedDict
 from typing import Iterable, Tuple
 
 import torch
-import vllm
-from packaging.version import Version
 
 from roll.platforms import current_platform
-from roll.third_party.vllm.vllm_utils import TensorLoRARequest, patch_vllm_lora_manager
+from roll.third_party.vllm.vllm_utils import (
+    TensorLoRARequest,
+    patch_vllm_lora_manager,
+    patch_vllm_moe_model_weight_loader,
+)
 from roll.utils.collective import collective
 from roll.utils.cuda_ipc_utils import MultiprocessingSerializer
+from roll.utils.fp8 import is_mxfp8_ascend
 from roll.utils.logging import get_logger
-from roll.utils.offload_states import clear_memory
 from roll.utils.send_recv_utils import monkey_patch_torch_reductions, named_tensors_from_bucket
 
-# Apply GDN attention patch at module import time.
-# This ensures the patch is applied in EngineCore subprocesses as well,
-# since this module is imported when worker_extension_cls is loaded.
-from roll.third_party.vllm.gdn_patcher import patch_gdn_attention
-patch_gdn_attention()
-
 logger = get_logger()
+
+
+def _restore_mxfp8_weights(model: torch.nn.Module) -> None:
+    """Restore vLLM-Ascend MXFP8 weights to checkpoint layout before refit."""
+    restored = 0
+    for module in model.modules():
+        if not getattr(module, "_mxfp8_transformed", False):
+            continue
+        quant_method = getattr(module, "quant_method", None)
+        quant_method = getattr(quant_method, "quant_method", quant_method)
+        restore = getattr(quant_method, "restore_weights_for_rl_loading", None)
+        if restore is not None:
+            restore(module)
+            restored += 1
+    if restored:
+        logger.info("MXFP8: restored %d modules before weight update", restored)
 
 
 class TensorLoraManager:
@@ -35,90 +46,82 @@ class TensorLoraManager:
         self.lora_params[name] = weight
 
     def build_request(self, peft_config: dict) -> TensorLoRARequest:
-        """
-        Generate a unique LoRA ID based on the PEFT configuration rather than
-        using a timestamp to assert all tp-ranks get the same LoRA ID.
-        """
+        """Build the same LoRA ID on every TP rank from the PEFT config."""
         self.add_lora_count += 1
         peft_config["add_lora_count"] = self.add_lora_count
         peft_config_str = json.dumps(peft_config, sort_keys=True)
-        hash_obj = hashlib.sha256(peft_config_str.encode("utf-8"))
-        hex_dig = hash_obj.hexdigest()
-        lora_int_id = int(hex_dig, 16) % 0x7FFFFFFF
-
-        lora_request = TensorLoRARequest(
-            lora_name=f"{lora_int_id}",
+        lora_int_id = int(hashlib.sha256(peft_config_str.encode()).hexdigest(), 16) % 0x7FFFFFFF
+        request = TensorLoRARequest(
+            lora_name=str(lora_int_id),
             lora_int_id=lora_int_id,
             lora_path="dummy_lora_path",
             peft_config=peft_config,
             lora_tensors=self.lora_params,
         )
-        del self.lora_params
         self.lora_params = OrderedDict()
-        return lora_request
+        return request
 
 
 class WorkerBase:
     def custom_init_worker(self, *args, **kwargs):
-        self.weight_loaded: bool = True
-        self.kv_cache_loaded: bool = True
-        self.buffers = None
-        self.buffer_cache = None
+        self.weight_loaded = True
+        self.kv_cache_loaded = True
         self.tensor_lora_manager = TensorLoraManager()
+        self._is_mxfp8_model = is_mxfp8_ascend(self.vllm_config.quant_config)
+        self._model_update_in_progress = False
 
     def reload_model(self):
         if not self.weight_loaded:
             self.wake_up(["weights"])
             self.weight_loaded = True
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        # before updating the parameters, we need to reinitialize the previously released model
+    def begin_model_update(self):
+        if not self._is_mxfp8_model:
+            return
+        if self._model_update_in_progress:
+            raise RuntimeError("MXFP8 model update is already in progress")
         self.reload_model()
-        if vllm.__version__ < "0.8.5":
-            from roll.third_party.vllm.vllm_utils import patch_vllm_moe_model_weight_loader
+        _restore_mxfp8_weights(self.model_runner.model)
+        self._model_update_in_progress = True
 
-            patch_vllm_moe_model_weight_loader(self.model_runner.model)
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        self.reload_model()
+        auto_finalize = self._is_mxfp8_model and not self._model_update_in_progress
+        if auto_finalize:
+            self.begin_model_update()
 
-        # Convert to list for multiple iterations (draft model also needs the same weights)
         weights_list = list(weights)
-
-        # Update target model (skips mtp.* prefixed weights via skip_prefixes)
+        patch_vllm_moe_model_weight_loader(self.model_runner.model)
         self.model_runner.model.load_weights(weights=weights_list)
 
-        # Update drafter model (MTP/EAGLE) if exists
-        # Drafter models like EagleProposer and DraftModelProposer have a model attribute
-        # that needs to be updated separately with the same weights
-        if hasattr(self.model_runner, "drafter") and hasattr(self.model_runner.drafter, "model"):
+        drafter = getattr(self.model_runner, "drafter", None)
+        if hasattr(drafter, "model"):
             logger.info("Updating drafter (MTP/EAGLE) model weights...")
-            self.model_runner.drafter.model.load_weights(weights=weights_list)
+            patch_vllm_moe_model_weight_loader(drafter.model)
+            drafter.model.load_weights(weights=weights_list)
+
+        if auto_finalize:
+            self.process_weights_after_loading()
 
     def load_states(self):
         self.reload_model()
         if not self.kv_cache_loaded:
             self.wake_up(["kv_cache"])
             self.kv_cache_loaded = True
-        if vllm.__version__ < "0.8.5" and self.buffers is not None:
-            # https://github.com/vllm-project/vllm/issues/16564
-            model = self.model_runner.model
-            for name, buffer in model.named_buffers():
-                if name in self.buffers:
-                    buffer.data.copy_(self.buffers[name].data)
-            self.buffers = None
 
     def offload_states(self, level):
-        assert (self.weight_loaded and self.kv_cache_loaded) or (not self.weight_loaded and not self.kv_cache_loaded)
+        assert (self.weight_loaded and self.kv_cache_loaded) or (
+            not self.weight_loaded and not self.kv_cache_loaded
+        )
         if not self.weight_loaded:
             return
-        if vllm.__version__ < "0.8.5" and level == 2:
-            # https://github.com/vllm-project/vllm/issues/16564
-            model = self.model_runner.model
-            self.buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
         self.sleep(level)
         self.weight_loaded = False
         self.kv_cache_loaded = False
         if hasattr(self, "recv_manager"):
             self.recv_manager.clear()
-        clear_memory()
+        gc.collect()
+        current_platform.empty_cache()
 
     def setup_collective_group(self, master_address, master_port, rank_offset, world_size, group_name, backend):
         group_rank = self.rank + rank_offset
@@ -159,28 +162,21 @@ class WorkerBase:
             for name, weight in named_params:
                 self.tensor_lora_manager.add_weight(name, weight)
             return
-        self.load_weights([(name, weight) for name, weight in named_params])
+        self.load_weights(named_params)
 
     def process_weights_after_loading(self):
-        if Version(vllm.__version__) >= Version("0.11.1"):
-            from vllm.model_executor.model_loader.utils import process_weights_after_loading
-            from vllm.utils.torch_utils import set_default_torch_dtype
-            device_config = self.device_config
-            load_config = self.vllm_config.load_config
-            load_device = (device_config.device if load_config.device is None else load_config.device)
-            target_device = torch.device(load_device)
-            with set_default_torch_dtype(self.model_config.dtype):
-                process_weights_after_loading(self.model_runner.model,self.model_config,target_device)
-        if (Version("0.11.0") == Version(vllm.__version__) or
-                Version("0.11.1rc1") == Version(vllm.__version__) or
-                Version("0.11.1rc2.dev0+gc3a722fcb.d20251021") == Version(vllm.__version__)):
-            from vllm.model_executor.model_loader.utils import process_weights_after_loading,set_default_torch_dtype
-            device_config = self.device_config
-            load_config = self.vllm_config.load_config
-            load_device = (device_config.device if load_config.device is None else load_config.device)
-            target_device = torch.device(load_device)
-            with set_default_torch_dtype(self.model_config.dtype):
-                process_weights_after_loading(self.model_runner.model,self.model_config,target_device)
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader.utils import process_weights_after_loading
+        from vllm.utils.torch_utils import set_default_torch_dtype
+
+        load_device = self.vllm_config.load_config.device or self.device_config.device
+        with set_default_torch_dtype(self.model_config.dtype), set_current_vllm_config(self.vllm_config):
+            process_weights_after_loading(
+                self.model_runner.model,
+                self.model_config,
+                torch.device(load_device),
+            )
+        self._model_update_in_progress = False
 
 
 class WorkerV1(WorkerBase):

--- a/roll/utils/fp8.py
+++ b/roll/utils/fp8.py
@@ -1,6 +1,53 @@
-from typing import List
+from collections.abc import Mapping
+from typing import Any, List
 
 import torch
+
+
+def _get_quant_config_value(config: Any, key: str, default: Any = None) -> Any:
+    return config.get(key, default) if isinstance(config, Mapping) else getattr(config, key, default)
+
+
+def _is_ascend_config(config: Any) -> bool:
+    return str(_get_quant_config_value(config, "quant_method", "")).lower() == "ascend"
+
+
+def is_mxfp8_ascend(quant_config: Any) -> bool:
+    """Return whether this is an Ascend MXFP8 configuration."""
+    if quant_config is None:
+        return False
+
+    return (
+        quant_config.__class__.__name__ == "AscendModelSlimConfig"
+        or _is_ascend_config(quant_config)
+        or any(
+            _is_ascend_config(_get_quant_config_value(quant_config, key))
+            for key in ("quant_description", "quantization_config")
+        )
+    )
+
+
+def per_block_fp8_quant_ascend(
+    param_value: torch.Tensor,
+    dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a tensor using Ascend MXFP8 dynamic quantization."""
+    try:
+        import torch_npu
+    except ImportError as exc:
+        raise RuntimeError("torch_npu is required for Ascend MXFP8 quantization.") from exc
+
+    npu = getattr(torch, "npu", None)
+    if npu is None or not npu.is_available():
+        raise RuntimeError("No available Ascend NPU was detected.")
+
+    weight, scale = torch_npu.npu_dynamic_mx_quant(
+        param_value.to(dtype or torch.bfloat16),
+        axis=-1,
+        dst_type=torch_npu.float8_e4m3fn,
+    )
+    return weight, scale.flatten(-2, -1)
+
 
 # Block quant operator
 #

--- a/roll/utils/vllm_online_quantization.py
+++ b/roll/utils/vllm_online_quantization.py
@@ -1,0 +1,118 @@
+from collections.abc import Mapping
+from typing import Any
+
+
+ASCEND_MXFP8_ONLINE_QUANTIZATION = "ascend_mxfp8"
+ASCEND_MXFP8_QUANT_TYPE = "W8A8_MXFP8"
+FLOAT_QUANT_TYPE = "FLOAT"
+
+_ATTENTION_PROJECTIONS = ("q_proj", "k_proj", "v_proj", "o_proj", "qkv_proj")
+_DENSE_MLP_PROJECTIONS = ("gate_proj", "up_proj", "down_proj", "gate_up_proj")
+
+
+def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping.")
+    return value
+
+
+def default_load_format_for_quantization(kwargs: Mapping[str, Any]) -> str:
+    return "auto" if kwargs.get("quantization") == "ascend" and not kwargs.get("online_quantization") else "dummy"
+
+
+def _set_projections(description: dict[str, Any], prefix: str, names: tuple[str, ...], value: str) -> None:
+    description.update({f"{prefix}.{name}.weight": value for name in names})
+
+
+def _is_moe_model(config: Any, options: Mapping[str, Any]) -> bool:
+    if "is_moe" in options:
+        return bool(options["is_moe"])
+    model_type = str(getattr(config, "model_type", "")).lower()
+    expert_fields = ("num_experts", "num_local_experts", "n_routed_experts", "moe_intermediate_size")
+    return "moe" in model_type or any(getattr(config, name, 0) not in (None, 0, 1) for name in expert_fields)
+
+
+def _is_moe_layer(config: Any, layer_idx: int) -> bool:
+    if layer_idx < int(getattr(config, "first_k_dense_replace", 0) or 0):
+        return False
+    frequency = getattr(config, "moe_layer_freq", 1)
+    if isinstance(frequency, (list, tuple)):
+        return bool(frequency[layer_idx])
+    return layer_idx % int(frequency or 1) == 0
+
+
+def build_ascend_mxfp8_quant_description(
+    hf_config: Any,
+    options: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the ModelSlim description needed by vLLM-Ascend for Qwen rollout."""
+    options = options or {}
+    config = getattr(hf_config, "text_config", hf_config)
+    num_layers = options.get("num_hidden_layers", getattr(config, "num_hidden_layers", None))
+    if num_layers is None:
+        raise ValueError("online_quantization=ascend_mxfp8 requires num_hidden_layers in the HF config.")
+
+    description: dict[str, Any] = {
+        "quant_method": "ascend",
+        "group_size": int(options.get("group_size", 32)),
+        "version": "1.0.0",
+        "model_quant_type": ASCEND_MXFP8_QUANT_TYPE,
+        "model.embed_tokens.weight": FLOAT_QUANT_TYPE,
+        "lm_head.weight": FLOAT_QUANT_TYPE,
+    }
+    is_moe = _is_moe_model(config, options)
+    for layer_idx in range(int(num_layers)):
+        layer = f"model.layers.{layer_idx}"
+        _set_projections(description, f"{layer}.self_attn", _ATTENTION_PROJECTIONS, ASCEND_MXFP8_QUANT_TYPE)
+        mlp = f"{layer}.mlp"
+        if is_moe and _is_moe_layer(config, layer_idx):
+            _set_projections(description, mlp, ("gate", "router"), FLOAT_QUANT_TYPE)
+            _set_projections(
+                description, f"{mlp}.experts.0", _DENSE_MLP_PROJECTIONS[:3], ASCEND_MXFP8_QUANT_TYPE
+            )
+            description[f"{mlp}.experts.weight"] = ASCEND_MXFP8_QUANT_TYPE
+            _set_projections(description, f"{mlp}.shared_expert", _DENSE_MLP_PROJECTIONS, ASCEND_MXFP8_QUANT_TYPE)
+        else:
+            _set_projections(description, mlp, _DENSE_MLP_PROJECTIONS, ASCEND_MXFP8_QUANT_TYPE)
+
+    extra_description = options.get("extra_quant_description", {})
+    description.update(_require_mapping(extra_description, "online_quantization_config.extra_quant_description"))
+    return description
+
+
+def apply_online_quantization_config(kwargs: dict[str, Any], hf_config: Any | None = None) -> dict[str, Any] | None:
+    online_quantization = kwargs.pop("online_quantization", None)
+    options = kwargs.pop("online_quantization_config", None) or {}
+    if not online_quantization:
+        return None
+    if online_quantization != ASCEND_MXFP8_ONLINE_QUANTIZATION:
+        raise ValueError(f"Unsupported online_quantization={online_quantization!r}.")
+    options = _require_mapping(options, "online_quantization_config")
+    if kwargs.get("quantization") not in (None, "ascend"):
+        raise ValueError(
+            "online_quantization=ascend_mxfp8 requires strategy_config.quantization "
+            "to be omitted or set to 'ascend'."
+        )
+
+    kwargs.update(quantization="ascend", load_format="dummy")
+    if hf_config is None:
+        from transformers import AutoConfig
+
+        model = kwargs.get("model")
+        if not model:
+            raise ValueError("online_quantization=ascend_mxfp8 requires the vLLM model path.")
+        hf_config = AutoConfig.from_pretrained(
+            model,
+            trust_remote_code=bool(kwargs.get("trust_remote_code", True)),
+            revision=kwargs.get("revision"),
+        )
+
+    hf_overrides = dict(_require_mapping(kwargs.get("hf_overrides") or {}, "hf_overrides"))
+    description = {
+        **build_ascend_mxfp8_quant_description(hf_config, options),
+        **_require_mapping(hf_overrides.get("quantization_config", {}), "hf_overrides.quantization_config"),
+    }
+    if description.get("quant_method") != "ascend":
+        raise ValueError("hf_overrides.quantization_config.quant_method must be 'ascend'.")
+    kwargs["hf_overrides"] = {**hf_overrides, "quantization_config": description}
+    return description

--- a/tests/third_party/megatron/test_tensor_parallel_entropy.py
+++ b/tests/third_party/megatron/test_tensor_parallel_entropy.py
@@ -1,0 +1,48 @@
+import torch
+
+from roll.third_party.megatron import tensor_parallel
+
+
+def _eager_mul_reduce(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return (a * b).sum(dim=-1, keepdim=True)
+
+
+def test_tp1_entropy_skips_distributed_collectives(monkeypatch):
+    monkeypatch.setattr(tensor_parallel.mpu, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(tensor_parallel, "_mul_reduce", _eager_mul_reduce)
+
+    def unexpected_all_reduce(*args, **kwargs):
+        raise AssertionError("TP=1 entropy must not call all_reduce")
+
+    monkeypatch.setattr(tensor_parallel.dist, "all_reduce", unexpected_all_reduce)
+
+    logits = torch.tensor([[1.0, 2.0, 3.0]])
+    actual = tensor_parallel.vocab_parallel_entropy(logits, use_fused_kernel=False)
+    probabilities = torch.softmax(logits, dim=-1)
+    expected = -(probabilities * torch.log_softmax(logits, dim=-1)).sum(dim=-1)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_tp2_entropy_uses_three_distributed_collectives(monkeypatch):
+    monkeypatch.setattr(tensor_parallel.mpu, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(tensor_parallel.mpu, "get_tensor_model_parallel_group", lambda: "tp-group")
+    monkeypatch.setattr(tensor_parallel, "_mul_reduce", _eager_mul_reduce)
+
+    calls = []
+
+    def record_all_reduce(tensor, op=None, group=None):
+        calls.append((op, group))
+
+    monkeypatch.setattr(tensor_parallel.dist, "all_reduce", record_all_reduce)
+
+    tensor_parallel.vocab_parallel_entropy(
+        torch.tensor([[1.0, 2.0]]),
+        use_fused_kernel=False,
+    )
+
+    assert calls == [
+        (torch.distributed.ReduceOp.MAX, "tp-group"),
+        (None, "tp-group"),
+        (None, "tp-group"),
+    ]

--- a/tests/third_party/vllm/test_ascend_moe.py
+++ b/tests/third_party/vllm/test_ascend_moe.py
@@ -1,0 +1,69 @@
+import pytest
+
+
+pytest.importorskip("vllm")
+torch = pytest.importorskip("torch")
+
+from roll.third_party.vllm.npu.ascend_moe import (
+    _copy_transposed_expert_shard,
+    _map_global_expert_to_local,
+)
+
+
+class _Experts:
+    expert_map = [-1, 0, -1, 1]
+
+
+def test_copy_transposed_w13_tp_shard_and_ep_local_expert():
+    # Two local experts, TP=2, hidden=4, intermediate=6.
+    param = torch.zeros((2, 4, 6), dtype=torch.float32)
+    loaded = torch.arange(6 * 4, dtype=torch.float32).reshape(1, 6, 4)
+
+    copied = _copy_transposed_expert_shard(
+        param,
+        loaded,
+        "w1",
+        local_expert_id=1,
+        tp_rank=1,
+        tp_world_size=2,
+    )
+
+    assert copied
+    expected = loaded[0].transpose(-1, -2)[:, 3:]
+    assert torch.equal(param[1, :, :3], expected)
+    assert torch.count_nonzero(param[0]) == 0
+
+
+def test_copy_transposed_w2_skips_ep_nonlocal_expert():
+    param = torch.zeros((2, 3, 4), dtype=torch.float32)
+    loaded = torch.arange(4 * 6, dtype=torch.float32).reshape(1, 4, 6)
+
+    copied = _copy_transposed_expert_shard(
+        param,
+        loaded,
+        "w2",
+        local_expert_id=-1,
+        tp_rank=0,
+        tp_world_size=2,
+    )
+
+    assert not copied
+    assert torch.count_nonzero(param) == 0
+
+    copied = _copy_transposed_expert_shard(
+        param,
+        loaded,
+        "w2",
+        local_expert_id=0,
+        tp_rank=1,
+        tp_world_size=2,
+    )
+    assert copied
+    assert torch.equal(param[0], loaded[0, :, 3:].transpose(-1, -2))
+
+
+def test_ep_global_to_local_mapping():
+    experts = _Experts()
+    assert _map_global_expert_to_local(experts, 1) == 0
+    assert _map_global_expert_to_local(experts, 3) == 1
+    assert _map_global_expert_to_local(experts, 0) == -1

--- a/tests/utils/test_ascend_mxfp8_checkpoint.py
+++ b/tests/utils/test_ascend_mxfp8_checkpoint.py
@@ -1,0 +1,141 @@
+import json
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+import mcore_adapter.models.checkpoint_loaders.ascend_mxfp8 as ascend_mxfp8
+from mcore_adapter.models.checkpoint_loaders.ascend_mxfp8 import (
+    ASCEND_MXFP8_QUANT_TYPE,
+    FLOAT_QUANT_TYPE,
+    AscendMxfp8CheckpointAdapter,
+    AscendMxfp8CheckpointError,
+    detect_ascend_mxfp8_quant_description,
+    load_ascend_mxfp8_quant_description,
+    require_trainable_mxfp8_state_dict_loader,
+    scale_name_candidates,
+)
+
+
+def _quant_description():
+    return {
+        "quant_method": "ascend",
+        "group_size": 32,
+        "model_quant_type": ASCEND_MXFP8_QUANT_TYPE,
+        "model.layers.0.self_attn.q_proj.weight": ASCEND_MXFP8_QUANT_TYPE,
+        "model.embed_tokens.weight": FLOAT_QUANT_TYPE,
+    }
+
+
+def test_load_quant_description_from_modelslim_file(tmp_path):
+    path = tmp_path / "quant_model_description.json"
+    path.write_text(json.dumps(_quant_description()), encoding="utf-8")
+
+    description = load_ascend_mxfp8_quant_description(str(tmp_path))
+
+    assert description["quant_method"] == "ascend"
+    assert description["model.layers.0.self_attn.q_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+
+
+def test_load_quant_description_from_hf_config(tmp_path):
+    config = {
+        "model_type": "qwen3",
+        "quantization_config": {
+            "quant_method": "ascend",
+            "quant_description": {
+                "model_quant_type": ASCEND_MXFP8_QUANT_TYPE,
+                "model.layers.0.mlp.down_proj.weight": ASCEND_MXFP8_QUANT_TYPE,
+            },
+        },
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+    description = load_ascend_mxfp8_quant_description(str(tmp_path))
+
+    assert description["quant_method"] == "ascend"
+    assert description["model.layers.0.mlp.down_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+
+
+def test_detect_quant_description_returns_none_for_standard_hf_checkpoint(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3"}), encoding="utf-8")
+
+    assert detect_ascend_mxfp8_quant_description(str(tmp_path)) is None
+
+
+def test_detect_quant_description_rejects_unsupported_ascend_format(tmp_path):
+    config = {"quantization_config": {"quant_method": "ascend", "model_quant_type": "W8A8"}}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(AscendMxfp8CheckpointError, match="not a supported Ascend MXFP8 format"):
+        detect_ascend_mxfp8_quant_description(str(tmp_path))
+
+
+def test_checkpoint_adapter_pairs_quantized_weight_with_scale():
+    adapter = AscendMxfp8CheckpointAdapter(_quant_description())
+    weight_name = "model.layers.0.self_attn.q_proj.weight"
+    state_dict = {
+        weight_name: torch.ones(4, 4, dtype=torch.uint8),
+        f"{weight_name}_scale": torch.ones(4, dtype=torch.float32),
+    }
+
+    payload = adapter.get_quantized_weight(weight_name, state_dict)
+
+    assert payload.name == weight_name
+    assert payload.scale_name == f"{weight_name}_scale"
+    assert torch.equal(payload.weight, state_dict[weight_name])
+    assert torch.equal(payload.scale, state_dict[f"{weight_name}_scale"])
+
+
+def test_checkpoint_adapter_keeps_float_weights_out_of_quantized_names():
+    adapter = AscendMxfp8CheckpointAdapter(_quant_description())
+
+    assert adapter.is_float_weight("model.embed_tokens.weight")
+    assert "model.embed_tokens.weight" not in adapter.quantized_weight_names()
+
+
+def test_checkpoint_adapter_rejects_missing_scale():
+    adapter = AscendMxfp8CheckpointAdapter(_quant_description())
+    weight_name = "model.layers.0.self_attn.q_proj.weight"
+
+    with pytest.raises(AscendMxfp8CheckpointError, match="Missing MXFP8 scale tensor"):
+        adapter.get_quantized_weight(weight_name, {weight_name: torch.ones(4, 4, dtype=torch.uint8)})
+
+
+def test_scale_name_candidates_include_modelslim_variants():
+    candidates = scale_name_candidates("model.layers.0.mlp.down_proj.weight")
+
+    assert "model.layers.0.mlp.down_proj.weight_scale" in candidates
+    assert "model.layers.0.mlp.down_proj.weight_scale_inv" in candidates
+    assert "model.layers.0.mlp.down_proj.scale" in candidates
+
+
+def test_trainable_state_dict_loader_missing_is_explicit(monkeypatch):
+    monkeypatch.delenv("ROLL_ASCEND_MXFP8_STATE_DICT_LOADER", raising=False)
+    monkeypatch.setattr(ascend_mxfp8, "_TRAINABLE_STATE_DICT_LOADER_CANDIDATES", ())
+
+    with pytest.raises(RuntimeError, match="will not silently dequantize to BF16"):
+        require_trainable_mxfp8_state_dict_loader()
+
+
+def test_trainable_state_dict_loader_candidates_stay_minimal():
+    candidates = ascend_mxfp8._TRAINABLE_STATE_DICT_LOADER_CANDIDATES
+
+    assert candidates == (
+        "mindspeed.core.transformer.custom_layers.transformer_engine.load_modelslim_mxfp8_state_dict",
+        "mindspeed.core.transformer.custom_layers.transformer_engine.load_ascend_mxfp8_state_dict",
+    )
+
+
+def test_trainable_state_dict_loader_env_override(monkeypatch):
+    module = ModuleType("fake_mxfp8_loader")
+
+    def load_state_dict(**kwargs):
+        return {}
+
+    module.load_state_dict = load_state_dict
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setenv("ROLL_ASCEND_MXFP8_STATE_DICT_LOADER", f"{module.__name__}.load_state_dict")
+    monkeypatch.setattr(ascend_mxfp8, "_TRAINABLE_STATE_DICT_LOADER_CANDIDATES", ())
+
+    assert ascend_mxfp8.get_trainable_mxfp8_state_dict_loader() is load_state_dict

--- a/tests/utils/test_fp8_utils.py
+++ b/tests/utils/test_fp8_utils.py
@@ -1,0 +1,37 @@
+from collections.abc import Mapping
+
+from roll.utils.fp8 import is_mxfp8_ascend
+
+
+class QuantDescriptionMapping(Mapping):
+    def __init__(self, values):
+        self._values = values
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self):
+        return len(self._values)
+
+
+class ConfigLike:
+    def __init__(self, quant_description):
+        self.quant_description = quant_description
+
+
+def test_is_mxfp8_ascend_detects_top_level_mapping():
+    assert is_mxfp8_ascend({"quant_method": "ascend"})
+
+
+def test_is_mxfp8_ascend_detects_mapping_quant_description():
+    quant_description = QuantDescriptionMapping({"quant_method": "ascend"})
+
+    assert is_mxfp8_ascend(ConfigLike(quant_description))
+
+
+def test_is_mxfp8_ascend_rejects_non_ascend_configs():
+    assert not is_mxfp8_ascend({"quant_method": "fp8"})
+    assert not is_mxfp8_ascend(ConfigLike({"quant_method": "fp8"}))

--- a/tests/utils/test_megatron_fp8_config.py
+++ b/tests/utils/test_megatron_fp8_config.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from mcore_adapter import TrainingArguments
+from roll.third_party.megatron.model_update import estimate_weight_size_for_model_update, normalize_weight_for_model_update
+
+
+def test_training_args_syncs_fp8_aliases():
+    args = TrainingArguments(output_dir="tmp", fp8="e4m3", fp8_recipe="mxfp8")
+
+    assert args.fp8 == "e4m3"
+    assert args.fp8_format == "e4m3"
+
+
+def test_training_args_rejects_mismatched_fp8_aliases():
+    with pytest.raises(ValueError, match="must match"):
+        TrainingArguments(output_dir="tmp", fp8="e4m3", fp8_format="hybrid", fp8_recipe="mxfp8")
+
+
+def test_training_args_rejects_fp8_param_without_npu():
+    with pytest.raises(ValueError, match="only supported for Ascend NPU"):
+        TrainingArguments(output_dir="tmp", fp8="e4m3", fp8_recipe="mxfp8", fp8_param=True)
+
+
+def test_training_args_preserves_user_fp8_param_config(monkeypatch):
+    monkeypatch.setattr("mcore_adapter.training_args.current_platform.is_npu", lambda: True)
+
+    args = TrainingArguments(
+        output_dir="tmp",
+        fp8_format="hybrid",
+        fp8_recipe="delayed",
+        fp8_param=True,
+    )
+
+    assert args.fp8 == "hybrid"
+    assert args.fp8_format == "hybrid"
+    assert args.fp8_recipe == "delayed"
+    assert args.transformer_impl == "transformer_engine"
+
+
+@pytest.mark.parametrize("transformer_impl", [None, "local"])
+def test_training_args_uses_transformer_engine_for_npu_bf16(monkeypatch, transformer_impl):
+    monkeypatch.setattr("mcore_adapter.training_args.current_platform.is_npu", lambda: True)
+
+    args = TrainingArguments(output_dir="tmp", transformer_impl=transformer_impl)
+
+    assert args.transformer_impl == "transformer_engine"
+    assert args.fp8 is None
+
+
+def test_training_args_rejects_fp8_param_without_fp8_format(monkeypatch):
+    monkeypatch.setattr("mcore_adapter.training_args.current_platform.is_npu", lambda: True)
+
+    with pytest.raises(ValueError, match="fp8 or fp8_format to be set"):
+        TrainingArguments(output_dir="tmp", fp8_param=True)
+
+
+def test_training_args_rejects_fp8_param_without_recipe(monkeypatch):
+    monkeypatch.setattr("mcore_adapter.training_args.current_platform.is_npu", lambda: True)
+
+    with pytest.raises(ValueError, match="fp8_recipe to be set"):
+        TrainingArguments(output_dir="tmp", fp8="hybrid", fp8_param=True)
+
+
+def test_training_args_rejects_fp8_recipe_without_fp8_format():
+    with pytest.raises(ValueError, match="fp8_recipe requires fp8"):
+        TrainingArguments(output_dir="tmp", fp8_recipe="mxfp8")
+
+
+def test_training_args_forces_flash_attn_off_for_npu_batch_invariant(monkeypatch):
+    monkeypatch.setattr("mcore_adapter.training_args.current_platform.is_npu", lambda: True)
+
+    args = TrainingArguments(
+        output_dir="tmp",
+        fp8="e4m3",
+        fp8_recipe="mxfp8",
+        use_flash_attn_npu_batch_invariant=True,
+    )
+
+    assert args.use_flash_attn is False
+
+
+def test_normalize_weight_for_model_update_unwraps_fp8_like_weight():
+    data = torch.ones(2, 2, dtype=torch.float32)
+    weight = SimpleNamespace(data=data, dtype=torch.bfloat16)
+
+    normalized = normalize_weight_for_model_update(weight)
+
+    assert torch.is_tensor(normalized)
+    assert normalized.dtype == torch.bfloat16
+    assert torch.equal(normalized, data.to(torch.bfloat16))
+
+
+def test_normalize_weight_for_model_update_prefers_dequantize_hook():
+    class Fp8LikeWeight:
+        data = torch.ones(2, 2, dtype=torch.uint8)
+        dtype = torch.float8_e4m3fn if hasattr(torch, "float8_e4m3fn") else torch.uint8
+
+        def dequantize(self):
+            return torch.ones(2, 2, dtype=torch.bfloat16)
+
+    normalized = normalize_weight_for_model_update(Fp8LikeWeight())
+
+    assert normalized.dtype == torch.bfloat16
+    assert torch.equal(normalized, torch.ones(2, 2, dtype=torch.bfloat16))
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="torch does not expose native float8 dtype")
+def test_normalize_weight_for_model_update_casts_native_float8():
+    weight = torch.ones(2, 2).to(torch.float8_e4m3fn)
+
+    normalized = normalize_weight_for_model_update(weight)
+
+    assert normalized.dtype == torch.bfloat16
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="torch does not expose native float8 dtype")
+def test_estimate_weight_size_for_model_update_uses_normalized_dtype():
+    weight = torch.ones(2, 2).to(torch.float8_e4m3fn)
+
+    assert estimate_weight_size_for_model_update(weight) == 4 * 2

--- a/tests/utils/test_vllm_online_quantization.py
+++ b/tests/utils/test_vllm_online_quantization.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import pytest
+
+from roll.utils.vllm_online_quantization import (
+    ASCEND_MXFP8_QUANT_TYPE,
+    FLOAT_QUANT_TYPE,
+    apply_online_quantization_config,
+    build_ascend_mxfp8_quant_description,
+    default_load_format_for_quantization,
+)
+
+
+def test_build_ascend_mxfp8_quant_description_for_dense_qwen_like_model():
+    hf_config = SimpleNamespace(model_type="qwen3", num_hidden_layers=2)
+
+    description = build_ascend_mxfp8_quant_description(hf_config)
+
+    assert description["quant_method"] == "ascend"
+    assert description["group_size"] == 32
+    assert description["model.layers.0.self_attn.q_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.0.self_attn.qkv_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.1.mlp.gate_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.1.mlp.gate_up_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.embed_tokens.weight"] == FLOAT_QUANT_TYPE
+    assert description["lm_head.weight"] == FLOAT_QUANT_TYPE
+
+
+def test_build_ascend_mxfp8_quant_description_for_qwen_moe_model():
+    hf_config = SimpleNamespace(
+        model_type="qwen3_moe",
+        num_hidden_layers=1,
+        num_experts=8,
+        moe_intermediate_size=768,
+    )
+
+    description = build_ascend_mxfp8_quant_description(hf_config)
+
+    assert description["model.layers.0.mlp.gate.weight"] == FLOAT_QUANT_TYPE
+    assert description["model.layers.0.mlp.router.weight"] == FLOAT_QUANT_TYPE
+    assert description["model.layers.0.mlp.experts.0.gate_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.0.mlp.experts.0.up_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.0.mlp.experts.0.down_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+    assert description["model.layers.0.mlp.shared_expert.gate_proj.weight"] == ASCEND_MXFP8_QUANT_TYPE
+
+
+def test_apply_online_quantization_config_injects_hf_overrides():
+    kwargs = {
+        "model": "Qwen/Qwen3-8B",
+        "load_format": "auto",
+        "online_quantization": "ascend_mxfp8",
+        "online_quantization_config": {"group_size": 64},
+        "hf_overrides": {"rope_scaling": {"type": "default"}},
+    }
+    hf_config = SimpleNamespace(model_type="qwen3", num_hidden_layers=1)
+
+    quant_config = apply_online_quantization_config(kwargs, hf_config=hf_config)
+
+    assert kwargs["quantization"] == "ascend"
+    assert kwargs["load_format"] == "dummy"
+    assert "online_quantization" not in kwargs
+    assert "online_quantization_config" not in kwargs
+    assert kwargs["hf_overrides"]["rope_scaling"] == {"type": "default"}
+    assert kwargs["hf_overrides"]["quantization_config"] is quant_config
+    assert quant_config["quant_method"] == "ascend"
+    assert quant_config["group_size"] == 64
+
+
+def test_apply_online_quantization_config_rejects_conflicting_quantization():
+    kwargs = {
+        "model": "Qwen/Qwen3-8B",
+        "online_quantization": "ascend_mxfp8",
+        "quantization": "fp8",
+    }
+
+    with pytest.raises(ValueError, match="requires strategy_config.quantization"):
+        apply_online_quantization_config(kwargs, hf_config=SimpleNamespace(model_type="qwen3", num_hidden_layers=1))
+
+
+def test_prequantized_ascend_defaults_to_auto_load_format():
+    assert default_load_format_for_quantization({"quantization": "ascend"}) == "auto"
+
+
+def test_online_ascend_mxfp8_defaults_to_dummy_load_format():
+    assert (
+        default_load_format_for_quantization(
+            {"quantization": "ascend", "online_quantization": "ascend_mxfp8"}
+        )
+        == "dummy"
+    )


### PR DESCRIPTION
## Summary

This PR adds end-to-end Ascend NPU FP8 support for ROLL RLVR pipelines, including Megatron FP8 training, vLLM-Ascend online MXFP8 quantization, ModelSlim checkpoint loading, and Qwen3.5 MoE weight reload.

The changes target the following dependency stack:

- CANN 9.1
- Ascend 950
- PyTorch 2.10
- torch-npu 2.10
- Megatron-LM `core_r0.17.0`
- MegatronAdaptor `core_r0.17.0`
- vLLM `v0.23.0`
- vLLM-Ascend `v0.23.0rc1`

## Motivation

ROLL previously lacked a complete Ascend FP8 training and rollout path.

This PR enables the following workflows:

1. Megatron training with BF16/FP16 master parameters and FP8 computation.
2. Online conversion of synchronized actor weights to Ascend MXFP8 for vLLM rollout.
3. Training from ModelSlim pre-quantized MXFP8 checkpoints.
4. Correct Qwen3.5 MoE weight reload with TP and EP enabled.

## Main changes

### Ascend FP8 runtime

- Add centralized NPU runtime initialization.
- Integrate MegatronAdaptor and TransformerEngineNPU initialization.
- Propagate FP8 format and recipe settings into Megatron.
- Add explicit validation for unsupported or incomplete FP8 configurations.
- Keep FP8 execution enabled instead of falling back to BF16.

### vLLM online MXFP8 quantization

- Add `online_quantization: ascend_mxfp8`.
- Generate ModelSlim-compatible quantization descriptions.
- Quantize synchronized floating-point weight shards with Ascend dynamic MXFP8 quantization.
- Preserve parameter identity across repeated weight updates.
- Support dense Qwen and Qwen MoE models.

### Qwen3.5 MoE reload

- Handle Ascend-specific transposed parameter layouts.
- Apply TP sharding before loading weights.
- Map global expert IDs to local experts under EP.
- Avoid duplicate transposition during repeated reloads.
- Keep router and non-quantized parameters in floating-point format.

### ModelSlim checkpoint loading

- Detect Ascend MXFP8 metadata from checkpoint files.
- Match quantized weights with their scale tensors.
- Reject missing or unsupported quantization metadata.
- Require a trainable MindSpeed/TransformerEngineNPU loader instead of silently dequantizing to BF16.

### Runtime stability

- Initialize and offload reference workers before vLLM reserves its KV cache on colocated devices.
- Skip unnecessary tensor-parallel collectives when TP size is 1.
- Keep the TP>1 entropy reduction path unchanged.
- Avoid repeatedly compiling the entropy reduction helper.
- Limit repeated fused-kernel fallback warnings.

### Docker and examples

- Add `docker/Dockerfile.A5` for the CANN 9.1 / Ascend 950 environment.
- Use the local repository as the Docker build source.
- Add BF16 and FP8/MXFP8 four-NPU RLVR example configurations.

## Tests

Added focused tests for:

- Ascend MXFP8 checkpoint metadata and weight/scale matching.
- FP8 configuration validation.
- Online quantization description generation.
- Repeated vLLM weight updates.
- Qwen3.5 MoE TP/EP weight mapping.
- TP=1 entropy without distributed collectives.
- TP>1 entropy collective behavior.

## Validation performed

- [x] `git diff --check`
- [x] Qwen3-30B-A3B FP8/MXFP8 pipeline started successfully with TP=1 and EP=8
- [x] Training reached step 2
- [x] Rollout output was inspected and contained no garbled text
- [x] Branch remains a single commit on top of `alibaba/main`
- [ ] Newly added unit tests were not executed locally because no usable Python environment is installed
- [ ] `docker build` was not executed locally because the Docker Desktop Linux engine was unavailable

## Known limitations

- TP=2 with optimizer CPU offload can exceed available pinned host memory in the tested environment.
- Switching optimizer offload to pageable memory avoids the pinned allocation failure but can trigger Ray host-memory pressure.
- The currently validated eight-NPU configuration uses TP=1 and EP=8.
- This implementation intentionally targets the dependency versions listed above and does not preserve compatibility with older vLLM/vLLM-Ascend releases.

## Compatibility

Existing non-NPU and non-FP8 paths are intended to remain unchanged. Ascend-specific patches are installed only when the NPU runtime and corresponding quantization mode are active.