### PR TITLE
fix(dynamic batching): preserve static mini-batch updates

### DIFF
--- a/docs_roll/docs/User Guides/Advanced Features/dynamic_batching.md
+++ b/docs_roll/docs/User Guides/Advanced Features/dynamic_batching.md
@@ -127,6 +127,7 @@ The Dynamic Batching parameters are divided into `train` and `infer`:
 
 ### Train
 - `use_dynamic_batching_in_train`: Whether to enable this feature during the `train_step`.
+- `keep_mini_batch`: Whether dynamic batching should preserve the number and sample size of static training mini-batches. It is disabled by default for backward compatibility.
 - `max_tokens_per_microbatch_in_train`: The maximum number of tokens allowed per micro-batch during training.
 - `sequence_length_round_in_train`: The sequence length of each micro-batch must be divisible by this value. It should also be divisible by `tensor_model_parallel_size * context_parallel_size`. Common values are 128 or 64.
 
@@ -168,6 +169,7 @@ actor_train:
   device_mapping: list(range(0,8))
   infer_batch_size: 2
   use_dynamic_batching_in_train: true
+  keep_mini_batch: true
   max_tokens_per_microbatch_in_train: 8192
   sequence_length_round_in_train: 128
   use_dynamic_batching_in_infer: true

--- a/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/dynamic_batching.md
+++ b/docs_roll/i18n/zh-Hans/docusaurus-plugin-content-docs/current/User Guides/Advanced Features/dynamic_batching.md
@@ -125,6 +125,7 @@ shard1:
 与 Dynamic Batching 相关的参数如下，分为 train 和 infer 两个部分
 - Train
   - use_dynamic_batching_in_train: 是否在 `train_step` 时开启；
+  - keep_mini_batch: 是否在动态切分 micro-batch 时保留静态训练 mini-batch 的数量和样本数。默认为关闭，以兼容已有配置；
   - max_tokens_per_microbatch_in_train: 训练时每个 micro_batch 最大 token 数量；
   - sequence_length_round_in_train: 训练时每个 micro_batch 的序列长度需要能被这个参数整除，需要能够被 `tensor_model_parallel_size * context_parallel_size` 整除，一般取 128,64 即可；
 - Infer
@@ -167,6 +168,7 @@ actor_train:
   device_mapping: list(range(0,8))
   infer_batch_size: 2
   use_dynamic_batching_in_train: true
+  keep_mini_batch: true
   max_tokens_per_microbatch_in_train: 8192
   sequence_length_round_in_train: 128
   use_dynamic_batching_in_infer: true

--- a/roll/configs/worker_config.py
+++ b/roll/configs/worker_config.py
@@ -152,6 +152,13 @@ class WorkerConfig:
             "minimizing padding and improving computational and memory efficiency."
         },
     )
