### PR TITLE
fix(mcore-adapter): drop mm_token_type_ids before forwarding into GPTModel.forward

### DIFF
--- a/mcore_adapter/src/mcore_adapter/models/qwen3_5/modeling_qwen3_5.py
+++ b/mcore_adapter/src/mcore_adapter/models/qwen3_5/modeling_qwen3_5.py
@@ -283,6 +283,8 @@ class Qwen3_5Model(Qwen3_5McaGPTModel, MultimodalEmbeddingMixin):
     ) -> "torch.Tensor":
         force_vit_image = kwargs.pop("force_vit_image", False)
         force_vit_video = kwargs.pop("force_vit_video", False)
+        # Qwen3.5-VL's processor emits this by default; no consumer forwards it further.
+        kwargs.pop("mm_token_type_ids", None)
         packed_seq_params = kwargs.get("packed_seq_params", None)
 
         if (

--- a/tests/models/test_qwen3_5_forward_kwargs.py
+++ b/tests/models/test_qwen3_5_forward_kwargs.py
@@ -1,0 +1,91 @@
+"""Regression test for #457: Qwen3.5-VL's mm_token_type_ids reaching GPTModel.forward.
+
+Builds a bare Qwen3_5Model instance without the heavy Megatron distributed init
+(not needed: the bug is a pure kwargs-forwarding TypeError raised at Python's
+argument-binding step, before any tensor-parallel state is touched), and drives
+forward() the way a real non-first pipeline-parallel stage does.
+"""
+
+import inspect
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import mcore_adapter.models.model_factory as model_factory
+import torch
+from mcore_adapter.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Model
+from megatron.core.models.gpt.gpt_model import GPTModel
+
+
+class _FakePackingState:
+    position_ids = torch.zeros(1, 1, dtype=torch.long)
+    cp_batch = {
+        "input_ids": torch.zeros(1, 1, dtype=torch.long),
+        "attention_mask": torch.ones(1, 1, 1, 1, dtype=torch.bool),
+    }
+
+
+def _bare_model():
+    model = object.__new__(Qwen3_5Model)
+    model.pre_process = False
+    model.config = SimpleNamespace(mtp_num_layers=None)
+    model.prepare_packing_state = lambda *a, **k: _FakePackingState()
+    return model
+
+
+@contextmanager
+def _capture_super_forward():
+    """Stand in for the real GPTModel.forward, reached via super() from
+    Qwen3_5Model.forward, and record exactly the kwargs that arrive there."""
+    captured = {}
+
+    def fake_super_forward(self, **kw):
+        # Prove the kwargs reaching this point would bind against the REAL
+        # Megatron signature, without needing a fully constructed GPTModel.
+        inspect.signature(GPTModel.forward).bind(self, **kw)
+        captured.update(kw)
+        return torch.zeros(1)
+
+    had_own_forward = "forward" in model_factory.McaGPTModel.__dict__
+    orig = model_factory.McaGPTModel.__dict__.get("forward")
+    model_factory.McaGPTModel.forward = fake_super_forward
+    try:
+        yield captured
+    finally:
+        if had_own_forward:
+            model_factory.McaGPTModel.forward = orig
+        else:
+            del model_factory.McaGPTModel.forward
+
+
+def test_mm_token_type_ids_does_not_reach_gptmodel_forward():
+    """The Qwen3.5-VL processor's mm_token_type_ids has no consumer and must be
+    dropped before forward() reaches Megatron's GPTModel.forward, whose signature
+    has no **kwargs catch-all (binding an unrecognized keyword there raises
+    TypeError before the method body runs at all, matching #457's traceback)."""
+    model = _bare_model()
+    with _capture_super_forward() as captured:
+        model.forward(
+            input_ids=torch.zeros(1, 1, dtype=torch.long),
+            position_ids=torch.zeros(1, 1, dtype=torch.long),
+            attention_mask=torch.ones(1, 1, 1, 1, dtype=torch.bool),
+            mm_token_type_ids=torch.zeros(1, 1, dtype=torch.long),
+        )
+    assert "mm_token_type_ids" not in captured
+
+
+def test_force_vit_kwargs_still_popped():
+    """Guards the two pre-existing kwargs this change sits next to, so a future
+    edit can't silently stop popping them while touching this block."""
+    model = _bare_model()
+    with _capture_super_forward() as captured:
+        model.forward(
+            input_ids=torch.zeros(1, 1, dtype=torch.long),
+            position_ids=torch.zeros(1, 1, dtype=torch.long),
+            attention_mask=torch.ones(1, 1, 1, 1, dtype=torch.bool),
+            force_vit_image=True,
+            force_vit_video=True,
+            mm_token_type_ids=torch.zeros(1, 1, dtype=torch.long),
+        )
+    assert "force_vit_image" not in captured
+    assert "force_vit_video" not in captured
+    assert "mm_token_type_ids" not in captured


### PR DESCRIPTION
## What

`Qwen3_5Model.forward` (`mcore_adapter/src/mcore_adapter/models/qwen3_5/modeling_qwen3_5.py`)
pops `force_vit_image`/`force_vit_video` out of `**kwargs` and then forwards the rest of
`kwargs` unfiltered into `super().forward(...)`, which resolves through `McaGPTModel` to
Megatron's `GPTModel.forward`. That method has a fixed keyword signature with no `**kwargs`
catch-all, so any extra key raises `TypeError` at argument-binding time, before the method
body runs.

`transformers`' `Qwen3VLProcessor` (used for Qwen3.5-VL too) sets `return_mm_token_type_ids:
True` by default and lists `mm_token_type_ids` in its `model_input_names`. Nothing in ROLL or
mcore_adapter reads that key (`grep -rn "token_type" .` returns zero hits repo-wide), so a
Qwen3.5 VLM batch carries it straight through to `GPTModel.forward` and crashes every
training/inference forward call, matching the traceback in #457.

## Fix

Pop `mm_token_type_ids` next to the two VIT-only kwargs that are already popped, before the
kwargs dict reaches either of the two `super().forward()` call sites in this method (both
share the same dict, so one pop covers both paths).

## Verification

- Reproduced the exact `TypeError: GPTModel.forward() got an unexpected keyword argument
  'mm_token_type_ids'` in a clean `python:3.11-slim` container against current HEAD
  (`192b1a0`), driving a bare `Qwen3_5Model` instance through `forward()` the way a
  non-first pipeline-parallel stage calls it (no GPU/NPU needed: the failure is pure
  keyword-argument binding).
- Added `tests/models/test_qwen3_5_forward_kwargs.py` (2 tests). Ran both on unmodified
  `192b1a0` (both fail with the `TypeError` above) and on this branch (both pass), in the
  same container.
- Confirmed against the installed `transformers` package that `mm_token_type_ids` is the
  only processor-emitted key beyond what `forward()` already declares by name.
- Not verified: an end-to-end Qwen3.5-VL RL training run (needs GPU/NPU and real model
  weights, unavailable here). No CI workflow in this repo currently runs `tests/models/`
  (`ci-npu-test.yml` only runs `tests/utils` and `tests/third_party/sglang`), so this test
  isn't wired into a gate; happy to add that if you'd like.

Fixes #457

## FYI, out of scope here

`mcore_adapter/src/mcore_adapter/models/qwen3_vl/modeling_qwen3_vl.py` has the identical
pattern (pops `force_vit_image`/`force_vit_video` only, forwards the rest of `kwargs`
unfiltered) and the same processor would hit it the same way. I did not reproduce or touch
it since #457 is scoped to Qwen3.5; flagging in case it's worth a follow-up.