+    keep_mini_batch: bool = field(
+        default=False,
+        metadata={
+            "help": "Keep the number and sample size of training mini-batches consistent with static batching. "
+            "Dynamic micro-batches are split at each static mini-batch boundary before optimizer updates."
+        },
+    )
     max_tokens_per_microbatch_in_train: int = field(
         default=0,
         metadata={
@@ -360,4 +367,3 @@ def is_actor_infer_overlapping_with_any_cluster(actor_infer: WorkerConfig, actor
                 return True
 
     return False
-

--- a/roll/distributed/strategy/megatron_strategy.py
+++ b/roll/distributed/strategy/megatron_strategy.py
@@ -1350,7 +1350,7 @@ class MegatronTrainStrategy(MegatronInferStrategy, TrainStrategy):
         if self.model.config.num_moe_experts is not None and self.model.config.num_moe_experts > 1:
             reduce_aux_losses_tracker_across_ranks()
             tracker = get_moe_layer_wise_logging_tracker()
-            loss_scale = 1 / self.megatron_train_args.gradient_accumulation_steps
+            loss_scale = 1 / num_microbatches
             moe_losses = {
                 self.worker_config.name + "/" + k: (v["values"].float() * loss_scale).mean().item()
                 for k, v in tracker.items()
@@ -1363,7 +1363,7 @@ class MegatronTrainStrategy(MegatronInferStrategy, TrainStrategy):
             MTPLossLoggingHelper.reduce_loss_in_tracker()
             tracker = MTPLossLoggingHelper.tracker
             if "values" in tracker:
-                loss_scale = 1 / self.megatron_train_args.gradient_accumulation_steps
+                loss_scale = 1 / num_microbatches
                 mtp_losses = tracker["values"] * loss_scale
                 mtp_num_layers = mtp_losses.shape[0]
                 for i in range(mtp_num_layers):

--- a/roll/pipeline/agentic/agentic_pipeline.py
+++ b/roll/pipeline/agentic/agentic_pipeline.py
@@ -525,7 +525,9 @@ class AgenticPipeline(BasePipeline):
                             batch_balance_metrics = batch_balance(batch, dp_size=self.actor_train.dp_size,
                                 minibatch_size=self.actor_train.dp_size * self.pipeline_config.actor_train.training_args.per_device_train_batch_size *
                                 self.pipeline_config.actor_train.training_args.gradient_accumulation_steps,
-                                logging_prefix="global_seqlen/actor_train")
+                                logging_prefix="global_seqlen/actor_train",
+                                keep_minibatch=self.pipeline_config.actor_train.keep_mini_batch
+                                and self.pipeline_config.actor_train.use_dynamic_batching_in_train)
                             metrics.update(batch_balance_metrics)
                             # update actor
                             if self.pipeline_config.actor_train.use_dynamic_batching_in_train:

--- a/roll/pipeline/base_worker.py
+++ b/roll/pipeline/base_worker.py
@@ -85,11 +85,21 @@ class ActorWorker(Worker):
                     per_device_train_batch_size * self.worker_config.training_args.gradient_accumulation_steps
             )
             if self.worker_config.use_dynamic_batching_in_train:
-                # TODO: support `keep_mini_batch`, The number of mini_batch may be smaller than original size
+                strategy_config = (
+                    self.worker_config.strategy_args.strategy_config
+                    if self.worker_config.strategy_args is not None
+                    else {}
+                )
                 dataloader = make_mini_batch_iter_for_dynamic_batching(
                     data=data,
                     epochs=self.pipeline_config.ppo_epochs,
                     ga_steps=self.worker_config.training_args.gradient_accumulation_steps,
+                    keep_mini_batch=self.worker_config.keep_mini_batch,
+                    mini_batch_size=backward_batch_size,
+                    pipeline_model_parallel_size=strategy_config.get("pipeline_model_parallel_size", 1),
+                    virtual_pipeline_model_parallel_size=strategy_config.get(
+                        "virtual_pipeline_model_parallel_size", None
+                    ),
                 )
             else:
                 dataloader = data.make_iterator(

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -776,7 +776,9 @@ class RLVRPipeline(BasePipeline):
                             batch_balance_metrics = batch_balance(batch, dp_size=self.actor_train.dp_size,
                                 minibatch_size=self.pipeline_config.actor_train.training_args.per_device_train_batch_size
                                 * self.pipeline_config.actor_train.training_args.gradient_accumulation_steps
-                                * self.actor_train.dp_size, logging_prefix="global_seqlen/actor_train")
+                                * self.actor_train.dp_size, logging_prefix="global_seqlen/actor_train",
+                                keep_minibatch=self.pipeline_config.actor_train.keep_mini_batch
+                                and self.pipeline_config.actor_train.use_dynamic_batching_in_train)
                             metrics_mgr.add_metrics(batch_balance_metrics)
                             # update actor
                             if self.pipeline_config.actor_train.use_dynamic_batching_in_train:

--- a/roll/utils/dynamic_batching.py
+++ b/roll/utils/dynamic_batching.py
@@ -1,5 +1,6 @@
-import bisect
-from typing import Iterator
+import copy
+from numbers import Integral
+from typing import Iterator, Optional
 
 import torch
 
@@ -8,6 +9,83 @@ from roll.utils.logging import get_logger
 
 
 logger = get_logger()
+
+
+def _normalize_pipeline_model_parallel_size(pipeline_model_parallel_size: Optional[int]) -> int:
+    if pipeline_model_parallel_size is None:
+        return 1
+    if (
+        isinstance(pipeline_model_parallel_size, bool)
+        or not isinstance(pipeline_model_parallel_size, Integral)
+        or pipeline_model_parallel_size < 1
+    ):
+        raise ValueError(
+            "pipeline_model_parallel_size must be a positive integer, "
+            f"got {pipeline_model_parallel_size!r}"
+        )
+    return int(pipeline_model_parallel_size)
+
+
+def _split_ranges_to_vpp_multiple(
+    micro_batch_indices: list[list[int]],
+    micro_batch_lengths: list[int],
+    pipeline_model_parallel_size: int,
+    logical_mini_batch_index: int,
+) -> None:
+    """Split ranges in one logical mini-batch to satisfy the VPP schedule.
+
+    Megatron's interleaved pipeline schedule requires the number of
+    micro-batches in each logical mini-batch to be a multiple of the pipeline
+    parallel size.  Splitting a range increases that count by one while
+    preserving sample order and the padded sequence length associated with the
+    range.  The lists are intentionally mutated in place so the caller can
+    retain the grouping structure it has already built.
+    """
+    if pipeline_model_parallel_size <= 0:
+        raise ValueError(
+            "pipeline_model_parallel_size must be positive, "
+            f"got {pipeline_model_parallel_size}"
+        )
+
+    current_count = len(micro_batch_indices)
+    target_count = (
+        (current_count + pipeline_model_parallel_size - 1) // pipeline_model_parallel_size
+    ) * pipeline_model_parallel_size
+    splits_needed = target_count - current_count
+
+    while splits_needed:
+        # Prefer the largest range so that repeated midpoint splits leave as
+        # much room as possible for any remaining required splits.
+        splittable_index = next(
+            (
+                index
+                for index, (start, end) in sorted(
+                    enumerate(micro_batch_indices),
+                    key=lambda item: item[1][1] - item[1][0],
+                    reverse=True,
+                )
+                if end - start > 1
+            ),
+            None,
+        )
+        if splittable_index is None:
+            raise ValueError(
+                f"logical mini-batch {logical_mini_batch_index} has {current_count} "
+                f"micro-batches and cannot be split into a multiple of "
+                f"pipeline_model_parallel_size={pipeline_model_parallel_size}; "
+                "there are not enough multi-sample ranges"
+            )
+
+        start, end = micro_batch_indices[splittable_index]
+        midpoint = start + (end - start) // 2
+        length = micro_batch_lengths[splittable_index]
+        micro_batch_indices[splittable_index : splittable_index + 1] = [
+            [start, midpoint],
+            [midpoint, end],
+        ]
+        micro_batch_lengths[splittable_index : splittable_index + 1] = [length, length]
+        splits_needed -= 1
+        current_count += 1
 
 
 def dynamic_batching_shard(
@@ -20,10 +98,11 @@ def dynamic_batching_shard(
     log_prefix: str = None,
 ) -> tuple[DataProto, dict]:
     #TODO use Karmarkar–Karp algorithm to replace the greedy implementation
+    pipeline_model_parallel_size = _normalize_pipeline_model_parallel_size(pipeline_model_parallel_size)
     attention_mask = origin_batch.batch["attention_mask"]
     batch_size = attention_mask.shape[0]
     seq_lens = attention_mask.view(batch_size, -1).sum(-1).tolist()
-    
+
     if 0 in seq_lens:
         logger.warning(f"The attention_mask is all zero in the {log_prefix} stage. Please verify the rollout stage.")
 
@@ -69,51 +148,24 @@ def dynamic_batching_shard(
         for (start, end), length in zip(global_micro_batch_indices, global_micro_batch_lengths)
     )
     if pipeline_model_parallel_size > 1 and virtual_pipeline_model_parallel_size:
-        # pad to multiple of `microbatch_group_size_per_vp_stage`
+        # Pad to a multiple of the pipeline parallel size.  A dynamic range
+        # may contain many samples, so it can be split more than once when a
+        # large token cap produces only a handful of ranges.  The old
+        # implementation considered each original range only once, which
+        # raised an assertion for e.g. one ``[0, 8)`` range needing three
+        # additional micro-batches for ``pp_size=4``.
         num_micro_batches = len(global_micro_batch_indices)
         padded_num_micro_batches = (
             (num_micro_batches + pipeline_model_parallel_size - 1) // pipeline_model_parallel_size
         ) * pipeline_model_parallel_size
         assert pipeline_model_parallel_size <= shard_size, f"The pipeline_model_size: {pipeline_model_parallel_size} should not be greater than num_seqs in one dp_rank"
         assert padded_num_micro_batches <= shard_size
-        num_micro_batches_needed = padded_num_micro_batches - num_micro_batches
-        
-        splittable_mbs = [i for i in range(num_micro_batches) if (global_micro_batch_indices[i][1] - global_micro_batch_indices[i][0]) > 1]
-        # sort by tokens
-        splittable_mbs.sort(key=lambda x: (global_micro_batch_indices[x][1] - global_micro_batch_indices[x][0]) * global_micro_batch_lengths[x], reverse=True)
-
-        assert len(splittable_mbs) >= num_micro_batches_needed
-        dropped_mbs = []
-        added_micro_batch_indices = []
-        added_micro_batch_lengths = []
-        while num_micro_batches_needed:
-            mb_to_split = splittable_mbs.pop(0)
-
-            # compute split point
-            split_start, split_end = global_micro_batch_indices[mb_to_split]
-            split_length = global_micro_batch_lengths[mb_to_split]
-            split_seqs = split_end - split_start
-            split_point = split_start + (split_seqs // 2)
-
-            # generate new mb
-            new_mb1 = [split_start, split_point]
-            new_mb2 = [split_point, split_end]
-            
-            # record dropped and added mbs
-            dropped_mbs.append(mb_to_split)
-            added_micro_batch_indices += [new_mb1, new_mb2]
-            added_micro_batch_lengths += [split_length, split_length]
-            
-            num_micro_batches_needed -= 1
-
-        global_micro_batch_indices = [global_micro_batch_indices[i] for i in range(num_micro_batches) if i not in dropped_mbs]
-        global_micro_batch_lengths = [global_micro_batch_lengths[i] for i in range(num_micro_batches) if i not in dropped_mbs]
-
-        # insert added_mbs, ensure sorted
-        for added_mbs_indices, added_mbs_length in zip(added_micro_batch_indices, added_micro_batch_lengths):
-            insert_indice = bisect.bisect_right(global_micro_batch_indices, added_mbs_indices)
-            global_micro_batch_indices.insert(insert_indice, added_mbs_indices)
-            global_micro_batch_lengths.insert(insert_indice, added_mbs_length)        
+        _split_ranges_to_vpp_multiple(
+            global_micro_batch_indices,
+            global_micro_batch_lengths,
+            pipeline_model_parallel_size,
+            logical_mini_batch_index=0,
+        )
 
     batch = DataProto.concat(aggregated_shards)
     batch.meta_info["global_micro_batch_indices"] = global_micro_batch_indices
@@ -142,10 +194,13 @@ def make_mini_batch_iter_for_dynamic_batching(
     data: DataProto,
     epochs: int,
     ga_steps: int = 1,
+    keep_mini_batch: bool = False,
+    mini_batch_size: Optional[int] = None,
+    pipeline_model_parallel_size: int = 1,
+    virtual_pipeline_model_parallel_size: Optional[int] = None,
 ) -> Iterator[DataProto]:
     """
-        Iterator that groups previously created global micro batches into mini batches
-        based on gradient accumulation steps (ga_steps).
+        Iterator that groups previously created global micro batches into mini batches.
 
         Terminology:
         - Micro batch: The smallest training unit that can fit into GPU memory
@@ -154,30 +209,133 @@ def make_mini_batch_iter_for_dynamic_batching(
           `max_tokens_per_microbatch`.
         - Mini batch: A group of several micro batches.
           During training, you iterate over each micro batch inside a mini batch,
-          perform forward/backward passes, accumulate gradients, and after `ga_steps`
-          micro batches, perform a parameter update (`optimizer.step()`).
+          perform forward/backward passes, accumulate gradients, and then perform a
+          parameter update (`optimizer.step()`).
 
         This function:
         1. Reads the global micro batch indices/lengths from `data.meta_info`.
-        2. Groups `ga_steps` consecutive micro batches into a single mini batch.
-        3. Adjusts indices so micro batches are relative to the mini batch.
-        4. Yields each mini batch for training.
+        2. By default, groups `ga_steps` consecutive micro batches into a mini batch.
+           With `keep_mini_batch`, instead preserves static sample-level mini-batch
+           boundaries and splits dynamic micro batches that cross those boundaries.
+        3. When virtual pipeline parallelism is enabled, splits ranges within
+           each logical mini-batch until its micro-batch count is a multiple of
+           ``pipeline_model_parallel_size``.
+        4. Adjusts indices so micro batches are relative to the mini batch.
+        5. Yields each mini batch for training.
         """
+    pipeline_model_parallel_size = _normalize_pipeline_model_parallel_size(pipeline_model_parallel_size)
     global_micro_batch_indices = data.meta_info["global_micro_batch_indices"]
     global_micro_batch_lengths = data.meta_info["global_micro_batch_lengths"]
+
+    assert ga_steps > 0, f"ga_steps must be positive, got {ga_steps}"
+    assert len(global_micro_batch_indices) == len(global_micro_batch_lengths), (
+        "global_micro_batch_indices and global_micro_batch_lengths must have the same length"
+    )
+
+    # The ranges are produced by ``dynamic_batching_shard`` and are local to a
+    # DP rank.  Validate them before grouping so a malformed layout cannot
+    # silently drop or duplicate samples when a range is split at a boundary.
+    batch_size = len(data)
+    validated_micro_batch_indices = []
+    validated_micro_batch_lengths = []
+    if batch_size == 0:
+        assert not global_micro_batch_indices, "an empty batch cannot have micro-batch ranges"
+    else:
+        assert global_micro_batch_indices, "a non-empty batch must have micro-batch ranges"
+        expected_start = 0
+        for range_idx, (micro_start, micro_end) in enumerate(global_micro_batch_indices):
+            assert isinstance(micro_start, Integral) and isinstance(micro_end, Integral), (
+                f"micro-batch range {range_idx} must contain integer offsets, "
+                f"got [{micro_start!r}, {micro_end!r}]"
+            )
+            micro_start = int(micro_start)
+            micro_end = int(micro_end)
+            assert micro_start == expected_start, (
+                "global micro-batch ranges must be sorted and contiguous: "
+                f"expected start {expected_start}, got {micro_start} at range {range_idx}"
+            )
+            assert micro_start < micro_end <= batch_size, (
+                f"invalid global micro-batch range [{micro_start}, {micro_end}) "
+                f"for batch size {batch_size}"
+            )
+            assert global_micro_batch_lengths[range_idx] > 0, (
+                f"micro-batch length must be positive, got {global_micro_batch_lengths[range_idx]}"
+            )
+            validated_micro_batch_indices.append([micro_start, micro_end])
+            validated_micro_batch_lengths.append(global_micro_batch_lengths[range_idx])
+            expected_start = micro_end
+        assert expected_start == batch_size, (
+            "global micro-batch ranges must cover the complete local batch: "
+            f"last end {expected_start}, batch size {batch_size}"
+        )
+    global_micro_batch_indices = validated_micro_batch_indices
+    global_micro_batch_lengths = validated_micro_batch_lengths
+
+    if keep_mini_batch:
+        assert mini_batch_size is not None and mini_batch_size > 0, (
+            f"mini_batch_size must be positive when keep_mini_batch is enabled, got {mini_batch_size}"
+        )
+        assert batch_size % mini_batch_size == 0, (
+            f"batch size {batch_size} must be divisible by mini_batch_size {mini_batch_size} "
+            "when keep_mini_batch is enabled"
+        )
+
+        grouped_indices = [[] for _ in range(batch_size // mini_batch_size)]
+        grouped_lengths = [[] for _ in grouped_indices]
+        for (start, end), length in zip(global_micro_batch_indices, global_micro_batch_lengths):
+            while start < end:
+                group_idx = start // mini_batch_size
+                group_end = min(end, (group_idx + 1) * mini_batch_size)
+                grouped_indices[group_idx].append([start, group_end])
+                grouped_lengths[group_idx].append(length)
+                start = group_end
+
+        # Every logical mini-batch must contain exactly its static sample
+        # budget.  These checks also make an accidental empty group fail at the
+        # point where the bad layout is constructed rather than at yield time.
+        for group_idx, (indices_group, lengths_group) in enumerate(zip(grouped_indices, grouped_lengths)):
+            assert indices_group and lengths_group, f"logical mini-batch {group_idx} is empty"
+            group_start = group_idx * mini_batch_size
+            group_end = group_start + mini_batch_size
+            assert indices_group[0][0] == group_start and indices_group[-1][1] == group_end, (
+                f"logical mini-batch {group_idx} does not cover [{group_start}, {group_end})"
+            )
+            assert all(
+                left[1] == right[0] for left, right in zip(indices_group, indices_group[1:])
+            ), f"micro-batch ranges in logical mini-batch {group_idx} are not contiguous"
+
+            if pipeline_model_parallel_size > 1 and virtual_pipeline_model_parallel_size:
+                _split_ranges_to_vpp_multiple(
+                    indices_group,
+                    lengths_group,
+                    pipeline_model_parallel_size,
+                    group_idx,
+                )
+    else:
+        grouped_indices = [
+            global_micro_batch_indices[i : i + ga_steps]
+            for i in range(0, len(global_micro_batch_indices), ga_steps)
+        ]
+        grouped_lengths = [
+            global_micro_batch_lengths[i : i + ga_steps]
+            for i in range(0, len(global_micro_batch_lengths), ga_steps)
+        ]
+
     for _ in range(epochs):
-        for i in range(0, len(global_micro_batch_indices), ga_steps):
-            indices_chunk = global_micro_batch_indices[i : i + ga_steps]
+        for indices_chunk, lengths_chunk in zip(grouped_indices, grouped_lengths):
             start = indices_chunk[0][0]
             end = indices_chunk[-1][-1]
             mini_batch = data.slice(start, end)
-
-            data.meta_info["micro_batch_indices"] = [[x - start for x in row] for row in indices_chunk]
-            data.meta_info["micro_batch_lengths"] = global_micro_batch_lengths[i : i + ga_steps]
-            mini_batch.meta_info["mini_batch_size"] = mini_batch.batch.batch_size[0]
+            mini_batch.meta_info = copy.deepcopy(data.meta_info)
+            mini_batch.meta_info["micro_batch_indices"] = [
+                [micro_batch_start - start, micro_batch_end - start]
+                for micro_batch_start, micro_batch_end in indices_chunk
+            ]
+            mini_batch.meta_info["micro_batch_lengths"] = list(lengths_chunk)
+            mini_batch.meta_info["mini_batch_size"] = len(mini_batch)
             mini_batch.meta_info["num_micro_batchs"] = len(indices_chunk)
 
-            yield (mini_batch)
+            yield mini_batch
 
 
 def make_micro_batch_iter_for_dynamic_batching(mini_batch: DataProto):

--- a/roll/utils/functionals.py
+++ b/roll/utils/functionals.py
@@ -1669,6 +1669,18 @@ def batch_balance(batch: DataProto, dp_size, minibatch_size, logging_prefix="glo
     workload_lst = calculate_workload(global_seqlen_lst)
     world_size = dp_size
     if keep_minibatch:
+        if minibatch_size <= 0:
+            raise ValueError(f"minibatch_size must be positive, got {minibatch_size}")
+        if batch_size % minibatch_size != 0:
+            raise ValueError(
+                f"batch size {batch_size} must be divisible by minibatch_size {minibatch_size} "
+                "when keep_minibatch is enabled"
+            )
+        if minibatch_size % world_size != 0:
+            raise ValueError(
+                f"minibatch_size {minibatch_size} must be divisible by dp_size {world_size} "
+                "when keep_minibatch is enabled"
+            )
         # Decouple the DP balancing and mini-batching.
         minibatch_num = len(workload_lst) // minibatch_size
         global_partition_lst = [[] for _ in range(world_size)]
@@ -1698,5 +1710,4 @@ def batch_balance(batch: DataProto, dp_size, minibatch_size, logging_prefix="glo
     metrics = {}
     metrics.update(global_balance_stats)
     return metrics
-
 

--- a/tests/utils/test_dynamic_batching.py
+++ b/tests/utils/test_dynamic_batching.py
@@ -1,7 +1,13 @@
+import pytest
 import torch
 
 from roll.distributed.scheduler.protocol import DataProto
-from roll.utils.dynamic_batching import *
+from roll.utils.dynamic_batching import (
+    dynamic_batching_shard,
+    make_micro_batch_iter_for_dynamic_batching,
+    make_mini_batch_iter_for_dynamic_batching,
+)
+from roll.utils.functionals import batch_balance
 
 
 def test_dynamic_batching():
@@ -22,20 +28,22 @@ def test_dynamic_batching():
 
     # test dynamic_batching_shard
     data, _ = dynamic_batching_shard(data, dp_size, max_tokens_per_microbatch, sequence_length_round)
-    assert data.meta_info["global_micro_batch_indices"] == [[0,2],[2,3]]
+    assert data.meta_info["global_micro_batch_indices"] == [[0, 2], [2, 3]]
     assert data.meta_info["global_micro_batch_lengths"] == [4, 8]
 
     # test make_mini_batch_iter_for_dynamic_batching
-    data_dp0 = data.slice(0, num_seq//dp_size)
+    data_dp0 = data.slice(0, num_seq // dp_size)
     mini_batch_iter = make_mini_batch_iter_for_dynamic_batching(data_dp0, 1, 1)
     mini_batch0 = next(mini_batch_iter)
-    assert mini_batch0.meta_info["micro_batch_indices"] == [[0,2]]
-    assert data.meta_info["micro_batch_lengths"] == [4]
-    
+    assert mini_batch0.meta_info["micro_batch_indices"] == [[0, 2]]
+    assert data_dp0.meta_info["global_micro_batch_indices"] == [[0, 2], [2, 3]]
+    assert data_dp0.meta_info["global_micro_batch_lengths"] == [4, 8]
+    assert data_dp0.meta_info["micro_batch_lengths"] == [4, 8]
+
     # test make_mini_batch_iter_for_dynamic_batching
     micro_batch_iter = make_micro_batch_iter_for_dynamic_batching(mini_batch0)
     micro_batch0 = next(micro_batch_iter)
-    assert tuple(micro_batch0.batch["input_ids"].shape) == (2,4)
+    assert tuple(micro_batch0.batch["input_ids"].shape) == (2, 4)
 
 
 def test_dynamic_batching_with_vpp():
@@ -58,11 +66,281 @@ def test_dynamic_batching_with_vpp():
     # test dynamic_batching_shard
     pipeline_model_parallel_size = 4
     virtual_pipeline_model_size = 2
-    data, _ = dynamic_batching_shard(data, dp_size, max_tokens_per_microbatch, sequence_length_round, 
+    data, _ = dynamic_batching_shard(data, dp_size, max_tokens_per_microbatch, sequence_length_round,
                                      pipeline_model_parallel_size=pipeline_model_parallel_size,
                                      virtual_pipeline_model_parallel_size=virtual_pipeline_model_size)
     assert data.meta_info["global_micro_batch_indices"].__len__() % pipeline_model_parallel_size == 0
     assert data.meta_info["global_micro_batch_lengths"].__len__() == data.meta_info["global_micro_batch_indices"].__len__()
+
+
+def _make_dynamic_batch(max_tokens_per_microbatch):
+    num_samples, sequence_length = 8, 8
+    return dynamic_batching_shard(
+        DataProto.from_dict(
+            tensors={
+                "input_ids": torch.arange(num_samples * sequence_length).reshape(num_samples, sequence_length),
+                "attention_mask": torch.ones((num_samples, sequence_length), dtype=torch.long),
+            }
+        ),
+        dp_size=1,
+        max_tokens_per_microbatch=max_tokens_per_microbatch,
+        sequence_length_round=sequence_length,
+    )[0]
+
+
+def test_issue_442_keep_mini_batch_with_more_dynamic_micro_batches():
+    data = _make_dynamic_batch(max_tokens_per_microbatch=8)
+
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=3,
+            ga_steps=2,
+            keep_mini_batch=True,
+            mini_batch_size=4,
+        )
+    )
+
+    assert len(mini_batches) == 6
+    assert all(len(mini_batch) == 4 for mini_batch in mini_batches)
+    assert all(mini_batch.meta_info["num_micro_batchs"] == 4 for mini_batch in mini_batches)
+    assert all(
+        mini_batch.meta_info["micro_batch_indices"] == [[0, 1], [1, 2], [2, 3], [3, 4]]
+        for mini_batch in mini_batches
+    )
+
+
+def test_issue_442_keep_mini_batch_with_fewer_dynamic_micro_batches():
+    data = _make_dynamic_batch(max_tokens_per_microbatch=64)
+    source_ranges = [range(start, end) for start, end in data.meta_info["global_micro_batch_indices"]]
+
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=3,
+            ga_steps=2,
+            keep_mini_batch=True,
+            mini_batch_size=4,
+        )
+    )
+
+    assert len(mini_batches) == 6
+    assert all(len(mini_batch) == 4 for mini_batch in mini_batches)
+    assert [
+        mini_batch.meta_info["micro_batch_indices"] for mini_batch in mini_batches[:2]
+    ] == [[[0, 4]], [[0, 4]]]
+    assert [
+        mini_batch.batch["input_ids"][:, 0].tolist() for mini_batch in mini_batches[:2]
+    ] == [list(range(0, 32, 8)), list(range(32, 64, 8))]
+    assert [sample for sample_range in source_ranges for sample in sample_range] == list(range(8))
+
+
+def test_issue_442_dynamic_mini_batch_metadata_is_independent():
+    num_samples, sequence_length = 8, 8
+    data = DataProto.from_dict(
+        tensors={
+            "input_ids": torch.arange(num_samples * sequence_length).reshape(num_samples, sequence_length),
+            "attention_mask": torch.ones((num_samples, sequence_length), dtype=torch.long),
+        },
+        meta_info={
+            "global_micro_batch_indices": [[0, 2], [2, 4], [4, 5], [5, 8]],
+            "global_micro_batch_lengths": [8, 8, 8, 8],
+        },
+    )
+
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=1,
+            ga_steps=2,
+            keep_mini_batch=True,
+            mini_batch_size=4,
+        )
+    )
+
+    assert [mini_batch.meta_info["micro_batch_indices"] for mini_batch in mini_batches] == [
+        [[0, 2], [2, 4]],
+        [[0, 1], [1, 4]],
+    ]
+    assert [mini_batch.meta_info["micro_batch_lengths"] for mini_batch in mini_batches] == [
+        [8, 8],
+        [8, 8],
+    ]
+    assert mini_batches[0].meta_info is not mini_batches[1].meta_info
+    mini_batches[0].meta_info["micro_batch_indices"][0][0] = 99
+    assert mini_batches[1].meta_info["micro_batch_indices"] == [[0, 1], [1, 4]]
+    assert data.meta_info["global_micro_batch_indices"] == [[0, 2], [2, 4], [4, 5], [5, 8]]
+    assert data.meta_info["global_micro_batch_lengths"] == [8, 8, 8, 8]
+    assert "micro_batch_indices" not in data.meta_info
+    assert "micro_batch_lengths" not in data.meta_info
+
+
+def test_issue_442_keep_mini_batch_splits_ranges_at_every_static_boundary():
+    """A dynamic range may span more than one static logical mini-batch."""
+    data = DataProto.from_dict(
+        tensors={
+            "input_ids": torch.arange(12).reshape(6, 2),
+            "attention_mask": torch.ones((6, 2), dtype=torch.long),
+        },
+        meta_info={
+            "global_micro_batch_indices": [[0, 6]],
+            "global_micro_batch_lengths": [2],
+        },
+    )
+
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=1,
+            ga_steps=8,
+            keep_mini_batch=True,
+            mini_batch_size=2,
+        )
+    )
+
+    assert [len(mini_batch) for mini_batch in mini_batches] == [2, 2, 2]
+    assert [mini_batch.meta_info["micro_batch_indices"] for mini_batch in mini_batches] == [
+        [[0, 2]],
+        [[0, 2]],
+        [[0, 2]],
+    ]
+    assert [mini_batch.meta_info["micro_batch_lengths"] for mini_batch in mini_batches] == [[2], [2], [2]]
+
+
+def test_issue_442_keep_mini_batch_splits_each_group_for_vpp():
+    data = DataProto.from_dict(
+        tensors={
+            "input_ids": torch.arange(16).reshape(8, 2),
+            "attention_mask": torch.ones((8, 2), dtype=torch.long),
+        },
+        meta_info={
+            "global_micro_batch_indices": [[0, 4], [4, 8]],
+            "global_micro_batch_lengths": [2, 2],
+        },
+    )
+
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=1,
+            ga_steps=2,
+            keep_mini_batch=True,
+            mini_batch_size=4,
+            pipeline_model_parallel_size=4,
+            virtual_pipeline_model_parallel_size=2,
+        )
+    )
+
+    assert len(mini_batches) == 2
+    assert all(mini_batch.meta_info["num_micro_batchs"] == 4 for mini_batch in mini_batches)
+    assert all(
+        mini_batch.meta_info["micro_batch_indices"] == [[0, 1], [1, 2], [2, 3], [3, 4]]
+        for mini_batch in mini_batches
+    )
+    assert all(mini_batch.meta_info["micro_batch_lengths"] == [2, 2, 2, 2] for mini_batch in mini_batches)
+
+
+def test_issue_442_keep_mini_batch_rejects_undersized_vpp_group():
+    data = DataProto.from_dict(
+        tensors={
+            "input_ids": torch.arange(4).reshape(2, 2),
+            "attention_mask": torch.ones((2, 2), dtype=torch.long),
+        },
+        meta_info={
+            "global_micro_batch_indices": [[0, 1], [1, 2]],
+            "global_micro_batch_lengths": [2, 2],
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot be split into a multiple"):
+        list(
+            make_mini_batch_iter_for_dynamic_batching(
+                data,
+                epochs=1,
+                ga_steps=2,
+                keep_mini_batch=True,
+                mini_batch_size=2,
+                pipeline_model_parallel_size=4,
+                virtual_pipeline_model_parallel_size=2,
+            )
+        )
+
+
+def test_issue_442_keep_mini_batch_handles_large_dynamic_range_with_vpp():
+    """The shard-level VPP padding must tolerate a range that needs repeats."""
+    data = _make_dynamic_batch(max_tokens_per_microbatch=64)
+    data, _ = dynamic_batching_shard(
+        data,
+        dp_size=1,
+        max_tokens_per_microbatch=64,
+        sequence_length_round=8,
+        pipeline_model_parallel_size=4,
+        virtual_pipeline_model_parallel_size=2,
+    )
+
+    assert data.meta_info["global_micro_batch_indices"] == [[0, 2], [2, 4], [4, 6], [6, 8]]
+    mini_batches = list(
+        make_mini_batch_iter_for_dynamic_batching(
+            data,
+            epochs=1,
+            ga_steps=2,
+            keep_mini_batch=True,
+            mini_batch_size=4,
+            pipeline_model_parallel_size=4,
+            virtual_pipeline_model_parallel_size=2,
+        )
+    )
+
+    assert len(mini_batches) == 2
+    assert all(mini_batch.meta_info["num_micro_batchs"] == 4 for mini_batch in mini_batches)
+    assert all(
+        mini_batch.meta_info["micro_batch_indices"] == [[0, 1], [1, 2], [2, 3], [3, 4]]
+        for mini_batch in mini_batches
+    )
+
+
+@pytest.mark.parametrize(
+    ("ranges", "message"),
+    [
+        ([[0, 2], [3, 4]], "contiguous"),
+        ([[0, 2]], "complete local batch"),
+        ([[0, 3], [2, 4]], "contiguous"),
+    ],
+)
+def test_issue_442_keep_mini_batch_rejects_non_covering_layouts(ranges, message):
+    data = DataProto.from_dict(
+        tensors={
+            "input_ids": torch.zeros((4, 2), dtype=torch.long),
+            "attention_mask": torch.ones((4, 2), dtype=torch.long),
+        },
+        meta_info={
+            "global_micro_batch_indices": ranges,
+            "global_micro_batch_lengths": [2] * len(ranges),
+        },
+    )
+
+    with pytest.raises(AssertionError, match=message):
+        list(
+            make_mini_batch_iter_for_dynamic_batching(
+                data,
+                epochs=1,
+                ga_steps=2,
+                keep_mini_batch=True,
+                mini_batch_size=2,
+            )
+        )
+
+
+@pytest.mark.parametrize("minibatch_size", [0, 3, 8])
+def test_issue_442_batch_balance_rejects_incomplete_static_batch(minibatch_size):
+    data = DataProto.from_dict(
+        tensors={
+            "attention_mask": torch.ones((4, 2), dtype=torch.long),
+        }
+    )
+
+    with pytest.raises(ValueError, match="minibatch_size|divisible"):
+        batch_balance(data, dp_size=2, minibatch_size=minibatch_size, keep_minibatch=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Add an opt-in `keep_mini_batch` option for dynamic actor training.

When enabled, dynamic micro-batch ranges are split at static mini-batch
boundaries so each optimizer update receives the same number of samples as
static batching. Metadata is copied for each yielded batch so later
iterations do not overwrite earlier batches.

The option is disabled by default to preserve existing behavior.

## How was this tested?

- `pytest -q tests/utils/test_dynamic_batching.py`
- `python -m compileall -q roll tests/utils/test_dynamic_batching.py`
- `git diff --check`

Fixes #442
